### PR TITLE
fix: use setup script for Conductor task list ID

### DIFF
--- a/commands/new-project.md
+++ b/commands/new-project.md
@@ -261,17 +261,19 @@ If installed, create `conductor.json` in the project root with scripts tailored 
 ```json
 {
   "scripts": {
-    "setup": "npm install && [ -f \"$CONDUCTOR_ROOT_PATH/.env.local\" ] && cp \"$CONDUCTOR_ROOT_PATH/.env.local\" .env.local || true",
+    "setup": "npm install && [ -f \"$CONDUCTOR_ROOT_PATH/.env.local\" ] && cp \"$CONDUCTOR_ROOT_PATH/.env.local\" .env.local || true; node -e \"var fs=require('fs'),f='.claude/settings.json',s={};try{s=JSON.parse(fs.readFileSync(f,'utf8'))}catch{}s.env=Object.assign(s.env||{},{CLAUDE_CODE_TASK_LIST_ID:process.env.CONDUCTOR_WORKSPACE_NAME||'default'});fs.writeFileSync(f,JSON.stringify(s,null,2)+'\\n')\"",
     "run": "npm run dev -- --port $CONDUCTOR_PORT",
     "archive": "rm -rf \"$HOME/.claude/tasks/${CONDUCTOR_WORKSPACE_NAME}\" 2>/dev/null; true"
   },
   "env": {
-    "CLAUDE_CODE_TASK_LIST_ID": "${CONDUCTOR_WORKSPACE_NAME}"
+    "CLAUDE_CODE_ENABLE_TASKS": "true"
   }
 }
 ```
 
-> **Why `CLAUDE_CODE_TASK_LIST_ID`?** This env var tells Claude Code where to persist tasks (`~/.claude/tasks/{ID}/`). Each Conductor workspace gets its own task list so parallel workspaces don't pollute each other's tracking. Agents within the same workspace (orchestrator + subagents) share the list — which gives live visibility into sub-task progress.
+> **Why `CLAUDE_CODE_TASK_LIST_ID` in the setup script?** Conductor's `env` block does not interpolate shell variables like `${CONDUCTOR_WORKSPACE_NAME}` — it passes them as literal strings. The setup script runs in a shell where `$CONDUCTOR_WORKSPACE_NAME` resolves correctly, and writes the value into `.claude/settings.json` so Claude Code picks it up. Each workspace gets its own task list so parallel workspaces don't pollute each other's tracking.
+>
+> **Why `CLAUDE_CODE_ENABLE_TASKS` in env?** This is a static value (no interpolation needed), so the `env` block works fine. It enables native task tracking used by `/fh:plan-work` and `/fh:build`.
 >
 > **Why `archive` cleans up?** Task lists persist at `~/.claude/tasks/{ID}/`. Without cleanup, old workspace task lists accumulate indefinitely. The archive script removes the directory when the workspace is torn down.
 

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -263,7 +263,7 @@ If not present, use the **Edit tool** to merge into settings.json:
 
 Merge carefully — do NOT overwrite other `env` keys that may already exist.
 
-> **Why `CLAUDE_CODE_ENABLE_TASKS`?** Enables native task tracking used by `/fh:plan-work` and `/fh:build` for live progress visibility. Task list IDs are configured per-workspace via Conductor's `conductor.json` env block, or via `CLAUDE_CODE_TASK_LIST_ID` env var for non-Conductor setups.
+> **Why `CLAUDE_CODE_ENABLE_TASKS`?** Enables native task tracking used by `/fh:plan-work` and `/fh:build` for live progress visibility. Task list IDs are configured per-workspace via Conductor's setup script (which writes `CLAUDE_CODE_TASK_LIST_ID` into `.claude/settings.json`), or via `CLAUDE_CODE_TASK_LIST_ID` env var for non-Conductor setups.
 
 After writing:
 
@@ -505,22 +505,28 @@ If installed, display:
   │ $CONDUCTOR_DEFAULT_BRANCH  │ Default branch (usually main)    │
   └────────────────────────────┴──────────────────────────────────┘
 
-  Task tracking: Each workspace gets its own task list via
-  CLAUDE_CODE_TASK_LIST_ID in conductor.json env block.
+  Task tracking: Each workspace gets its own task list via the
+  setup script, which writes CLAUDE_CODE_TASK_LIST_ID into
+  .claude/settings.json using the workspace name.
   /fh:new-project configures this automatically.
 
   If you have an existing project, create conductor.json manually:
 
     {
       "scripts": {
-        "setup": "npm install && cp \"$CONDUCTOR_ROOT_PATH/.env.local\" .env.local 2>/dev/null; true",
+        "setup": "npm install && cp \"$CONDUCTOR_ROOT_PATH/.env.local\" .env.local 2>/dev/null; true; node -e \"var fs=require('fs'),f='.claude/settings.json',s={};try{s=JSON.parse(fs.readFileSync(f,'utf8'))}catch{}s.env=Object.assign(s.env||{},{CLAUDE_CODE_TASK_LIST_ID:process.env.CONDUCTOR_WORKSPACE_NAME||'default'});fs.writeFileSync(f,JSON.stringify(s,null,2)+'\\n')\"",
         "run": "npm run dev -- --port $CONDUCTOR_PORT",
         "archive": "rm -rf \"$HOME/.claude/tasks/${CONDUCTOR_WORKSPACE_NAME}\" 2>/dev/null; true"
       },
       "env": {
-        "CLAUDE_CODE_TASK_LIST_ID": "${CONDUCTOR_WORKSPACE_NAME}"
+        "CLAUDE_CODE_ENABLE_TASKS": "true"
       }
     }
+
+  Note: CLAUDE_CODE_TASK_LIST_ID must be set via the setup script
+  (not the env block) because Conductor does not interpolate shell
+  variables in env values. The setup script has access to
+  $CONDUCTOR_WORKSPACE_NAME and writes it to .claude/settings.json.
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Conductor's `env` block doesn't interpolate shell variables — `${CONDUCTOR_WORKSPACE_NAME}` was passed as a literal string
- Moved `CLAUDE_CODE_TASK_LIST_ID` to the setup script where `$CONDUCTOR_WORKSPACE_NAME` resolves correctly (writes to `.claude/settings.json` via node one-liner)
- Added static `CLAUDE_CODE_ENABLE_TASKS=true` to the `env` block (no interpolation needed)
- Updated both `commands/new-project.md` and `commands/setup.md`

## Test plan
- [ ] Create a new Conductor workspace and verify `CLAUDE_CODE_TASK_LIST_ID` is set to the workspace name
- [ ] Verify native tasks work in the new workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)