### PR TITLE
Add local Sentry observability skill and integration

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -183,6 +183,22 @@ Once all tasks are accounted for (completed, or explicitly skipped with user sig
 
 (GSD state updates happen once in Step 6, not per-wave. Don't edit STATE.md during execution.)
 
+### After-wave error check
+
+If `.sentry-local/events.db` exists, check for errors that appeared during wave execution:
+
+```bash
+node lib/sentry-local-query.mjs recent --minutes 5
+```
+
+If new errors appeared:
+- **Runtime errors during build** — these may indicate the just-built code has issues
+- Surface the errors to the orchestrator: "N new runtime errors detected during Wave X execution"
+- Include in the wave report alongside spot-check results
+- These errors inform the spec gate — if the code runs but produces errors, that's a spec concern
+
+If the query script or db doesn't exist, skip silently.
+
 ---
 
 ## Step 3b: Per-Wave Spec Gate

--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -14,6 +14,31 @@ This command runs in a single context by default. Escalates to parallel agents w
 
 ---
 
+## Step 0: Check Runtime Errors
+
+Before triaging from code alone, check if the local error store has runtime context.
+
+1. Check if `.sentry-local/events.db` exists:
+```bash
+[ -f ".sentry-local/events.db" ] && echo "STORE_EXISTS" || echo "NO_STORE"
+```
+
+2. If `STORE_EXISTS`, query recent errors:
+```bash
+node lib/sentry-local-query.mjs recent --minutes 60
+```
+
+3. Use the results to inform triage:
+   - If errors match the reported bug → use the stack trace, breadcrumbs, and request context as starting evidence
+   - If errors show a pattern (same error repeating) → note the frequency
+   - If no recent errors → proceed to Step 1 with code-only analysis
+
+4. If `NO_STORE`: skip this step silently. The project may not have observability set up.
+
+This step should consume <2% context. Don't deep-dive the errors yet — just surface them as input to triage.
+
+---
+
 ## Step 1: Triage
 
 Quickly assess bug depth before choosing strategy. Spend <5% context.

--- a/.claude/skills/observability/SKILL.md
+++ b/.claude/skills/observability/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: observability
+description: Query the local Sentry error store (.sentry-local/events.db) for runtime errors, stack traces, and breadcrumbs. Use when debugging, investigating errors, or checking runtime health.
+user-invokable: true
+---
+
+Query the local Sentry error store for runtime context.
+
+$ARGUMENTS
+
+---
+
+## Section 1: Query Local Error Store
+
+### Prerequisites
+
+Check if the local error store exists:
+
+```bash
+[ -f ".sentry-local/events.db" ] && echo "STORE_EXISTS" || echo "NO_STORE"
+```
+
+- If `NO_STORE`: report "No local error store found. The project may not have observability set up — run `/fh:new-project` to scaffold it, or set `SENTRY_LOCAL=true` and restart the dev server."
+- If `STORE_EXISTS`: proceed with queries below.
+
+### Query commands
+
+Run queries via `node lib/sentry-local-query.mjs {command}`:
+
+**Recent errors:**
+```bash
+node lib/sentry-local-query.mjs recent
+```
+Returns last 20 errors with timestamp, level, message, and exception summary.
+
+**Recent errors within time window:**
+```bash
+node lib/sentry-local-query.mjs recent --minutes N
+```
+Returns errors from the last N minutes. Useful for checking errors during a specific operation.
+
+**Full-text search:**
+```bash
+node lib/sentry-local-query.mjs search "keyword"
+```
+Searches across messages, exception text, and breadcrumbs. Use for finding errors related to a specific feature, endpoint, or error message.
+
+**Error statistics:**
+```bash
+node lib/sentry-local-query.mjs stats
+```
+Returns error count by level, most common errors (grouped by message), and error rate trend over the last hour.
+
+**Full error detail:**
+```bash
+node lib/sentry-local-query.mjs detail {event_id}
+```
+Returns the complete error event including breadcrumbs, request context, tags, and full stack trace. Use after finding an interesting error via `recent` or `search`.
+
+### Notes
+
+- Output is structured text optimized for agent consumption (not JSON).
+- If `lib/sentry-local-query.mjs` doesn't exist but `.sentry-local/events.db` does, the project wasn't fully set up with `/fh:new-project`. Suggest running it to scaffold the query tool.
+- The error store auto-prunes events older than 7 days.
+
+---
+
+## Section 2: Scaffolded Files Reference
+
+These files are scaffolded by `/fh:new-project` (Step 5b). This section documents them for agents that need to understand or modify the observability setup.
+
+### `lib/sentry-local.ts` (~150 lines)
+
+SQLite-backed Sentry transport and initialization helpers.
+
+**`createLocalSentryStore()`** — returns an `OfflineStore` backed by SQLite:
+- Uses `better-sqlite3` with WAL mode + 5s `busy_timeout`
+- Auto-creates `.sentry-local/events.db` and tables on first call
+- `push(envelope)` — serialize envelope, parse out event fields (event_id, timestamp, level, message, exception, breadcrumbs, tags, request, contexts), INSERT into events table + store raw envelope
+- `unshift(envelope)` — same as push (order doesn't matter for local store)
+- `shift()` — return oldest envelope (for replay to real Sentry later)
+- Auto-prune: DELETE events older than 7 days on every 100th write
+
+**`initSentryServer()`** — wraps `Sentry.init()` for server:
+- If `SENTRY_LOCAL=true`: use `makeOfflineTransport(makeNodeTransport)` with `createStore: createLocalSentryStore`, `shouldStore: () => true`
+- If `SENTRY_DSN` is set (no `SENTRY_LOCAL`): standard Sentry.init with real DSN
+- If neither: noop (don't init Sentry)
+- DSN: use `SENTRY_DSN` env var, or a dummy `https://local@localhost/1` for local mode
+
+**`initSentryClient()`** — wraps `Sentry.init()` for browser:
+- If `NEXT_PUBLIC_SENTRY_LOCAL=true`: init with `tunnel: '/api/sentry-local'`
+- If `NEXT_PUBLIC_SENTRY_DSN` is set: standard init with real DSN
+- If neither: noop
+
+**SQLite schema:**
+```sql
+CREATE TABLE IF NOT EXISTS events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_id TEXT UNIQUE,
+  timestamp TEXT NOT NULL,
+  level TEXT NOT NULL DEFAULT 'error',
+  type TEXT,
+  message TEXT,
+  transaction_name TEXT,
+  release TEXT,
+  environment TEXT,
+  tags TEXT,
+  breadcrumbs TEXT,
+  exception TEXT,
+  request TEXT,
+  contexts TEXT,
+  user_data TEXT,
+  envelope BLOB,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_events_level ON events(level);
+CREATE INDEX IF NOT EXISTS idx_events_created ON events(created_at DESC);
+```
+
+### `lib/sentry-local-query.mjs` (~100 lines)
+
+CLI query tool for agents to inspect the error store.
+
+- Subcommands: `recent`, `search`, `stats`, `detail`
+- Reads from `.sentry-local/events.db` via `better-sqlite3`
+- Output: structured text optimized for LLM consumption (not JSON)
+- Graceful error on missing db: "No .sentry-local/events.db found. Run your app with SENTRY_LOCAL=true to start capturing errors."
+
+### `app/api/sentry-local/route.ts` (~40 lines)
+
+Browser envelope receiver (tunnel endpoint).
+
+- POST handler that receives Sentry envelope from browser tunnel
+- Guards with `SENTRY_LOCAL !== 'true'` → return 404
+- Imports `parseEnvelope` from `@sentry/core` + store from `lib/sentry-local`
+- Parses envelope body, extracts events, stores in SQLite
+- Returns 200 (Sentry SDK expects this)
+- try/catch everything — never crashes the API route
+
+### `instrumentation.ts` (~10 lines)
+
+Next.js instrumentation hook.
+
+- Calls `initSentryServer()` from `lib/sentry-local`
+- Runs at server startup via Next.js `register()` function
+
+### Client-side init
+
+Added to `app/layout.tsx` or a provider component.
+
+- Calls `initSentryClient()` from `lib/sentry-local`
+- Wrapped in `useEffect` or top-level module init
+
+### `.sentry-local/.gitignore`
+
+Contains single line: `*` — excludes the SQLite database from git.
+
+### Dependencies
+
+Added to `package.json`:
+- `@sentry/browser` `@sentry/node` `@sentry/core` `better-sqlite3`
+- devDependency: `@types/better-sqlite3`
+
+### Environment variables
+
+| Variable | Side | Purpose |
+|----------|------|---------|
+| `SENTRY_LOCAL=true` | Server | Enables local SQLite store via offline transport |
+| `NEXT_PUBLIC_SENTRY_LOCAL=true` | Client | Enables local store via tunnel endpoint |
+| `SENTRY_DSN` | Server | Cloud Sentry DSN (used when `SENTRY_LOCAL` is not set) |
+| `NEXT_PUBLIC_SENTRY_DSN` | Client | Cloud Sentry DSN (used when `NEXT_PUBLIC_SENTRY_LOCAL` is not set) |
+
+All observability code gracefully degrades:
+- `SENTRY_LOCAL` not set → everything noops
+- `better-sqlite3` import fails → console.warn once, disable
+- SQLite write fails → drop event, warn
+- Swap to cloud Sentry = remove `SENTRY_LOCAL=true`, set real DSN

--- a/.planning/09-PLAN.md
+++ b/.planning/09-PLAN.md
@@ -1,0 +1,334 @@
+---
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - .claude/skills/observability/SKILL.md
+  - .claude/skills/fix/SKILL.md
+  - .claude/skills/build/SKILL.md
+  - commands/new-project.md
+autonomous: true
+
+must_haves:
+  truths:
+    - "A new /fh:observability skill exists that teaches agents how to query the local Sentry error store via lib/sentry-local-query.mjs"
+    - "The /fh:fix skill has a new Step 0 that queries .sentry-local/events.db for recent errors before triage"
+    - "The /fh:build skill checks for new runtime errors after each wave completes"
+    - "The /fh:new-project command scaffolds Sentry local observability files into user projects including lib/sentry-local.ts, lib/sentry-local-query.mjs, app/api/sentry-local/route.ts, instrumentation.ts, and client-side Sentry init"
+    - "All observability code is gated behind SENTRY_LOCAL=true env var and gracefully degrades when not set or when better-sqlite3 is unavailable"
+  artifacts:
+    - path: ".claude/skills/observability/SKILL.md"
+      provides: "Skill teaching agents to query local Sentry error store"
+      contains: "sentry-local-query.mjs"
+    - path: ".claude/skills/fix/SKILL.md"
+      provides: "Updated fix skill with error context before triage"
+      contains: "sentry-local"
+    - path: ".claude/skills/build/SKILL.md"
+      provides: "Updated build skill with after-wave error check"
+      contains: "sentry-local"
+    - path: "commands/new-project.md"
+      provides: "Updated new-project with observability scaffold step"
+      contains: "SENTRY_LOCAL"
+  key_links:
+    - from: ".claude/skills/fix/SKILL.md"
+      to: ".claude/skills/observability/SKILL.md"
+      via: "references observability skill for query patterns"
+    - from: ".claude/skills/build/SKILL.md"
+      to: ".claude/skills/observability/SKILL.md"
+      via: "references observability skill for after-wave checks"
+    - from: "commands/new-project.md"
+      to: "user's lib/sentry-local.ts"
+      via: "scaffolds file content during project setup"
+---
+
+<objective>
+Add local Sentry-compatible observability to the fhhs-skills plugin. Create a new observability skill, integrate error awareness into /fix and /build, and update /new-project to scaffold all observability files into user projects automatically.
+</objective>
+
+<context>
+@.claude/skills/fix/SKILL.md
+@.claude/skills/build/SKILL.md
+@commands/new-project.md
+@.planning/designs/2026-03-19-local-observability.md
+</context>
+
+<tasks>
+<task type="auto">
+  <name>Task 1: Create /fh:observability skill and scaffold templates</name>
+  <files>
+    .claude/skills/observability/SKILL.md
+  </files>
+  <action>
+Create `.claude/skills/observability/SKILL.md` with:
+
+**Frontmatter:** name: observability, description for querying local Sentry error store, user-invokable: true
+
+**Body — two sections:**
+
+### Section 1: Query Local Error Store
+Instructions for agents to query the local error store. Include:
+- Check if `.sentry-local/events.db` exists (if not, report "No local error store found" and stop)
+- Run queries via `node lib/sentry-local-query.mjs {command}`:
+  - `recent` — last 20 errors with timestamp, level, message, exception summary
+  - `recent --minutes N` — errors from last N minutes
+  - `search "keyword"` — full-text search across messages and exceptions
+  - `stats` — error count by level, most common errors, error rate trend
+  - `detail {event_id}` — full error with breadcrumbs, request context, tags
+- Format output for agent consumption (structured, scannable)
+- Note: if `lib/sentry-local-query.mjs` doesn't exist, the project wasn't set up with `/fh:new-project` — suggest running it
+
+### Section 2: Scaffolded Files Reference
+Document what `/fh:new-project` scaffolds for observability. This is reference for agents that need to understand or modify the observability setup:
+
+**`lib/sentry-local.ts`** (~150 lines) — contains:
+- `createLocalSentryStore()` — returns `OfflineStore` backed by SQLite
+  - Uses `better-sqlite3` with WAL mode + 5s busy_timeout
+  - Auto-creates `.sentry-local/events.db` and tables on first call
+  - `push(envelope)` — serialize envelope, parse out event fields (event_id, timestamp, level, message, exception, breadcrumbs, tags, request, contexts), INSERT into events table + store raw envelope
+  - `unshift(envelope)` — same as push (order doesn't matter for local store)
+  - `shift()` — return oldest envelope (for replay to real Sentry later)
+  - Auto-prune: DELETE events older than 7 days on every 100th write
+- `initSentryServer()` — wraps `Sentry.init()` for server:
+  - If `SENTRY_LOCAL=true`: use `makeOfflineTransport(makeNodeTransport)` with `createStore: createLocalSentryStore`, `shouldStore: () => true`
+  - If `SENTRY_DSN` is set (no `SENTRY_LOCAL`): standard Sentry.init with real DSN
+  - If neither: noop (don't init Sentry)
+  - DSN: use `SENTRY_DSN` env var, or a dummy `https://local@localhost/1` for local mode
+- `initSentryClient()` — wraps `Sentry.init()` for browser:
+  - If `NEXT_PUBLIC_SENTRY_LOCAL=true`: init with `tunnel: '/api/sentry-local'`
+  - If `NEXT_PUBLIC_SENTRY_DSN` is set: standard init with real DSN
+  - If neither: noop
+- SQLite schema:
+```sql
+CREATE TABLE IF NOT EXISTS events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_id TEXT UNIQUE,
+  timestamp TEXT NOT NULL,
+  level TEXT NOT NULL DEFAULT 'error',
+  type TEXT,
+  message TEXT,
+  transaction_name TEXT,
+  release TEXT,
+  environment TEXT,
+  tags TEXT,
+  breadcrumbs TEXT,
+  exception TEXT,
+  request TEXT,
+  contexts TEXT,
+  user_data TEXT,
+  envelope BLOB,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_events_level ON events(level);
+CREATE INDEX IF NOT EXISTS idx_events_created ON events(created_at DESC);
+```
+
+**`lib/sentry-local-query.mjs`** (~100 lines) — CLI query tool:
+- Subcommands: `recent`, `search`, `stats`, `detail`
+- Reads from `.sentry-local/events.db` via `better-sqlite3`
+- Output: structured text optimized for LLM consumption (not JSON)
+- Graceful error on missing db: "No .sentry-local/events.db found. Run your app with SENTRY_LOCAL=true to start capturing errors."
+
+**`app/api/sentry-local/route.ts`** (~40 lines):
+- POST handler that receives Sentry envelope from browser tunnel
+- Guards with `SENTRY_LOCAL !== 'true'` → return 404
+- Imports `parseEnvelope` from `@sentry/core` + store from `lib/sentry-local`
+- Parses envelope body, extracts events, stores in SQLite
+- Returns 200 (Sentry SDK expects this)
+- try/catch everything — never crash the API route
+
+**`instrumentation.ts`** (~10 lines):
+- Next.js instrumentation hook
+- Calls `initSentryServer()` from `lib/sentry-local`
+
+**Client-side init** — added to `app/layout.tsx` or a provider:
+- Calls `initSentryClient()` from `lib/sentry-local`
+- Wrapped in `useEffect` or top-level module init
+
+**`.sentry-local/.gitignore`**: contains single line `*`
+
+**Dependencies added to package.json:**
+- `@sentry/browser` `@sentry/node` `@sentry/core` `better-sqlite3`
+- devDependency: `@types/better-sqlite3`
+
+**Environment variables:**
+- `SENTRY_LOCAL=true` — enables local store (server-side)
+- `NEXT_PUBLIC_SENTRY_LOCAL=true` — enables local store (client-side, must be NEXT_PUBLIC_ prefixed)
+- `SENTRY_DSN` / `NEXT_PUBLIC_SENTRY_DSN` — for cloud Sentry (overrides local when SENTRY_LOCAL is not set)
+  </action>
+  <verify>
+    - `.claude/skills/observability/SKILL.md` exists with correct frontmatter
+    - Skill documents all query subcommands (recent, search, stats, detail)
+    - Skill documents all scaffolded files with enough detail for agents to understand and modify them
+    - Skill documents environment variable behavior (SENTRY_LOCAL, SENTRY_DSN, NEXT_PUBLIC_ variants)
+  </verify>
+  <done>The observability skill exists, is user-invokable, and contains complete reference documentation for both querying the error store and understanding the scaffolded observability files</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Integrate observability into /fix, /build, and /new-project</name>
+  <files>
+    .claude/skills/fix/SKILL.md
+    .claude/skills/build/SKILL.md
+    commands/new-project.md
+  </files>
+  <action>
+### 2a: Update `/fh:fix` — add Step 0 before triage
+
+Insert a new **Step 0: Check Runtime Errors** before the existing Step 1.
+
+Content:
+```markdown
+## Step 0: Check Runtime Errors
+
+Before triaging from code alone, check if the local error store has runtime context.
+
+1. Check if `.sentry-local/events.db` exists:
+```bash
+[ -f ".sentry-local/events.db" ] && echo "STORE_EXISTS" || echo "NO_STORE"
+```
+
+2. If `STORE_EXISTS`, query recent errors:
+```bash
+node lib/sentry-local-query.mjs recent --minutes 60
+```
+
+3. Use the results to inform triage:
+   - If errors match the reported bug → use the stack trace, breadcrumbs, and request context as starting evidence
+   - If errors show a pattern (same error repeating) → note the frequency
+   - If no recent errors → proceed to Step 1 with code-only analysis
+
+4. If `NO_STORE`: skip this step silently. The project may not have observability set up.
+
+This step should consume <2% context. Don't deep-dive the errors yet — just surface them as input to triage.
+```
+
+Renumber nothing — keep existing steps as Step 1, 2, 3, 4. This is Step 0 (pre-triage).
+
+### 2b: Update `/fh:build` — add after-wave error check
+
+In Step 3 ("Execute Waves"), after the "After each wave completes" section and before the spec gate (Step 3b), add an error store check:
+
+```markdown
+### After-wave error check
+
+If `.sentry-local/events.db` exists, check for errors that appeared during wave execution:
+
+```bash
+node lib/sentry-local-query.mjs recent --minutes 5
+```
+
+If new errors appeared:
+- **Runtime errors during build** — these may indicate the just-built code has issues
+- Surface the errors to the orchestrator: "⚠ N new runtime errors detected during Wave X execution"
+- Include in the wave report alongside spot-check results
+- These errors inform the spec gate — if the code runs but produces errors, that's a spec concern
+
+If the query script or db doesn't exist, skip silently.
+```
+
+### 2c: Update `/fh:new-project` — add observability scaffold step
+
+Add a new **Step 5b: Observability Setup** after Step 5 (Requirements + Roadmap) and before Step 6 (Infrastructure Setup).
+
+Content:
+```markdown
+## Step 5b: Observability Setup
+
+Scaffold local Sentry-compatible error tracking. This captures browser and server errors to a local SQLite store that agents can query during debugging.
+
+### Dependencies
+
+Add to the project's package.json (these will be installed in Phase 1 when npm install runs):
+
+Note in `.planning/REQUIREMENTS.md` that Phase 1 scaffolding must include:
+```
+npm install @sentry/browser @sentry/node @sentry/core better-sqlite3
+npm install -D @types/better-sqlite3
+```
+
+### Scaffold files
+
+Create the following files using the templates documented in the `/fh:observability` skill (Section 2: Scaffolded Files Reference). Read that skill for the complete file contents.
+
+1. **`lib/sentry-local.ts`** — SQLite-backed Sentry transport + init helpers
+2. **`lib/sentry-local-query.mjs`** — CLI query tool for agents
+3. **`app/api/sentry-local/route.ts`** — browser envelope receiver (tunnel endpoint)
+4. **`instrumentation.ts`** — Next.js server-side Sentry init
+5. **`.sentry-local/.gitignore`** — contains `*` (exclude db from git)
+
+### Environment setup
+
+Add to `.env.local` (or create it):
+```
+SENTRY_LOCAL=true
+NEXT_PUBLIC_SENTRY_LOCAL=true
+```
+
+### Client-side init
+
+Note in the Phase 1 plan that `app/layout.tsx` needs to call `initSentryClient()` from `lib/sentry-local`. This happens during scaffolding, not here — we just create the library files.
+
+### Conductor integration
+
+If `conductor.json` is being created (Step 7), add `SENTRY_LOCAL` and `NEXT_PUBLIC_SENTRY_LOCAL` to the env block:
+```json
+{
+  "env": {
+    "CLAUDE_CODE_ENABLE_TASKS": "true",
+    "SENTRY_LOCAL": "true",
+    "NEXT_PUBLIC_SENTRY_LOCAL": "true"
+  }
+}
+```
+
+This ensures every Conductor workspace (including git worktrees) has local observability enabled. The `.sentry-local/` directory lives in the worktree root, so each workspace gets its own error store that is cleaned up when the worktree is deleted.
+```
+
+Also update the Step 8 handoff output to include:
+```
+- lib/sentry-local.ts       — local error tracking (Sentry SDK → SQLite)
+- lib/sentry-local-query.mjs — error query CLI for agents
+- .sentry-local/             — error store (gitignored, per-worktree)
+```
+
+And mention: "Error tracking is active in dev by default. Run `node lib/sentry-local-query.mjs recent` to see captured errors, or let `/fh:fix` query them automatically."
+  </action>
+  <verify>
+    - `/fh:fix` has Step 0 before Step 1 with error store query
+    - `/fh:build` has after-wave error check between wave completion and spec gate
+    - `/fh:new-project` has Step 5b that scaffolds all observability files
+    - `/fh:new-project` Step 7 (Conductor) includes SENTRY_LOCAL env vars
+    - `/fh:new-project` Step 8 (Handoff) lists observability files
+    - All new sections degrade gracefully when store/script doesn't exist
+  </verify>
+  <done>The /fix skill queries runtime errors before triage, /build checks for errors after each wave, and /new-project automatically scaffolds the complete observability stack into every new project</done>
+</task>
+</tasks>
+
+<verification>
+```bash
+# Verify all files exist
+[ -f ".claude/skills/observability/SKILL.md" ] && echo "OK: observability skill" || echo "MISSING"
+grep -l "sentry-local" .claude/skills/fix/SKILL.md && echo "OK: fix updated" || echo "MISSING"
+grep -l "sentry-local" .claude/skills/build/SKILL.md && echo "OK: build updated" || echo "MISSING"
+grep -l "SENTRY_LOCAL" commands/new-project.md && echo "OK: new-project updated" || echo "MISSING"
+
+# Verify skill frontmatter
+head -5 .claude/skills/observability/SKILL.md
+
+# Verify graceful degradation language
+grep -c "skip\|silently\|NO_STORE\|doesn't exist" .claude/skills/fix/SKILL.md
+grep -c "skip\|silently\|doesn't exist" .claude/skills/build/SKILL.md
+```
+</verification>
+
+<success_criteria>
+- A new /fh:observability skill exists that teaches agents how to query the local Sentry error store via lib/sentry-local-query.mjs
+- The /fh:fix skill has a new Step 0 that queries .sentry-local/events.db for recent errors before triage
+- The /fh:build skill checks for new runtime errors after each wave completes
+- The /fh:new-project command scaffolds Sentry local observability files into user projects including lib/sentry-local.ts, lib/sentry-local-query.mjs, app/api/sentry-local/route.ts, instrumentation.ts, and client-side Sentry init
+- All observability code is gated behind SENTRY_LOCAL=true env var and gracefully degrades when not set or when better-sqlite3 is unavailable
+</success_criteria>
+
+<output>.planning/SUMMARY.md</output>

--- a/.planning/10-PLAN.md
+++ b/.planning/10-PLAN.md
@@ -1,0 +1,282 @@
+---
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - commands/update.md
+autonomous: true
+
+must_haves:
+  truths:
+    - "After /fh:update completes, machine-level tooling (symlinks, hooks, env vars) reflects what the latest setup.md configures"
+    - "After /fh:update in a project with .planning/, the user is offered new features from new-project.md that their project doesn't have yet"
+    - "Existing GSD hooks in ~/.claude/settings.json are preserved — fhhs hooks are added alongside, never replacing gsd-* hooks"
+    - "Project reconciliation presents features in plain language describing what the user gets, not technical implementation details"
+    - "The update command does not maintain a separate feature checklist — it derives what's missing by reading setup.md, new-project.md, and the changelog"
+    - "After update, users are shown actionable tips about new skills and workflow changes they should know about, derived from changelog entries between old and new version"
+  artifacts:
+    - path: "commands/update.md"
+      provides: "Post-update reconciliation for machine, project, and knowledge drift"
+      contains: "Post-Update Reconciliation"
+  key_links:
+    - from: "commands/update.md"
+      to: "commands/setup.md"
+      via: "reads as source of truth for machine-level checks"
+    - from: "commands/update.md"
+      to: "commands/new-project.md"
+      via: "reads as source of truth for project-level checks"
+    - from: "commands/update.md"
+      to: "CHANGELOG.md"
+      via: "reads to derive new skills and workflow changes between versions"
+---
+
+<objective>
+Add post-update reconciliation to /fh:update so that after updating the plugin, existing users automatically get machine-level fixes (symlinks, hooks, env vars), are offered new project-level features they're missing, and learn about new skills and workflow changes they should start using.
+</objective>
+
+<context>
+@commands/update.md
+@commands/setup.md
+@commands/new-project.md
+@CHANGELOG.md
+</context>
+
+<tasks>
+<task type="auto">
+  <name>Task 1: Add Step 5 — Machine Reconciliation</name>
+  <files>commands/update.md</files>
+  <action>
+After the existing Step 4 "Confirm and Update" section, add a new Step 5 with two sub-sections.
+
+**Step 5: Post-Update Reconciliation**
+
+**Step 5a: Machine Reconciliation** (runs automatically after update, no prompt needed)
+
+This step re-applies machine-level setup from `commands/setup.md` to ensure the user's environment matches what the latest version expects. The agent should:
+
+1. Read `commands/setup.md` to understand current machine-level requirements
+2. Check each requirement against the user's actual state
+3. Fix anything that's missing or stale (all operations are idempotent)
+
+Specifically instruct the agent to check and fix:
+
+- **CLI symlinks** — Re-run the symlink block from setup.md Step 4 (ln -sfn to latest cached version). This is idempotent and fixes stale symlinks pointing to the old version.
+- **Hooks** — Read ~/.claude/settings.json and compare against the hooks defined in setup.md Step 5. Add any missing fhhs hooks (statusline, check-update, context-monitor). IMPORTANT: Do NOT remove existing hooks — including gsd-* hooks that may serve other projects. Only append missing fhhs hooks.
+- **Env vars** — Check ~/.claude/settings.json env block for vars required by setup.md Step 3c (CLAUDE_CODE_ENABLE_LSP, CLAUDE_CODE_ENABLE_TASKS). Add any missing ones.
+- **TypeScript LSP plugin** — Check if typescript-lsp@claude-plugins-official is installed. If not, note it but don't auto-install (requires terminal).
+
+Report what was fixed:
+```
+✓ CLI tools re-linked to vX.Y.Z
+✓ Context monitor hook added (new in vX.Y.Z)
+✓ CLAUDE_CODE_ENABLE_TASKS added to settings
+○ All hooks up to date
+```
+
+Key instruction: Tell the agent to READ setup.md to derive the checklist — don't duplicate the checklist in update.md. This way when setup.md adds new requirements, update.md automatically picks them up.
+  </action>
+  <verify>
+  - Step 5a exists after Step 4
+  - Instructions reference reading setup.md as source of truth
+  - Symlink refresh uses ln -sfn (idempotent)
+  - Hook check explicitly says "do NOT remove existing hooks including gsd-*"
+  - Reports what was fixed with ✓/○ symbols
+  </verify>
+  <done>After update, machine-level tooling is automatically reconciled to match what setup.md configures, without maintaining a separate checklist</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add Step 5b — Project Reconciliation</name>
+  <files>commands/update.md</files>
+  <action>
+After Step 5a, add Step 5b: Project Reconciliation.
+
+**Step 5b: Project Reconciliation** (only runs if .planning/ exists in cwd)
+
+This step checks whether the user's existing project has all the features that /fh:new-project would set up for a new project. The agent should:
+
+1. Check if `.planning/` exists in the current working directory. If not, skip Step 5b entirely with: "No project detected in this directory. Run /fh:update from your project root to check for new features."
+2. Read `commands/new-project.md` to understand what project-level features exist
+3. Check which features are present vs missing in the current project
+4. Present missing features in a single grouped prompt using plain language
+
+**Detection approach:**
+
+Instruct the agent to read new-project.md and check for each project-level feature it describes. For each, check the characteristic files/directories that would exist if the feature was set up. Examples the agent would derive from reading new-project.md:
+- Observability → check for `lib/sentry-local.ts`
+- Project tracker → check for `.project-tracker/`
+- Conductor config → check for `conductor.json` (only if /Applications/Conductor.app exists)
+- GSD CLI symlink → check for `.claude/get-shit-done/bin`
+- claude-mem → check installed_plugins.json (derived from reading setup.md Step 6)
+
+**Presenting missing features:**
+
+If nothing is missing: "Your project is up to date with all available features." Skip the prompt.
+
+If features are missing, present them in a grouped prompt. Use plain human language describing the benefit, not the technical implementation. Format:
+
+```
+## New features available for this project
+
+This update includes features that your project doesn't have yet.
+Pick which ones to add:
+
+  1. ◻ Catch runtime errors automatically
+     Captures browser and server errors to a local database that
+     /fh:fix and /fh:build query during debugging.
+
+  2. ◻ Project dashboard
+     Visual progress tracker showing phases, plans, and status
+     at a glance. Launch anytime with /fh:tracker.
+
+  3. ◻ Conductor workspace scripts
+     Auto-configures dev server, env vars, and task tracking
+     for each parallel workspace.
+
+  4. ◻ Persistent memory (claude-mem)
+     Automatically captures session context and reinjects
+     relevant history into future sessions.
+
+Which would you like to add? (e.g. "1 and 2", "all", or "none")
+```
+
+Use AskUserQuestion or equivalent to get the user's choice.
+
+**Applying selected features:**
+
+For each selected feature, instruct the agent to follow the relevant section of new-project.md to scaffold it. Reference the specific step:
+- Observability → follow new-project.md Step 5b
+- Project tracker → follow new-project.md Step 5 (project tracker section)
+- Conductor → follow new-project.md Step 7
+- claude-mem → follow setup.md Step 6
+- GSD CLI symlink → follow new-project.md Step 5 (symlink section)
+
+After applying, report what was added:
+
+```
+✓ Local error tracking added (lib/sentry-local.ts + query tool)
+✓ Project tracker scaffolded (.project-tracker/)
+```
+
+Suggest running `/fh:revise-claude-md` afterward if any features were added, so CLAUDE.md reflects the new capabilities.
+
+Key instruction: Tell the agent to READ new-project.md and setup.md to derive the feature list and scaffold steps — don't duplicate them in update.md. This is the core "holistic" design: update.md is a meta-instruction that points at the source of truth.
+  </action>
+  <verify>
+  - Step 5b exists after Step 5a
+  - Gated on .planning/ existing
+  - Instructions reference reading new-project.md and setup.md as source of truth
+  - Feature descriptions use plain human language (benefits, not technical details)
+  - Grouped prompt format with numbered items
+  - Scaffolding delegates back to the relevant step in new-project.md/setup.md
+  - Suggests /fh:revise-claude-md after adding features
+  </verify>
+  <done>After update in a project directory, users are offered new features in plain language and can selectively add them, with detection and scaffolding derived from new-project.md</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Add Step 5c — Knowledge Reconciliation</name>
+  <files>commands/update.md</files>
+  <action>
+After Step 5b, add Step 5c: What's New — Skills and Workflows.
+
+**Step 5c: Knowledge Reconciliation** (always runs after update)
+
+The changelog (Step 3) already showed version-by-version release notes. But users skim changelogs and miss actionable workflow changes. This step transforms changelog entries into **actionable tips** about new skills and changed workflows.
+
+The agent should:
+
+1. Read the CHANGELOG.md entries between the user's old version and the new version (already fetched in Step 2)
+2. Read the `.claude/skills/` directory to get the current list of all available skills with their descriptions (from SKILL.md frontmatter)
+3. Identify entries that represent:
+   - **New skills** — a command/skill that didn't exist before (look for "Added" entries mentioning `/fh:*`)
+   - **Workflow changes** — existing skills that work differently now (look for "Changed" entries about skill behavior)
+   - **New integrations** — features that connect skills together in new ways (e.g., "/fix now queries error store before triage")
+
+4. For each identified item, present it as an actionable tip — not "what changed" but "what you should do differently now." Format:
+
+```
+## What's New in Your Workflow
+
+### New skills
+
+  /fh:plan-review — Challenge your plan before building
+  Run after /plan-work and before /build. Catches failure
+  modes, edge cases, and security gaps. Three modes:
+  scope expansion, hold scope, scope reduction.
+
+  /fh:qa — Systematic QA testing
+  Run after building frontend features. Uses browser
+  automation to find bugs, produces structured reports
+  with screenshots and repro steps.
+
+  /fh:observability — Query runtime errors
+  Check what errors your app is throwing during development.
+  /fh:fix and /fh:build now use this automatically.
+
+### Workflow changes
+
+  /fh:fix now checks runtime errors first
+  Before triaging from code alone, /fix queries the local
+  error store for recent exceptions and stack traces.
+
+  /fh:build now detects runtime errors after each wave
+  If errors appear during execution, they're surfaced
+  alongside the spec gate results.
+
+  /fh:plan-work now suggests /fh:plan-review before /fh:build
+  The handoff step recommends plan challenge for non-trivial
+  plans. You can still go straight to /build if the plan
+  is straightforward.
+```
+
+**Deriving tips holistically:**
+
+The agent should derive these tips by:
+- Reading CHANGELOG.md for "Added" and "Changed" entries between versions
+- Cross-referencing with `.claude/skills/*/SKILL.md` descriptions to write accurate "when to use" guidance
+- NOT maintaining a hardcoded tips list in update.md — derive fresh each time from changelog + skill descriptions
+
+**Presentation rules:**
+- Only show tips for changes between the user's old and new version
+- Group into "New skills" and "Workflow changes"
+- Each tip: skill name + one-line what it does + 2-3 lines of when/how to use it
+- Skip internal/technical changes (eval additions, refactors, fix typos)
+- Skip changes the user already saw (if they're only jumping one minor version, this might be just 2-3 tips)
+- If no meaningful new skills or workflow changes: skip this section entirely
+
+This is informational only — no prompt, no action needed. Just display and continue.
+  </action>
+  <verify>
+  - Step 5c exists after Step 5b
+  - Instructions derive tips from CHANGELOG.md + skill descriptions, not a hardcoded list
+  - Tips are actionable ("run after /plan-work") not descriptive ("added plan-review skill")
+  - Grouped into "New skills" and "Workflow changes"
+  - Filters out internal/technical changes
+  - Informational only — no user prompt needed
+  </verify>
+  <done>After update, users see actionable tips about new skills and workflow changes derived from changelog entries, so they know what to start using differently</done>
+</task>
+</tasks>
+
+<verification>
+1. Read commands/update.md — Step 5 exists with 5a, 5b, and 5c sub-sections
+2. Grep for "setup.md" in update.md — confirms source-of-truth reference for machine checks
+3. Grep for "new-project.md" in update.md — confirms source-of-truth reference for project checks
+4. Grep for "CHANGELOG" in update.md — confirms source-of-truth reference for knowledge tips
+5. Grep for "do NOT remove" in update.md — confirms GSD hook preservation
+6. Grep for "plain language\|human language\|benefit" in update.md — confirms UX framing
+7. Grep for "actionable\|when to use\|workflow" in update.md — confirms knowledge tips are actionable
+8. Verify no hardcoded feature checklist or tips list duplicated from source files
+</verification>
+
+<success_criteria>
+- After /fh:update completes, machine-level tooling (symlinks, hooks, env vars) reflects what the latest setup.md configures
+- After /fh:update in a project with .planning/, the user is offered new features from new-project.md that their project doesn't have yet
+- Existing GSD hooks in ~/.claude/settings.json are preserved — fhhs hooks are added alongside, never replacing gsd-* hooks
+- Project reconciliation presents features in plain language describing what the user gets, not technical implementation details
+- The update command does not maintain a separate feature checklist — it derives what's missing by reading setup.md, new-project.md, and the changelog
+- After update, users see actionable tips about new skills and workflow changes derived from changelog entries between their old and new version
+</success_criteria>
+
+<output>.planning/SUMMARY.md</output>

--- a/.planning/designs/2026-03-19-local-observability.md
+++ b/.planning/designs/2026-03-19-local-observability.md
@@ -1,0 +1,41 @@
+# Local Observability Design
+
+## Decisions Locked
+1. Full Sentry SDK (`@sentry/browser` + `@sentry/node`) with `better-sqlite3` + SQLite storage
+2. `SENTRY_LOCAL=true` env var controls all local observability (route, transport, init)
+3. Next.js only for now — matches `/fh:new-project` defaults
+4. Query helper script (`lib/sentry-local-query.mjs`) — skills invoke via Bash, avoids sqlite3 CLI dep
+5. `.sentry-local/` at worktree root — dies with worktree, 7-day auto-prune
+6. Browser errors flow via Sentry `tunnel` option → Next.js API route → SQLite
+7. Server errors flow via `makeOfflineTransport` + custom `OfflineStore` → SQLite directly
+
+## Architecture
+```
+Browser (@sentry/browser)         Server (@sentry/node)
+  │ tunnel: '/api/sentry-local'     │ custom transport
+  ▼                                 ▼
+  Next.js API route ──────────► SQLite (.sentry-local/events.db)
+  (parses envelope,               (direct write via
+   stores in SQLite)               better-sqlite3)
+```
+
+## Integration Points
+- `/fh:fix` Step 0: query recent errors before triage
+- `/fh:build` after-wave: check for new errors during execution
+- `/fh:new-project`: scaffold all observability files automatically
+- `/fh:qa`: cross-reference error store in reports
+
+## Files Scaffolded into User Projects
+- `lib/sentry-local.ts` — transport + SQLite store + init helpers
+- `lib/sentry-local-query.mjs` — CLI query tool (recent, search, stats)
+- `app/api/sentry-local/route.ts` — browser envelope receiver
+- `instrumentation.ts` — server-side Sentry.init
+- Client-side Sentry.init in layout/provider
+- `.sentry-local/.gitignore` — contains `*`
+
+## Error Handling
+- All observability code is wrapped in try/catch — never crashes the app
+- `SENTRY_LOCAL` not set → everything noops
+- `better-sqlite3` import fails → console.warn once, disable
+- SQLite write fails → drop event, warn
+- Swap to cloud Sentry = remove `SENTRY_LOCAL=true`, set real DSN

--- a/commands/new-project.md
+++ b/commands/new-project.md
@@ -113,6 +113,48 @@ Mention the tracker in the Step 7 handoff output — the user can run `/fh:track
 
 ---
 
+## Step 5b: Observability Setup
+
+Scaffold local Sentry-compatible error tracking. This captures browser and server errors to a local SQLite store that agents can query during debugging.
+
+### Dependencies
+
+Add to the project's package.json (these will be installed in Phase 1 when npm install runs):
+
+Note in `.planning/REQUIREMENTS.md` that Phase 1 scaffolding must include:
+```
+npm install @sentry/browser @sentry/node @sentry/core better-sqlite3
+npm install -D @types/better-sqlite3
+```
+
+### Scaffold files
+
+Create the following files using the templates documented in the `/fh:observability` skill (Section 2: Scaffolded Files Reference). Read that skill for the complete file contents.
+
+1. **`lib/sentry-local.ts`** — SQLite-backed Sentry transport + init helpers
+2. **`lib/sentry-local-query.mjs`** — CLI query tool for agents
+3. **`app/api/sentry-local/route.ts`** — browser envelope receiver (tunnel endpoint)
+4. **`instrumentation.ts`** — Next.js server-side Sentry init
+5. **`.sentry-local/.gitignore`** — contains `*` (exclude db from git)
+
+### Environment setup
+
+Add to `.env.local` (or create it):
+```
+SENTRY_LOCAL=true
+NEXT_PUBLIC_SENTRY_LOCAL=true
+```
+
+### Client-side init
+
+Note in the Phase 1 plan that `app/layout.tsx` needs to call `initSentryClient()` from `lib/sentry-local`. This happens during scaffolding, not here — we just create the library files.
+
+### Conductor integration
+
+If `conductor.json` is being created (Step 7), add `SENTRY_LOCAL` and `NEXT_PUBLIC_SENTRY_LOCAL` to the env block — see Step 7.
+
+---
+
 ## Step 6: Infrastructure Setup
 
 Set up GitHub and Vercel so the project is ready for deployment from day one.
@@ -266,7 +308,9 @@ If installed, create `conductor.json` in the project root with scripts tailored 
     "archive": "rm -rf \"$HOME/.claude/tasks/${CONDUCTOR_WORKSPACE_NAME}\" 2>/dev/null; true"
   },
   "env": {
-    "CLAUDE_CODE_ENABLE_TASKS": "true"
+    "CLAUDE_CODE_ENABLE_TASKS": "true",
+    "SENTRY_LOCAL": "true",
+    "NEXT_PUBLIC_SENTRY_LOCAL": "true"
   }
 }
 ```
@@ -329,10 +373,15 @@ Project initialized:
 - .planning/config.json     — workflow settings
 - CLAUDE.md                 — project conventions
 - .project-tracker/         — visual dashboard (run /fh:tracker to launch)
+- lib/sentry-local.ts       — local error tracking (Sentry SDK → SQLite)
+- lib/sentry-local-query.mjs — error query CLI for agents
+- .sentry-local/             — error store (gitignored, per-worktree)
 - conductor.json            — Conductor workspace scripts (if Conductor detected)
 - GitHub repo               — <repo-url> (private)
 - vercel.json               — framework preset configured
 - Vercel project            — linked (auto-deploys on push to main, if GitHub App installed)
+
+Error tracking is active in dev by default. Run `node lib/sentry-local-query.mjs recent` to see captured errors, or let `/fh:fix` query them automatically.
 
 Next: run /plan-work to plan your first phase (scaffolding and core setup).
 ```


### PR DESCRIPTION
## Summary

Adds `/fh:observability` skill for querying runtime errors from a local SQLite-backed Sentry store. Integrates error context into `/fh:fix` (new Step 0 pre-triage query) and `/fh:build` (after-wave error detection). Updates `/fh:new-project` to scaffold complete observability setup.

## What's included

- **Observability skill** — teaches agents to query `.sentry-local/events.db` via `lib/sentry-local-query.mjs` with `recent`, `search`, `stats`, and `detail` subcommands
- **/fh:fix integration** — Step 0 queries recent errors before triage, using stack traces and breadcrumbs as starting evidence
- **/fh:build integration** — detects runtime errors after each wave completes, surfaces them alongside spec gate results
- **Project scaffold** — new-project Step 5b scaffolds lib/sentry-local.ts (SQLite transport), query tool, API tunnel route, and instrumentation hook

## Technical details

All observability code gates behind `SENTRY_LOCAL=true` env var and gracefully degrades when `better-sqlite3` is unavailable. Database auto-prunes events older than 7 days. Works in both Conductor worktrees and standard dev environments.

🤖 Generated with Claude Code