### PR TITLE
release: v1.12.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "fh",
       "description": "fhhs-skills: Composite workflow skills unifying engineering discipline, design quality, and project tracking. Includes /plan, /build, /fix, /verify, /critique, /polish, and 40+ more commands.",
-      "version": "1.12.4",
+      "version": "1.12.5",
       "author": {
         "name": "Konstantin"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fh",
   "description": "fhhs-skills: All-in-one workflow plugin — engineering discipline (TDD, verification, code review), design quality (critique, polish, normalize), and project tracking (phases, milestones, roadmaps). No other plugins required.",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "author": {
     "name": "Konstantin"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to fhhs-skills will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.5] - 2026-03-11
+
+### Fixed
+- **Parallel read cascade errors** — subagent prompts in /build and /quick no longer batch optional files (CLAUDE.md, skills/) with required reads, preventing cascade cancellations when optional files don't exist
+
+### Added
+- **Conductor workspace support** — /fh:setup detects Conductor and shows configuration guidance; /fh:new-project auto-generates conductor.json with stack-appropriate setup and run scripts
+
 ## [1.12.4] - 2026-03-08
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Bump plugin.json and marketplace.json to 1.12.5
- Add changelog entry for parallel read fix and Conductor workspace support

### Fixed
- **Parallel read cascade errors** — subagent prompts in /build and /quick no longer batch optional files with required reads

### Added
- **Conductor workspace support** — /fh:setup detects Conductor; /fh:new-project generates conductor.json

After merge: tag `v1.12.5` and create GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)