### PR TITLE
Close plan-review feedback loop (v1.20.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "fh",
       "description": "fhhs-skills: Composite workflow skills unifying engineering discipline, design quality, and project tracking. Includes /plan, /build, /fix, /verify, /critique, /polish, and 40+ more commands.",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "author": {
         "name": "Konstantin"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fh",
   "description": "fhhs-skills: All-in-one workflow plugin — engineering discipline (TDD, verification, code review), design quality (critique, polish, normalize), and project tracking (phases, milestones, roadmaps). No other plugins required.",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "author": {
     "name": "Konstantin"
   },

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -103,7 +103,7 @@ Use the structured template at `references/implementer-prompt.md`. Fill its plac
 
 - `{TASK_TEXT}` — Full task content (files, action, verify, done). Copy the text, don't reference the plan file.
 - `{CLAUDE_MD_SECTIONS}` — Relevant sections from CLAUDE.md for this task type (UI work → CONVENTIONS.md + DESIGN.md; new files → STRUCTURE.md; API work → ARCHITECTURE.md; tests → TESTING.md).
-- `{DESIGN_DECISIONS}` — If `.planning/phases/{phase}/{phase}-CONTEXT.md` exists, include the "Design Decisions" section. These are locked — subagents must not contradict them.
+- `{DESIGN_DECISIONS}` — If `.planning/phases/{phase}/{phase}-CONTEXT.md` exists, include the "Design Decisions" and "Review Decisions" sections. These are locked — subagents must not contradict them. Also include the "NOT in scope" section as a scope boundary — subagents must not implement deferred items listed there.
 - `{DESIGN_MD_CONTENT}` — For frontend tasks only: include `.planning/DESIGN.md` content (small, ~30 lines).
 - `{PHASE_DIR}` — Path to `.planning/phases/{phase}/` for deferred items logging.
 - `{TASK_NAME}` — Task identifier for deferred items format.
@@ -279,7 +279,7 @@ When skipped, note: "Design gates skipped (N/M files visual). Run /critique or /
 
 After all waves complete (including spec gates) and BEFORE self-check, run the design quality pipeline:
 
-**Context for all design gate subagents:** If `.planning/phases/{phase}/{phase}-CONTEXT.md` exists, include its "Design Decisions" section. These are locked design choices that critique/polish/normalize must respect.
+**Context for all design gate subagents:** If `.planning/phases/{phase}/{phase}-CONTEXT.md` exists, include its "Design Decisions" and "Review Decisions" sections. These are locked design choices that critique/polish/normalize must respect.
 
 ### Critique
 Dispatch subagent to invoke `/critique` on modified frontend files.

--- a/.claude/skills/build/references/implementer-prompt.md
+++ b/.claude/skills/build/references/implementer-prompt.md
@@ -22,6 +22,11 @@ If a skill looks relevant to your task, read its full SKILL.md for detailed guid
 Only deep-read skills that are clearly relevant — don't read all of them.
 
 {CLAUDE_MD_SECTIONS}
+
+### Locked Decisions & Scope Boundary
+
+The following decisions are locked — do not contradict them. "NOT in scope" items must not be implemented.
+
 {DESIGN_DECISIONS}
 
 ## Before You Begin

--- a/.claude/skills/plan-review/SKILL.md
+++ b/.claude/skills/plan-review/SKILL.md
@@ -340,37 +340,66 @@ Every AskUserQuestion MUST: (1) present 2-3 concrete lettered options, (2) state
 
 ---
 
-## Required Outputs
+## Required Outputs — Feed Back Into Plan Artifacts
 
-All findings go to `.planning/designs/`.
+Plan-review findings must flow back into the artifacts that `/fh:build` already reads. Do NOT write a standalone document to `.planning/designs/` — that path is not consumed by downstream skills.
 
-### "NOT in scope" section
-List work considered and explicitly deferred, with one-line rationale each.
+### Step A: Update PLAN.md `must_haves`
 
-### "What already exists" section
-List existing code/flows that partially solve sub-problems and whether the plan reuses them.
+After all review sections are complete, update the PLAN.md that was reviewed:
 
-### "Dream state delta" section
-Where this plan leaves us relative to the 12-month ideal.
+1. **Append new truths** to `must_haves.truths` from:
+   - Each CRITICAL GAP row in the Failure Modes Registry (rescued failure → observable truth)
+   - Each High-severity security finding (mitigation → observable truth)
+   - Each unhandled edge case the user chose to address
+2. **Append new artifacts** to `must_haves.artifacts` if the review identified files that must be created/modified (e.g., new test files for uncovered paths)
+3. **Append new key_links** if the review identified missing wiring between artifacts
+
+Format new truths with a `[review]` prefix so the executor and verifier can distinguish plan-original from review-added truths:
+```yaml
+truths:
+  - "Original truth from plan-work"
+  - "[review] TimeoutError on ExampleService.call() is rescued with retry + user message"
+```
+
+### Step B: Update CONTEXT.md
+
+Append to `.planning/phases/{phase}/{phase}-CONTEXT.md` (create the section if missing):
+
+**"Review Decisions" section** — Architecture and implementation decisions made during AskUserQuestion exchanges. Same format as "Design Decisions" — these are locked for `/build` subagents.
+
+**"NOT in scope" section** — Work considered and explicitly deferred during review, with one-line rationale each. The `/build` executor uses this as a scope boundary — subagents must not implement deferred items.
+
+### Step C: Human-Reference Summary
+
+Write a lightweight summary to `.planning/designs/review-YYYY-MM-DD-<topic>.md` for audit trail. This file is for **human reference only** — no downstream skill reads it. Include:
+
+- Mode selected
+- Completion summary table (below)
+- Diagrams produced during review
+- "What already exists" — existing code/flows that partially solve sub-problems
+- "Dream state delta" — where this plan leaves us relative to 12-month ideal
 
 ### Error & Rescue Registry (from Section 2)
-Complete table of every method that can fail, every error type, rescued status, rescue action, user impact.
+Complete table of every method that can fail, every error type, rescued status, rescue action, user impact. **Actionable findings (CRITICAL GAPs) must also appear as truths in PLAN.md per Step A.**
 
 ### Failure Modes Registry
 ```
   CODEPATH | FAILURE MODE   | RESCUED? | TEST? | USER SEES?     | LOGGED?
   ---------|----------------|----------|-------|----------------|--------
 ```
-Any row with RESCUED=N, TEST=N, USER SEES=Silent → **CRITICAL GAP**.
+Any row with RESCUED=N, TEST=N, USER SEES=Silent → **CRITICAL GAP** → must become a `[review]` truth in PLAN.md.
 
 ### Delight Opportunities (EXPANSION mode only)
-Identify at least 5 "bonus chunk" opportunities (<30 min each) that would make users think "oh nice, they thought of that." Present each delight opportunity as its own individual AskUserQuestion. Never batch them. For each one, describe what it is, why it would delight users, and effort estimate. Then present options: **A)** Add to plan backlog **B)** Skip **C)** Build it now in this PR.
+Identify at least 5 "bonus chunk" opportunities (<30 min each) that would make users think "oh nice, they thought of that." Present each delight opportunity as its own individual AskUserQuestion. Never batch them. For each one, describe what it is, why it would delight users, and effort estimate. Then present options: **A)** Add to plan backlog **B)** Skip **C)** Build it now in this PR. Items added to backlog go into CONTEXT.md "NOT in scope" with rationale "delight opportunity — deferred."
 
 ### Diagrams (mandatory, produce all that apply)
 1. System architecture
 2. Data flow (including shadow paths)
 3. State machine
 4. Error flow
+
+Include diagrams in both the PLAN.md `<context>` block (so executors see them) and the human-reference summary.
 
 ### Completion Summary
 ```
@@ -387,11 +416,10 @@ Identify at least 5 "bonus chunk" opportunities (<30 min each) that would make u
   | Section 5  (Tests)   | Diagram produced, ___ gaps                  |
   | Section 6  (Future)  | Reversibility: _/5, debt items: ___         |
   +--------------------------------------------------------------------+
-  | NOT in scope         | written (___ items)                          |
-  | What already exists  | written                                     |
-  | Dream state delta    | written                                     |
-  | Error/rescue registry| ___ methods, ___ CRITICAL GAPS              |
-  | Failure modes        | ___ total, ___ CRITICAL GAPS                |
+  | PLAN.md updated      | ___ truths added, ___ artifacts added        |
+  | CONTEXT.md updated   | ___ decisions locked, ___ items deferred     |
+  | Error/rescue registry| ___ methods, ___ CRITICAL GAPS → PLAN.md    |
+  | Failure modes        | ___ total, ___ CRITICAL GAPS → PLAN.md      |
   | Delight opportunities| ___ identified (EXPANSION only)             |
   | Diagrams produced    | ___ (list types)                            |
   | Unresolved decisions | ___ (listed below)                          |

--- a/.claude/skills/plan-work/SKILL.md
+++ b/.claude/skills/plan-work/SKILL.md
@@ -116,7 +116,7 @@ Resolve implementation gray areas before planning:
      | OPERATION | ERROR | NAMED EXCEPTION | RESCUE ACTION | USER SEES |
      |-----------|-------|-----------------|---------------|-----------|
 
-     > This is a lightweight ERM scoped to the discussed gray areas. If the user runs `/fh:plan-review` afterward, it will produce a comprehensive ERM across the entire plan and extend this one.
+     > This is a lightweight ERM scoped to the discussed gray areas. If the user runs `/fh:plan-review` afterward, it will produce a comprehensive ERM across the entire plan, extending this one, and feed CRITICAL GAPs back into PLAN.md as `[review]` truths.
 
    - **Failure Modes Registry**:
 
@@ -286,7 +286,7 @@ If a check fails, state which check failed, revise the plan, and recheck. After 
 
 After plan approval:
 
-1. **`/fh:plan-review`** (recommended) — Challenge the plan before building. Catches failure modes, edge cases, and architectural issues. Three modes: SCOPE EXPANSION (dream big), HOLD SCOPE (maximum rigor), SCOPE REDUCTION (strip to essentials). Plan-review produces comprehensive error maps, security analysis, and edge case coverage that strengthen the plan before execution.
+1. **`/fh:plan-review`** (recommended) — Challenge the plan before building. Catches failure modes, edge cases, and architectural issues. Three modes: SCOPE EXPANSION (dream big), HOLD SCOPE (maximum rigor), SCOPE REDUCTION (strip to essentials). **Feedback loop:** plan-review feeds findings back into PLAN.md (`must_haves.truths` with `[review]` prefix) and CONTEXT.md (review decisions + deferred scope). After plan-review completes, `/fh:build` automatically picks up the strengthened plan — no manual merging needed.
 2. **`/fh:build`** — Execute now. Skip review if the plan is straightforward or already reviewed.
 3. **Continue planning** — Plan more phases before building or reviewing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to fhhs-skills will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.0] - 2026-03-20
+
+### Changed
+- **`/fh:plan-review` feedback loop** — review findings now feed back into PLAN.md (`must_haves.truths` with `[review]` prefix) and CONTEXT.md (review decisions + deferred scope) instead of writing a disconnected file to `.planning/designs/`; `/fh:build` automatically picks up the strengthened plan
+- **`/fh:build` subagent context** — implementer prompt includes "Locked Decisions & Scope Boundary" framing so subagents respect review decisions and deferred scope from CONTEXT.md
+
 ## [1.19.0] - 2026-03-20
 
 ### Added

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -160,7 +160,7 @@ No changes. (Template variables adopted from upstream v1.2.0.)
 |---|--------|-----------|
 | 1 | Renamed `plan-ceo-review` → `plan-review` | Cleaner name; "CEO" framing replaced with "founder-level challenge" in description |
 | 2 | Removed gstack-upgrade check preamble | No gstack binary dependency in fhhs-skills |
-| 3 | Output path: findings go to `.planning/designs/` | GSD convention — all planning artifacts live in .planning/ |
+| 3 | Output: actionable findings feed back into PLAN.md (`must_haves.truths` with `[review]` prefix) and CONTEXT.md (review decisions + deferred scope); lightweight human-reference summary to `.planning/designs/review-*.md` | Closes the feedback loop — `/build` already reads PLAN.md + CONTEXT.md, so review findings are now prescriptive, not advisory-only |
 | 4 | Taste calibration reads `.planning/DESIGN.md` instead of discovering patterns | Leverages existing design context from `/fh:teach-impeccable` |
 | 5 | Reduced from 10 review sections to 6 (Architecture, Error/Rescue, Security, Data Flow, Tests, Long-Term Trajectory) | Observability, Deployment, Performance, Code Quality covered by `/fh:review`, `/fh:build`, and other skills |
 | 6 | Added "Challenge against must_haves" step (0B) | Plans from `/fh:plan-work` include must_haves — review should challenge their truths |


### PR DESCRIPTION
## Summary
- Close the plan-review artifact gap: findings now flow back into PLAN.md and CONTEXT.md instead of sitting in a disconnected `.planning/designs/` file
- Plan-review appends `[review]`-prefixed truths to must_haves and writes Review Decisions + NOT in scope to CONTEXT.md
- Build subagents now see "Locked Decisions & Scope Boundary" framing for review constraints
- Bump to v1.20.0 with changelog entry

## Test Plan
- Manually verify `/fh:plan-work` → `/fh:plan-review` → `/fh:build` workflow now shows review findings in executor context
- Check that `[review]` prefix distinguishes plan-original vs review-added truths
- Verify that /verify correctly handles the extended must_haves