### PR TITLE
fix: correct skills path after .claude-plugin/ move

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,6 +7,6 @@
   },
   "repository": "https://github.com/cinjoff/fhhs-skills",
   "license": "MIT",
-  "skills": "./.claude/skills",
+  "skills": "../.claude/skills",
   "keywords": ["workflow", "tdd", "design", "project-management", "gsd", "skills", "commands"]
 }


### PR DESCRIPTION
## Summary
- Fixed relative path in `.claude-plugin/plugin.json` from `./.claude/skills` to `../.claude/skills`
- This broke when `plugin.json` was moved into `.claude-plugin/` (c76e0fe) without updating the relative path
- Result: all `/fh:` skills were invisible to Claude Code

## Test plan
- [ ] Reinstall plugin and verify `/fh:` skills appear in slash commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)