### PR TITLE
fix: prevent parallel read cascade errors in build and quick skills

### DIFF
--- a/.claude/skills/build/references/implementer-prompt.md
+++ b/.claude/skills/build/references/implementer-prompt.md
@@ -14,9 +14,12 @@ You are implementing a task from a plan.
 
 ## Project Context
 
-Read `./CLAUDE.md` for project conventions.
-Check `.claude/skills/` or `.agents/skills/` for project-specific patterns — read each
+If `./CLAUDE.md` exists, read it for project conventions.
+If `.claude/skills/` exists, check it for project-specific patterns — read each
 SKILL.md index, follow rules relevant to your task.
+
+**Important:** Read optional files (CLAUDE.md, skills/) ONE AT A TIME — do not batch
+them with other reads. If a file doesn't exist, skip it and continue.
 
 {CLAUDE_MD_SECTIONS}
 {DESIGN_DECISIONS}

--- a/.claude/skills/quick/SKILL.md
+++ b/.claude/skills/quick/SKILL.md
@@ -244,11 +244,14 @@ Task(
 
 <files_to_read>
 - .planning/STATE.md (Project State)
-- ./CLAUDE.md (if exists — follow project-specific guidelines)
 ${DISCUSS_MODE ? '- ' + QUICK_DIR + '/' + next_num + '-CONTEXT.md (User decisions — locked, do not revisit)' : ''}
 </files_to_read>
 
-**Project skills:** Check .claude/skills/ or .agents/skills/ directory (if either exists) — read SKILL.md files, plans should account for project skill rules
+<optional_files_to_read>
+Read these ONE AT A TIME (not in parallel with other reads) — skip any that don't exist:
+- ./CLAUDE.md (project-specific guidelines)
+- .claude/skills/ directory (read SKILL.md files, plans should account for project skill rules)
+</optional_files_to_read>
 
 </planning_context>
 
@@ -399,9 +402,13 @@ Execute quick task ${next_num}.
 <files_to_read>
 - ${QUICK_DIR}/${next_num}-PLAN.md (Plan)
 - .planning/STATE.md (Project state)
-- ./CLAUDE.md (Project instructions, if exists)
-- .claude/skills/ or .agents/skills/ (Project skills, if either exists — list skills, read SKILL.md for each, follow relevant rules during implementation)
 </files_to_read>
+
+<optional_files_to_read>
+Read these ONE AT A TIME (not in parallel with other reads) — skip any that don't exist:
+- ./CLAUDE.md (Project instructions)
+- .claude/skills/ directory (list skills, read SKILL.md for each, follow relevant rules during implementation)
+</optional_files_to_read>
 
 <constraints>
 - Execute all tasks in the plan


### PR DESCRIPTION
## Summary
Subagent prompts were instructing agents to read optional files (CLAUDE.md, .agents/skills/) in parallel with guaranteed files. When one optional file didn't exist, it cascaded and cancelled all sibling parallel Read calls — causing the "Cancelled: parallel tool call Read(...) errored" failures.

## Changes
- Separate required and optional file reads in subagent prompts
- Add explicit "read ONE AT A TIME, skip if missing" instruction
- Remove nonexistent .agents/skills/ references throughout

## Impact
Fixes frequent failures when running /build in projects without CLAUDE.md or with non-GSD structure.

🤖 Generated with Claude Code