### PR TITLE
fix: /fh:update uses correct marketplace update command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "fh",
       "description": "fhhs-skills: Composite workflow skills unifying engineering discipline, design quality, and project tracking. Includes /plan, /build, /fix, /verify, /critique, /polish, and 40+ more commands.",
-      "version": "1.15.2",
+      "version": "1.15.3",
       "author": {
         "name": "Konstantin"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fh",
   "description": "fhhs-skills: All-in-one workflow plugin — engineering discipline (TDD, verification, code review), design quality (critique, polish, normalize), and project tracking (phases, milestones, roadmaps). No other plugins required.",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "author": {
     "name": "Konstantin"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to fhhs-skills will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.3] - 2026-03-18
+
+### Fixed
+- **/fh:update** — adds explicit `claude marketplace update` step before plugin update, preventing agents from using non-existent `claude marketplace refresh` command
+
 ## [1.15.2] - 2026-03-18
 
 ### Fixed

--- a/commands/update.md
+++ b/commands/update.md
@@ -131,11 +131,23 @@ AskUserQuestion:
 
 **If "Yes, update now":**
 
+Run these two commands in order. Both are required.
+
+**Step 4a — Refresh the marketplace index** so Claude Code sees the latest version:
+
+```bash
+claude marketplace update
+```
+
+> **IMPORTANT:** The correct command is `claude marketplace update`. There is NO `claude marketplace refresh` command — that does not exist and will fail.
+
+**Step 4b — Update the plugin:**
+
 ```bash
 claude plugin update fh@fhhs-skills
 ```
 
-Clear the update indicator from the statusline:
+**Step 4c — Clear the update indicator** from the statusline:
 
 ```bash
 rm -f "$HOME/.claude/cache/fhhs-update-check.json"


### PR DESCRIPTION
## Summary
- Adds explicit `claude marketplace update` step before `claude plugin update` in `/fh:update`
- Warns that `claude marketplace refresh` does not exist (the command agents kept inventing)

## Test plan
- [ ] Run `/fh:update` and verify it uses `claude marketplace update` (not `refresh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)