### PR TITLE
Fix /fh:update marketplace command reference

### DIFF
--- a/commands/update.md
+++ b/commands/update.md
@@ -131,15 +131,15 @@ AskUserQuestion:
 
 **If "Yes, update now":**
 
-Run these two commands in order. Both are required.
+Run these two commands in sequence. Both are required.
 
 **Step 4a — Refresh the marketplace index** so Claude Code sees the latest version:
 
 ```bash
-claude marketplace update
+claude plugin marketplace update fhhs-skills
 ```
 
-> **IMPORTANT:** The correct command is `claude marketplace update`. There is NO `claude marketplace refresh` command — that does not exist and will fail.
+> **IMPORTANT:** The marketplace name is `fhhs-skills` (NOT `fh@fhhs-skills` — that's the plugin name, not the marketplace name). There is NO `claude marketplace refresh` command — that does not exist.
 
 **Step 4b — Update the plugin:**
 


### PR DESCRIPTION
## Summary

Fixes the `/fh:update` skill instructions to use the correct `claude plugin marketplace update fhhs-skills` command instead of the ambiguous `claude marketplace update`. Also clarifies that the marketplace name is `fhhs-skills` (not the plugin name `fh@fhhs-skills`).

This prevents retry confusion and failed update attempts when users run the command.

## Testing

The command now works without needing trial-and-error to find the right marketplace name.

🤖 Generated with Claude Code