### PR TITLE
Phase 2-3.5: Upstream sync, capability audit, pipeline intelligence

### DIFF
--- a/.claude/skills/audit-upstream/SKILL.md
+++ b/.claude/skills/audit-upstream/SKILL.md
@@ -5,11 +5,20 @@ description: "Use when evaluating upstream skill changes after sync, assessing i
 
 # Audit Upstream
 
-Evaluate upstream skill changes, assess integration opportunities, and maintain the upstream capability index.
+Evaluate upstream skill capabilities, assess real usage in fhhs pipelines, identify gaps, and maintain the upstream capability index.
 
 Chain after `/fh:sync-upstream`: sync pulls code, this skill evaluates what changed.
 
 Arguments: $ARGUMENTS
+
+## Modes
+
+This skill supports two modes based on arguments:
+
+- **Incremental** (default, after sync): Detect what changed, assess new/modified items, update docs
+- **Deep** (when user asks for deep review, capability analysis, or comparison): Full capability scan of all upstreams with pipeline usage analysis, overlap detection, and strategic recommendations
+
+Use **deep** when: user says "deep", "review carefully", "compare", "what do I actually use", "overlap", or provides no prior index to diff against.
 
 ---
 
@@ -17,7 +26,7 @@ Arguments: $ARGUMENTS
 
 Inventory the `upstream/` directory. For each upstream source:
 
-1. **Identify version/commit** — read package.json, CHANGELOG, or git metadata to determine the current version
+1. **Identify version/commit** — read package.json, CHANGELOG, VERSION, or directory name to determine version
 2. **Compare against index** — read `.planning/upstream/INDEX.md` to detect:
    - Version changes (bumped since last audit)
    - New sources (present in `upstream/` but absent from INDEX.md)
@@ -28,163 +37,208 @@ Inventory the `upstream/` directory. For each upstream source:
    - **Agent definitions:** `agents/` directories
    - **Supporting assets:** references, templates, prompt templates, rule files, tools
 
-Build a complete inventory before proceeding. Record file paths and last-modified dates.
+Build a complete inventory before proceeding.
+
+**Mode gate:** In incremental mode, focus only on changed sources. In deep mode, scan ALL sources regardless of changes.
 
 ---
 
-## Step 2: DIFF
+## Step 2: READ DEEPLY
 
-For each upstream that has changed since the last audit:
+For each capability being assessed (changed items in incremental, ALL items in deep):
 
-1. **Identify changes** — new, modified, or removed items across all four asset categories
-2. **Read actual files** — understand the substance of each change, not just file-level diffs
-3. **Use git diff** between old and new snapshots when available:
-   ```
-   git diff <old-commit>..<new-commit> -- upstream/<source>/
-   ```
-4. **Summarize per source** — produce a change summary listing:
-   - Added items (with brief description)
-   - Modified items (what changed and why it matters)
-   - Removed items (impact on existing integrations)
+1. **Read the actual file content** — not just the filename or first line. Understand what the skill/agent/workflow actually does.
+2. **For each capability, extract:**
+   - **What it actually does** — concrete description of behavior, not marketing language
+   - **Value proposition** — what problem does this solve? What happens without it?
+   - **Key mechanisms** — how does it achieve its goal? (e.g., "spawns 4 parallel agents", "produces CONTEXT.md with locked decisions")
+   - **Anti-patterns addressed** — what bad outcomes does it prevent?
+3. **Use parallel agents** to read multiple upstream sources simultaneously — one agent per source for deep mode.
 
-If no changes detected for any upstream, skip to the "No changes" edge case handling.
+This step is critical. Previous audits produced inventories of file names. This step produces understanding of capabilities.
 
 ---
 
-## Step 3: ASSESS
+## Step 3: PIPELINE USAGE ANALYSIS
 
-For each new or changed item, evaluate on these dimensions:
+Determine which capabilities are actually wired into fhhs execution paths.
 
-### Quality Rating (A–D)
+1. **Search shipped skills** — grep `.claude/skills/*/SKILL.md` and `skills/*/PROMPT.md` for references to each upstream capability
+2. **Classify each capability:**
 
-| Rating | Criteria |
-|--------|----------|
-| **A** | Well-structured, handles edge cases, has error recovery, documented |
-| **B** | Solid structure, some edge cases handled, usable documentation |
-| **C** | Functional but gaps in error handling or documentation |
-| **D** | Incomplete, fragile, or poorly documented — needs work before integration |
+| Status | Meaning | How to detect |
+|--------|---------|---------------|
+| **ACTIVE** | Referenced in main execution paths, regularly triggered | Found in build/fix/plan-work/review/quick pipeline steps |
+| **CONDITIONAL** | Wired but only triggers under specific conditions | Found behind condition checks (visual ratio, project type, etc.) |
+| **INTERNAL** | Referenced by other internal skills only | Found in skills/ but not .claude/skills/ |
+| **DEAD** | Imported/shipped but never referenced in any pipeline | Exists in skills/ or .claude/skills/ but no pipeline references it |
+| **PATTERN ABSORBED** | The concept is used but the specific skill file is never loaded | Pattern visible in pipeline code but skill file unreferenced |
 
-### Integration Analysis
-
-- **Gap fill potential:** Does this address a known gap in the Gap Registry (`.planning/upstream/INDEX.md`)?
-- **Integration effort:**
-  - **Low** — reference only, no code changes needed
-  - **Medium** — new standalone skill or minor enhancement
-  - **High** — enhance existing composite skill, requires patching
-- **Risk assessment:**
-  - Breaking changes to existing patched skills
-  - Dependency conflicts with current integrations
-  - Naming collisions with existing `/fh:` skills
-- **SDLC phase coverage:** Which development lifecycle phase does this serve? (planning, implementation, testing, review, deployment, maintenance)
+3. **For dead capabilities, assess value:**
+   - Is this dead because it's genuinely not useful? → candidate for pruning
+   - Is this dead because it was never wired? → candidate for integration (gap)
+   - Is the pattern absorbed even though the file is unused? → mark as absorbed, no action needed
 
 ---
 
-## Step 4: RECOMMEND
+## Step 4: OVERLAP & COMPARISON ANALYSIS (deep mode only)
 
-Produce prioritized recommendations in four tiers:
+Identify capabilities that exist in multiple upstreams with different approaches:
 
-### Immediate
-Breaking changes or critical fixes to apply now. These block normal operation if ignored.
+1. **Group by function** — find capabilities that solve the same problem across upstreams
+   - Research: GSD phase-researcher vs Superpowers research vs fhhs inline research
+   - Planning: GSD planner vs Superpowers writing-plans vs fhhs plan-work
+   - Debugging: GSD debugger vs Superpowers systematic-debugging
+   - Review: GSD plan-checker vs gstack plan-review vs Superpowers code-review
+   - Execution: GSD executor vs Superpowers executing-plans vs SDD
+   - Verification: GSD verifier vs Superpowers verification-before-completion
 
-### Plan
-High-value integrations to plan via `/fh:plan-work`. Include:
-- What to integrate
-- Estimated effort
-- Which existing skills are affected
-- Suggested work item title
+2. **For each overlap, produce a comparison table:**
 
-### Backlog
-Lower-priority opportunities to track in the Gap Registry. Worth doing but not urgent.
+| Dimension | Source A | Source B | fhhs current |
+|-----------|---------|---------|--------------|
+| Philosophy | ... | ... | ... |
+| Depth | ... | ... | ... |
+| When it's better | ... | ... | ... |
+| What's missing | ... | ... | ... |
 
-### Skip
-Changes with no integration value. Always explain why — prevents re-evaluation in future audits.
+3. **Verdict per overlap** — which approach is right for fhhs and why? Is there value in combining?
 
 ---
 
-## Step 5: UPDATE
+## Step 5: ASSESS & RECOMMEND
 
-Refresh the upstream index using the split-file structure in `.planning/upstream/`:
+### For incremental mode (post-sync)
+
+For each new or changed item, evaluate:
+
+- **Quality Rating (A–D):**
+  - **A** — Well-structured, handles edge cases, documented
+  - **B** — Solid structure, some gaps, usable
+  - **C** — Functional but incomplete
+  - **D** — Needs work before integration
+- **Gap fill potential** — does this address a known gap in the Gap Registry?
+- **Integration effort** — Low (reference only) / Medium (new skill) / High (patch existing composite)
+- **Risk** — breaking changes, dependency conflicts, naming collisions
+
+### For deep mode
+
+Produce consolidated recommendations organized by impact area, not by upstream source:
+
+**Strengthen [pipeline-name]** — group recommendations by which fhhs pipeline they improve:
+- What to add/wire
+- Why (what gap it fills, with reference to the capability description)
+- Integration approach (how to wire it)
+
+**Wire [capability]** — for high-value dead capabilities that should be connected
+
+**Consider pruning** — for dead capabilities with no integration value
+
+### Recommendation tiers
+
+| Tier | Criteria |
+|------|----------|
+| **Immediate** | Breaking changes or critical fixes. Blocks normal operation. |
+| **Plan** | High-value integrations worth planning via `/fh:plan-work` |
+| **Backlog** | Worth doing but not urgent. Track in Gap Registry. |
+| **Skip** | No integration value. Explain why to prevent re-evaluation. |
+
+---
+
+## Step 6: UPDATE DOCUMENTS
 
 ### Per-source files
-Update `.planning/upstream/{source-name}.md` for changed upstreams only. Each file contains:
-- Source metadata (name, repo, version, last synced date)
-- Asset inventory across all four categories
-- Quality ratings for each asset
-- Integration status (integrated / planned / skipped)
+
+Update `.planning/upstream/{source-name}.md` for each assessed source. Required sections:
+
+```markdown
+# Upstream: {name} (v{version})
+
+**Overall Quality: {A-D}**
+
+## Overview
+{What this upstream is, its philosophy, what makes it distinctive}
+
+## File Tree
+{Directory structure with annotations}
+
+## Deep Capability Descriptions
+{Tables with columns: Capability | What It Actually Does | Value Proposition | fhhs Usage}
+
+Organize by functional category (e.g., "Planning & Discovery", "Quality & Discipline", "Execution").
+Each row must have substantive descriptions, not one-liners.
+fhhs Usage must use the pipeline status labels (ACTIVE/CONDITIONAL/DEAD/etc.) with
+specific pipeline references (e.g., "ACTIVE — wired in /fh:build Step 4").
+
+## Skills/Agents/Workflows Table
+{Inventory with: Name | SDLC Phase | Quality | Pipeline Status | fhhs Equivalent | Notes}
+
+Pipeline Status uses: ✅ Active | ✅ Conditional | 🔀 Partial | ⚠️ Dead (high-value gap) | ⬜ Available | 🚫 N/A
+
+## Supporting Assets Table
+{References, templates, prompts with usage status}
+
+## Assessment
+### What's Working
+### What's Underused (High-Value Gaps)
+### Recommendations
+{Priority | Action | Impact table}
+```
 
 ### INDEX.md
-Update the central index with:
-- **Version numbers** — reflect current `upstream/` state
-- **SDLC Coverage Matrix** — update phase coverage based on new/changed assets
-- **Gap Registry** — add new gaps discovered, close gaps filled by integrations
-- **Subagent Dispatch Matrix** — update if new agent definitions found
-- **Command Exposure Map** — update if new commands/workflows found
-- **Dashboard counts** — total skills, agents, commands, coverage percentage
 
-### Integration Log
-Append an entry to the Integration Log section of INDEX.md:
-```
-### {date} — Audit after sync
-- Sources evaluated: {list}
-- Changes found: {count new}, {count modified}, {count removed}
-- Recommendations: {count immediate}, {count plan}, {count backlog}, {count skip}
-```
+Update the central index. Required sections:
+
+- **Source Summary** — version, quality, capability counts, active vs dead counts
+- **Pipeline Usage Reality** — tables of actively wired, conditionally triggered, and high-value gaps
+- **SDLC Coverage Matrix** — phase coverage across upstreams with gap markers
+- **Subagent Dispatch Matrix** — which skills dispatch which agents
+- **Consolidated Recommendations** — grouped by impact area, not by upstream source
+- **Gap Registry** — prioritized list of unintegrated capabilities with status
+- **Integration Log** — append entry for this audit
 
 ### Cross-reference verification
-- Verify `PATCHES.md` is still accurate — no stale patch references to renamed/removed upstream files
+- Verify `PATCHES.md` is still accurate — no stale references to renamed/removed upstream files
 - Verify `COMPATIBILITY.md` reflects current version combinations
 
 ---
 
 ## Edge Cases
 
-All of these MUST be handled — never silently skip or fail.
-
 ### First run (no index exists)
-If `.planning/upstream/` directory or `INDEX.md` does not exist:
-1. Create `.planning/upstream/` directory
-2. Build all per-source files from scratch by scanning `upstream/`
-3. Create `INDEX.md` with full structure
-4. Message to user: **"First audit — creating full index."**
+If `.planning/upstream/` or `INDEX.md` does not exist:
+1. Create directory and build all per-source files from scratch
+2. Create INDEX.md with full structure
+3. Always run in deep mode on first run
+4. Message: **"First audit — creating full index."**
+
+### No changes detected (incremental mode)
+1. Short-circuit — do not rewrite files
+2. Output: **"No upstream changes since last audit on {date}."**
+3. Offer: "Run with `--deep` for full capability review."
 
 ### Upstream removed
-If a source is listed in INDEX.md but no longer exists in `upstream/`:
-1. Mark the source as **"ARCHIVED"** in INDEX.md
-2. Keep the per-source file with an archived header: `> ⚠️ ARCHIVED — source removed from upstream/ on {date}`
-3. Do not delete any tracking files
+Mark as **"ARCHIVED"** in INDEX.md, keep per-source file with archived header.
 
 ### Skill renamed in upstream
-Detect via content similarity (same SDLC phase + similar description):
-1. Match old and new names by comparing skill descriptions and phase coverage
-2. Update the name in the per-source file
-3. Add a note: `Renamed: {old-name} → {new-name} (detected by content similarity)`
-
-### No changes detected
-If no upstream sources have changed since the last audit:
-1. Short-circuit — do not rewrite any files
-2. Output: **"No upstream changes since last audit on {date}."**
-3. Exit the skill
+Detect via content similarity, update name, add rename note.
 
 ### Malformed or empty skill files
-If a skill file exists but cannot be parsed or is empty:
-1. Flag in the per-source file as: `⚠️ Unreadable: {file-path} — {reason}`
-2. Never silently skip — always surface the issue
-3. Continue processing remaining files
-
-### Write failure
-After each file write:
-1. Verify the write succeeded (file exists with expected content)
-2. Report any failures explicitly to the user
-3. Do not mark the audit as complete if any writes failed
+Flag as `⚠️ Unreadable: {path} — {reason}`, never silently skip.
 
 ---
 
 ## Workflow Chain
 
-> After running `/fh:sync-upstream`, run `/fh:audit-upstream` to evaluate what changed and update the index. This ensures the upstream capability index stays current with every sync.
+> Typical flows:
 >
-> Typical flow:
+> **After sync:**
 > 1. `/fh:sync-upstream` — pull latest upstream code
-> 2. `/fh:audit-upstream` — evaluate changes, update index
+> 2. `/fh:audit-upstream` — evaluate changes (incremental), update index
 > 3. `/fh:plan-work` — plan integration of recommended changes
-> 4. `/fh:build` — implement the integrations
+>
+> **Periodic deep review:**
+> 1. `/fh:audit-upstream` with deep/review/compare arguments
+> 2. Review overlap analysis and pipeline usage reality
+> 3. Decide which gaps to fill and which dead weight to prune
+> 4. `/fh:plan-work` — plan the improvements

--- a/.claude/skills/build/references/spec-gate-prompt.md
+++ b/.claude/skills/build/references/spec-gate-prompt.md
@@ -42,6 +42,10 @@ optimistic. You MUST verify everything independently by reading the actual code.
 - Check that done criteria are genuinely met
 - Look for stubs, placeholders, and unwired code
 
+## Fallow Static Analysis (if provided)
+
+If the orchestrator has included Fallow output below, use it as ground truth for unwired code detection. Fallow has analyzed the full codebase import graph — its findings are definitive, not heuristic.
+
 ## What to Check
 
 **Missing requirements:**
@@ -57,10 +61,13 @@ optimistic. You MUST verify everything independently by reading the actual code.
 - Empty catch blocks, no-op callbacks
 
 **Unwired code:**
-- Files created but never imported
-- Functions defined but never called
-- State defined but never rendered
-- API routes defined but never fetched from
+- If Fallow output is provided: cite its unused-exports and unused-files findings for files in this wave's diff. These are definitive — the export/file is not imported anywhere in the codebase.
+- If Fallow output is NOT provided: fall back to manual inspection:
+  - Files created but never imported
+  - Functions defined but never called
+  - State defined but never rendered
+  - API routes defined but never fetched from
+- In both cases: check whether "unused" is intentional (public API for future waves) or a genuine bug (unwired code that should be connected).
 
 **TypeScript strictness:**
 - Any use of `any` type (including implicit via missing annotations)

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -19,7 +19,7 @@ You are a **lean orchestrator**. Stay under 15% context usage. Delegate all anal
 | Flag | What runs | When to use |
 |------|-----------|-------------|
 | *(default — full)* | All 9 steps | Deep scrutiny before promoting |
-| `--quick` | Steps 1, 3, 4, 5, 6, 7, 8 (quality + goal verification + TS + evidence) | Fast pre-commit sanity check |
+| `--quick` | Steps 1, 1.5, 1.7, 2, 3, 4, 5, 6, 7, 8 (quality + goal verification + TS + evidence) | Fast pre-commit sanity check |
 
 ---
 
@@ -66,6 +66,30 @@ Budget: less than 2% context. Don't deep-dive errors — just surface file match
 
 ---
 
+## Step 1.7: Static Analysis (if available)
+
+If `fallow` is installed, run static analysis to provide ground truth data for the review agents.
+
+```bash
+if command -v fallow &>/dev/null; then
+  FALLOW_CHECK=$(fallow check --changed-since "$BASE_BRANCH" --format json --quiet 2>/dev/null) || FALLOW_CHECK=""
+  FALLOW_DUPES=$(fallow dupes --format json --quiet 2>/dev/null) || FALLOW_DUPES=""
+  FALLOW_HEALTH=$(fallow health --format json --quiet 2>/dev/null) || FALLOW_HEALTH=""
+fi
+```
+
+**Post-filter:** For `FALLOW_DUPES` and `FALLOW_HEALTH`, filter to entries involving files in the diff (from Step 1's file list). Cap each output at 200 lines. Skip injection for any empty outputs.
+
+If Fallow ran successfully and produced non-empty output, include it in the agent prompts dispatched in Step 2:
+- **Agent 1 (Code Quality + Architecture):** receives all three non-empty outputs — dead code, circular deps, duplication, complexity
+- **Agent 3 (Gap Analysis):** receives `FALLOW_CHECK` — unused exports/files for unwired code detection
+
+If fallow is NOT installed or all commands fail: skip silently. Do not mention Fallow in the report.
+
+Budget: less than 1% context. Fallow runs in <1 second.
+
+---
+
 ## Step 2: Dispatch Analysis (full and --quick modes)
 
 Based on mode, dispatch parallel subagents. Each agent receives ONLY the diff + its specific checklist — keep agent context lean.
@@ -75,6 +99,7 @@ Based on mode, dispatch parallel subagents. Each agent receives ONLY the diff + 
 **Agent 1 — Code Quality + Architecture** (`subagent_type: "code-reviewer"`)
 - Prompt: `skills/review/references/review-prompt.md`
 - Also include: `skills/review/references/production-safety-checklist.md` (two-pass safety review)
+- If Fallow data is available from Step 1.7, include it in the agent prompt under '## Static Analysis Findings'
 - Input: full diff (`git diff $BASE_BRANCH..HEAD`)
 - Covers: naming, structure, error handling, DRY, complexity, test quality, cross-file consistency, dependency direction, separation of concerns, abstraction quality, API design, cross-cutting concerns
 - If Next.js: include `.claude/skills/nextjs-perf/PROMPT.md` criteria
@@ -94,6 +119,7 @@ Based on mode, dispatch parallel subagents. Each agent receives ONLY the diff + 
 **Agent 3 — Gap Analysis** (`subagent_type: "code-reviewer"`)
 - Prompt: gap analysis section of `skills/review/references/review-prompt.md`
 - Input: full diff
+- If Fallow data is available from Step 1.7, include the `FALLOW_CHECK` unused-exports findings in the agent prompt
 - Covers: untested code paths, unhandled error states, incomplete features (TODO/FIXME/PLACEHOLDER), missing edge cases, API contract gaps
 
 ### --quick mode — dispatch 1 agent:

--- a/.claude/skills/review/references/review-prompt.md
+++ b/.claude/skills/review/references/review-prompt.md
@@ -26,6 +26,7 @@ Review the full diff from branch base to HEAD. Focus on changes introduced in th
 ### DRY
 - Is there duplicated logic that should be extracted?
 - Are shared utilities used consistently?
+- If Fallow duplication data is available, cite exact duplicate locations rather than inferring from the diff
 
 ### Complexity
 - Are there overly complex conditionals that should be decomposed?
@@ -49,6 +50,7 @@ Review the full diff from branch base to HEAD. Focus on changes introduced in th
 ### Dependency Direction
 - Do dependencies flow in one direction (e.g., UI -> service -> data)?
 - Are there circular imports? Check for A imports B imports A patterns.
+- If Fallow data is available, circular dependency findings are definitive — cite them directly
 - Do lower-level modules depend on higher-level abstractions? (dependency inversion)
 
 ### Separation of Concerns
@@ -126,6 +128,24 @@ Only apply if the project uses Next.js (`next.config.*` present):
 - **Barrel imports:** `import { X } from '@/components'` patterns that pull entire module trees into client bundles
 - **Caching:** Are expensive computations wrapped in `React.cache` or LRU caches? Are `fetch` calls using appropriate Next.js caching strategies?
 - **Bundle size:** Are large libraries imported on the client side when a lighter alternative exists?
+
+---
+
+## Static Analysis Findings (if provided)
+
+If this section contains Fallow output, treat it as **ground truth** — these findings are deterministic, based on full codebase import graph analysis.
+
+### How to use Fallow data in your review:
+
+**Dead code (unused exports/files):** Flag as Important. Cite the exact export name and file from Fallow output. Note: some unused exports are intentional public API — check if the export is documented or in an `index.ts` barrel file before flagging.
+
+**Circular dependencies:** Flag as Important or Critical (depending on whether it causes runtime issues). Cite the exact cycle chain from Fallow output. Reference the "Dependency Direction" criteria above.
+
+**Code duplication:** Flag as Minor or Important (depending on duplication size). Cite exact file:line ranges from Fallow output. Reference the "DRY" criteria above.
+
+**Complexity hotspots:** Flag functions exceeding cyclomatic complexity 15 or cognitive complexity 20 as Important. Cite the exact metric from Fallow output. Reference the "Complexity" criteria above.
+
+If no Fallow data is provided, use your existing analysis approach for these areas.
 
 ---
 

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -19,4 +19,44 @@ What to simplify: $ARGUMENTS
 
 Read `skills/simplify/PROMPT.md` and follow it completely. It runs 3 parallel review agents on the git diff — code reuse, code quality, and efficiency — then fixes issues directly.
 
+## Fallow Static Analysis (if available)
+
+Before dispatching the 3 review agents, check if Fallow is installed and gather deterministic findings to augment each agent's analysis.
+
+### 1. Availability check and execution
+
+```bash
+if command -v fallow &>/dev/null; then
+  BASE=$(git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null || echo "HEAD~10")
+  DIFF_FILES=$(git diff --name-only "$BASE"..HEAD)
+  FALLOW_CHECK=$(fallow check --changed-since "$BASE" --format json --quiet 2>/dev/null) || FALLOW_CHECK=""
+  FALLOW_DUPES=$(fallow dupes --mode semantic --format json --quiet 2>/dev/null) || FALLOW_DUPES=""
+  FALLOW_HEALTH=$(fallow health --format json --quiet 2>/dev/null) || FALLOW_HEALTH=""
+fi
+```
+
+### 2. Post-filter and cap output size
+
+- `FALLOW_CHECK` is already scoped via `--changed-since` — use as-is
+- `FALLOW_DUPES`: filter to entries involving files in `$DIFF_FILES` only
+- `FALLOW_HEALTH`: filter to entries involving files in `$DIFF_FILES`, then take top-10 by complexity score
+- **Hard cap:** If any output exceeds 200 lines after filtering, truncate to top findings by severity
+- **Skip empty:** Only inject non-empty outputs into agent prompts
+
+### 3. Inject filtered output into each agent's prompt
+
+Under a `## Static Analysis Findings` header:
+
+- **Code reuse agent** receives: `fallow dupes` output (exact duplicate locations) + `fallow check` unused exports
+- **Code quality agent** receives: `fallow health` output (complexity metrics) + `fallow check` circular dependency chains
+- **Efficiency agent** receives: `fallow health` output (complexity hotspots)
+
+### 4. If NOT available
+
+Skip silently. The 3 agents run with their existing diff-only analysis. No mention of Fallow in output.
+
+### 5. Key instruction to agents
+
+"Static analysis findings are deterministic ground truth. When Fallow reports a duplicate or unused export, cite the exact file:line from the Fallow output. Do not second-guess Fallow's structural findings — focus your LLM analysis on whether the finding is actionable (e.g., is the unused export intentionally part of a public API?)."
+
 Commit fixes: `refactor(scope): simplify pass`

--- a/.planning/11-PLAN.md
+++ b/.planning/11-PLAN.md
@@ -1,0 +1,265 @@
+---
+plan: 11
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - .claude/skills/simplify/SKILL.md
+  - .claude/skills/build/SKILL.md
+  - .claude/skills/build/references/spec-gate-prompt.md
+  - .claude/skills/review/SKILL.md
+  - .claude/skills/review/references/review-prompt.md
+autonomous: true
+
+must_haves:
+  truths:
+    - "When fallow is installed, simplify agents receive deterministic duplication, dead-code, and complexity data alongside the diff"
+    - "When fallow is installed, spec-gate unwired-code check uses fallow output for definitive unused-export detection instead of LLM inference"
+    - "When fallow is installed, review agents receive circular dependency, dead code, and complexity metrics as ground truth"
+    - "When fallow is NOT installed, all three skills behave identically to their current behavior — no errors, no missing steps, no degraded output"
+    - "[review] When a fallow command fails (nonzero exit), the output variable is set to empty string and that analysis is skipped — no garbage injected into agent prompts"
+    - "[review] Fallow dupes and health output is post-filtered to files in the diff and capped at 200 lines before injection into agent prompts"
+  artifacts:
+    - path: ".claude/skills/simplify/SKILL.md"
+      provides: "Fallow-enhanced simplify with duplication/dead-code/complexity data for agents"
+      contains: "fallow dupes"
+    - path: ".claude/skills/build/references/spec-gate-prompt.md"
+      provides: "Fallow-enhanced spec gate with deterministic unwired-code detection"
+      contains: "fallow check"
+    - path: ".claude/skills/review/SKILL.md"
+      provides: "Fallow-enhanced review orchestrator with static analysis step"
+      contains: "fallow check"
+    - path: ".claude/skills/review/references/review-prompt.md"
+      provides: "Instructions for review agent to consume Fallow static analysis findings"
+      contains: "Static Analysis Findings"
+    - path: ".claude/skills/build/SKILL.md"
+      provides: "Fallow orchestration in Step 3b for spec-gate data injection"
+      contains: "fallow check"
+  key_links:
+    - from: ".claude/skills/simplify/SKILL.md"
+      to: ".claude/skills/build/SKILL.md"
+      via: "build Step 8 invokes skills/simplify/"
+    - from: ".claude/skills/simplify/SKILL.md"
+      to: ".claude/skills/refactor/SKILL.md"
+      via: "refactor Step 5 invokes skills/simplify/"
+    - from: ".claude/skills/build/references/spec-gate-prompt.md"
+      to: ".claude/skills/build/SKILL.md"
+      via: "build Step 3b dispatches spec gate agent with this prompt"
+    - from: ".claude/skills/review/references/review-prompt.md"
+      to: ".claude/skills/review/SKILL.md"
+      via: "review Step 2 dispatches Agent 1 with this prompt"
+---
+
+<objective>
+Integrate Fallow CLI static analysis into the three highest-leverage skills: simplify (cascades to build/refactor/fix), spec-gate (build pipeline checkpoint), and review (main quality gate). Each integration follows the same pattern: detect fallow availability, run relevant commands with JSON output, inject findings into agent prompts as ground truth data. Graceful degradation when fallow is not installed.
+</objective>
+
+<context>
+@file .claude/skills/simplify/SKILL.md
+@file .claude/skills/build/references/spec-gate-prompt.md
+@file .claude/skills/review/SKILL.md
+@file .claude/skills/review/references/review-prompt.md
+@file .planning/research/fallow-tools-research.md
+@file .planning/research/fallow-integration-points.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add Fallow static analysis to simplify</name>
+  <files>.claude/skills/simplify/SKILL.md</files>
+  <action>
+  Modify `simplify/SKILL.md` to add a Fallow pre-analysis step before the 3 parallel review agents are dispatched.
+
+  **Add after line 20 ("Invoke `skills/simplify/`. It runs 3 parallel review agents..."), before the commit line:**
+
+  Add a new section "## Fallow Static Analysis (if available)" with these instructions:
+
+  1. **Availability check and execution:** Before dispatching the 3 review agents, check if fallow is installed and run analysis. Use the robust base-ref pattern from the review skill:
+     ```bash
+     if command -v fallow &>/dev/null; then
+       BASE=$(git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null || echo "HEAD~10")
+       DIFF_FILES=$(git diff --name-only "$BASE"..HEAD)
+       FALLOW_CHECK=$(fallow check --changed-since "$BASE" --format json --quiet 2>/dev/null) || FALLOW_CHECK=""
+       FALLOW_DUPES=$(fallow dupes --mode semantic --format json --quiet 2>/dev/null) || FALLOW_DUPES=""
+       FALLOW_HEALTH=$(fallow health --format json --quiet 2>/dev/null) || FALLOW_HEALTH=""
+     fi
+     ```
+
+  2. **Post-filter and cap output size:**
+     - `FALLOW_CHECK` is already scoped via `--changed-since` — use as-is
+     - `FALLOW_DUPES`: filter to entries involving files in `$DIFF_FILES` only
+     - `FALLOW_HEALTH`: filter to entries involving files in `$DIFF_FILES`, then take top-10 by complexity score
+     - **Hard cap:** If any output exceeds 200 lines after filtering, truncate to top findings by severity. Agent prompts must stay lean.
+     - **Skip empty:** Only inject non-empty outputs into agent prompts. If a command failed (empty string), omit that section entirely.
+
+  3. **Inject filtered output into each agent's prompt** under a `## Static Analysis Findings` header:
+     - **Code reuse agent** receives: `fallow dupes` output (exact duplicate locations with similarity %) + `fallow check` unused exports (dead code that should be removed, not refactored)
+     - **Code quality agent** receives: `fallow health` output (cyclomatic/cognitive complexity per function, maintainability scores) + `fallow check` circular dependency chains
+     - **Efficiency agent** receives: `fallow health` output (complexity hotspots to prioritize attention)
+
+  4. **If NOT available:** Skip silently. The 3 agents run with their existing diff-only analysis. No mention of Fallow in output.
+
+  5. **Key instruction to agents:** "Static analysis findings are deterministic ground truth. When Fallow reports a duplicate or unused export, cite the exact file:line from the Fallow output. Do not second-guess Fallow's structural findings — focus your LLM analysis on whether the finding is actionable (e.g., is the unused export intentionally part of a public API?)."
+
+  Keep the existing SKILL.md content intact. The Fallow section is additive.
+  </action>
+  <verify>
+  - Read the modified SKILL.md and confirm it contains `fallow dupes`, `fallow check`, `fallow health` commands
+  - Confirm the availability check pattern is present (`command -v fallow`)
+  - Confirm graceful degradation instruction ("If NOT available: skip silently")
+  - Confirm the three agents each receive appropriate Fallow data
+  </verify>
+  <done>When fallow is installed, simplify agents receive deterministic duplication, dead-code, and complexity data alongside the diff. When fallow is NOT installed, the skill behaves identically to before.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add Fallow to spec-gate unwired-code detection</name>
+  <files>.claude/skills/build/SKILL.md, .claude/skills/build/references/spec-gate-prompt.md</files>
+  <action>
+  Modify both files: the orchestrator (`build/SKILL.md`) runs Fallow and injects output; the template (`spec-gate-prompt.md`) consumes it.
+
+  **In `build/SKILL.md` — find Step 3b (spec-gate dispatch) and add Fallow orchestration:**
+
+  Before dispatching the spec-gate agent, add:
+  ```bash
+  if command -v fallow &>/dev/null; then
+    FALLOW_OUTPUT=$(fallow check --changed-since {WAVE_START_SHA} --format json --quiet 2>/dev/null) || FALLOW_OUTPUT=""
+  fi
+  ```
+  When dispatching the spec-gate agent, if `FALLOW_OUTPUT` is non-empty, include it in the agent prompt under a `## Fallow Static Analysis` section. If empty, omit the section entirely.
+
+  **In `spec-gate-prompt.md`:**
+
+  1. **Add before the "What to Check" section** a Fallow data consumption block:
+     ```
+     ## Fallow Static Analysis (if provided)
+
+     If the orchestrator has included Fallow output below, use it as ground truth for unwired code detection. Fallow has analyzed the full codebase import graph — its findings are definitive, not heuristic.
+     ```
+
+  2. **Modify the "Unwired code" subsection** to reference Fallow:
+     ```
+     **Unwired code:**
+     - If Fallow output is provided: cite its unused-exports and unused-files findings for files in this wave's diff. These are definitive — the export/file is not imported anywhere in the codebase.
+     - If Fallow output is NOT provided: fall back to manual inspection:
+       - Files created but never imported
+       - Functions defined but never called
+       - State defined but never rendered
+       - API routes defined but never fetched from
+     - In both cases: check whether "unused" is intentional (public API for future waves) or a genuine bug (unwired code that should be connected).
+     ```
+  </action>
+  <verify>
+  - Read build/SKILL.md and confirm Step 3b contains `fallow check --changed-since` with `|| FALLOW_OUTPUT=""` fallback
+  - Read spec-gate-prompt.md and confirm the "Fallow Static Analysis (if provided)" consumption section exists
+  - Confirm the two-tier unwired-code approach: Fallow when provided, manual fallback when not
+  - Confirm the existing manual checks are preserved as fallback
+  </verify>
+  <done>When fallow is installed, spec-gate unwired-code check uses fallow output for definitive unused-export detection instead of LLM inference. When fallow is NOT provided, the spec gate falls back to its existing manual inspection.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Add Fallow to review pipeline</name>
+  <files>.claude/skills/review/SKILL.md, .claude/skills/review/references/review-prompt.md</files>
+  <action>
+  Modify both files to add Fallow static analysis to the review pipeline.
+
+  **In `review/SKILL.md`:**
+
+  1. Add a new "Step 1.7: Static Analysis (if available)" between Step 1.5 (Runtime Error Check) and Step 2 (Dispatch Analysis):
+
+     ```markdown
+     ## Step 1.7: Static Analysis (if available)
+
+     If `fallow` is installed, run static analysis to provide ground truth data for the review agents.
+
+     ```bash
+     if command -v fallow &>/dev/null; then
+       FALLOW_CHECK=$(fallow check --format json --quiet 2>/dev/null) || FALLOW_CHECK=""
+       FALLOW_DUPES=$(fallow dupes --format json --quiet 2>/dev/null) || FALLOW_DUPES=""
+       FALLOW_HEALTH=$(fallow health --format json --quiet 2>/dev/null) || FALLOW_HEALTH=""
+     fi
+     ```
+
+     **Post-filter:** For `FALLOW_DUPES` and `FALLOW_HEALTH`, filter to entries involving files in the diff (from Step 1's file list). Cap each output at 200 lines. Skip injection for any empty outputs.
+
+     If Fallow ran successfully and produced non-empty output, include it in the agent prompts dispatched in Step 2:
+     - **Agent 1 (Code Quality + Architecture):** receives all three non-empty outputs — dead code, circular deps, duplication, complexity
+     - **Agent 3 (Gap Analysis):** receives `FALLOW_CHECK` — unused exports/files for unwired code detection
+
+     If fallow is NOT installed or all commands fail: skip silently. Do not mention Fallow in the report.
+
+     Budget: less than 1% context. Fallow runs in <1 second.
+     ```
+
+  2. In Step 2, modify the Agent 1 and Agent 3 dispatch descriptions to note:
+     - Agent 1: "If Fallow data is available from Step 1.7, include it in the agent prompt under '## Static Analysis Findings'"
+     - Agent 3: "If Fallow data is available from Step 1.7, include the unused-exports findings in the agent prompt"
+
+  **In `review/references/review-prompt.md`:**
+
+  1. Add a new section before "## Severity Classification" (line 132):
+
+     ```markdown
+     ---
+
+     ## Static Analysis Findings (if provided)
+
+     If this section contains Fallow output, treat it as **ground truth** — these findings are deterministic, based on full codebase import graph analysis.
+
+     ### How to use Fallow data in your review:
+
+     **Dead code (unused exports/files):** Flag as Important. Cite the exact export name and file from Fallow output. Note: some unused exports are intentional public API — check if the export is documented or in an `index.ts` barrel file before flagging.
+
+     **Circular dependencies:** Flag as Important or Critical (depending on whether it causes runtime issues). Cite the exact cycle chain from Fallow output. Reference the "Dependency Direction" criteria above.
+
+     **Code duplication:** Flag as Minor or Important (depending on duplication size). Cite exact file:line ranges from Fallow output. Reference the "DRY" criteria above.
+
+     **Complexity hotspots:** Flag functions exceeding cyclomatic complexity 15 or cognitive complexity 20 as Important. Cite the exact metric from Fallow output. Reference the "Complexity" criteria above.
+
+     If no Fallow data is provided, use your existing analysis approach for these areas.
+     ```
+
+  2. In the "### Dependency Direction" section (lines 49-52), add after "Are there circular imports?":
+     ```
+     - If Fallow data is available, circular dependency findings are definitive — cite them directly
+     ```
+
+  3. In the "### DRY" section (lines 27-28), add:
+     ```
+     - If Fallow duplication data is available, cite exact duplicate locations rather than inferring from the diff
+     ```
+  </action>
+  <verify>
+  - Read review/SKILL.md and confirm Step 1.7 exists with fallow commands
+  - Read review-prompt.md and confirm "Static Analysis Findings" section exists
+  - Confirm Agent 1 and Agent 3 dispatch descriptions reference Fallow data
+  - Confirm graceful degradation ("skip silently", "If no Fallow data is provided")
+  - Confirm review-prompt.md integrates Fallow into DRY and Dependency Direction sections
+  </verify>
+  <done>When fallow is installed, review agents receive circular dependency, dead code, complexity metrics, and duplication data as ground truth. When fallow is NOT installed, the review behaves identically to before.</done>
+</task>
+
+</tasks>
+
+<verification>
+1. Read all 5 modified files and confirm Fallow integration is present
+2. Grep for "fallow" across all modified files to verify command references
+3. Grep for "command -v fallow" to verify availability check pattern in simplify, build, and review
+4. Grep for '|| FALLOW_' to verify error fallback pattern in all 3 orchestrators (simplify, build, review)
+5. Grep for "200 lines" or equivalent cap instruction in simplify and review
+6. Grep for "filter" or "DIFF_FILES" to verify post-filtering instruction for dupes/health in simplify and review
+7. Grep for "Static Analysis Findings" in review-prompt.md
+8. Verify no existing behavior was removed (all original content preserved, Fallow is additive)
+9. Verify base-ref uses fallback pattern (main || master || HEAD~10) in simplify — not hardcoded "main"
+</verification>
+
+<success_criteria>
+- When fallow is installed, simplify agents receive deterministic duplication, dead-code, and complexity data alongside the diff
+- When fallow is installed, spec-gate unwired-code check uses fallow output for definitive unused-export detection instead of LLM inference
+- When fallow is installed, review agents receive circular dependency, dead code, and complexity metrics as ground truth
+- When fallow is NOT installed, all three skills behave identically to their current behavior — no errors, no missing steps, no degraded output
+</success_criteria>
+
+<output>.planning/SUMMARY.md</output>

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,0 +1,60 @@
+---
+type: project
+name: fhhs-skills
+version: v1
+created: "2026-03-25"
+---
+
+# fhhs-skills
+
+A Claude Code plugin that composes upstream skill libraries into a comprehensive software development toolkit, with patching and eval infrastructure to maintain quality.
+
+## Target Users
+
+Software developers using Claude Code — including non-technical users who need things to work without reading source code.
+
+## Problem
+
+Individual upstream skills are fragmented and don't work together cohesively. Users can't assemble a complete development workflow from disconnected plugins.
+
+## Solution
+
+Unify upstream skills (Superpowers, Impeccable, GSD) into an opinionated, well-documented toolkit that covers the full development lifecycle: planning, building, reviewing, testing, fixing, refactoring, and design quality.
+
+## Scope
+
+### In v1
+- Core development skills (plan, build, review, fix, refactor, simplify)
+- Design/UI skills (branding, critique, polish, animate, etc.)
+- GSD tracking infrastructure (.planning/, roadmap, phases)
+- Upstream sync mechanism (snapshots, PATCHES.md, COMPATIBILITY.md)
+- Eval suite for verifying skills work correctly
+- Non-technical-friendly documentation and setup flow
+
+### Out of scope
+- Building end-user apps (this is tooling)
+- Custom LLM integrations beyond Claude Code's plugin system
+- GUI/dashboard for managing skills (beyond tracker)
+
+## Constraints
+
+- **Team:** Solo maintainer
+- **Plugin boundary:** `.claude/skills/` is the only shipped directory — runtime file reads must be co-located there
+- **No postinstall hooks:** Claude Code plugins can't run shell at install time
+- **Upstream tracking:** Must track 3+ upstream repos and re-patch on updates without breaking downstream skills
+
+## Tech Stack
+
+- **Runtime:** Claude Code plugin system
+- **Languages:** Markdown (skills), JavaScript/Node.js (GSD tooling)
+- **Testing:** Custom eval suite with mock projects (130+ evals)
+- **Distribution:** plugin.json + marketplace.json
+- **Upstream management:** Snapshot + patch model
+
+## Success Criteria
+
+1. Skills trigger correctly and produce quality output for their intended use cases
+2. Eval suite passes — mock project tests verify skills behave as expected
+3. Non-technical users can install, run `/fh:setup`, and use skills without reading source code
+4. Upstream syncs don't break patched skills
+5. Plugin ships cleanly within `.claude/skills/` boundary — no runtime file-not-found errors

--- a/.planning/designs/2026-03-25-fallow-cli-integration.md
+++ b/.planning/designs/2026-03-25-fallow-cli-integration.md
@@ -1,0 +1,61 @@
+# Fallow CLI Integration Design
+
+**Date:** 2026-03-25
+**Status:** Plan written, pending approval
+
+## Decision: CLI over MCP
+
+Fallow's MCP server is a thin stdio wrapper — identical output, no token savings, no quality difference. CLI is more portable for a plugin that ships to users. Skills orchestrate when analysis runs (not Claude deciding spontaneously), so MCP's tool discoverability adds no value.
+
+## Tool Landscape
+
+| Tool | Purpose | Integration |
+|------|---------|-------------|
+| **Fallow** | Dead code, circular deps, duplication, complexity | CLI (`--format json`) |
+| **Serena** | Symbol navigation + editing, LSP superset | Deferred — separate MCP server, requires Python |
+| **Built-in LSP** | Go-to-definition, find-references, hover | Already used in fix/refactor/extract/plan-work |
+
+All three are complementary, zero overlap.
+
+## Integration Architecture
+
+```
+┌─────────────────────────────────────────────┐
+│              Availability Check              │
+│  command -v fallow → run / skip silently     │
+└──────────────┬──────────────────────────────┘
+               │
+    ┌──────────┴──────────┐
+    │ fallow check --json │ → unused exports, files, deps, circular deps
+    │ fallow dupes --json │ → code duplication (4 modes)
+    │ fallow health --json│ → complexity metrics, hotspots
+    └──────────┬──────────┘
+               │
+    ┌──────────┴──────────────────────────────┐
+    │        Inject into agent prompts         │
+    │  "## Static Analysis Findings"           │
+    │  Ground truth data alongside the diff    │
+    └──────────┬──────────────────────────────┘
+               │
+    ┌──────────┴──────────┐
+    │   LLM Agent Layer    │
+    │  Judges actionability│
+    │  Cites exact locations│
+    │  Filters false positives│
+    └──────────────────────┘
+```
+
+## Priority: Plan 11 (simplify → spec-gate → review)
+
+These three cover the highest-leverage integration points because:
+- **simplify** cascades through build, refactor, and fix
+- **spec-gate** is the build pipeline's quality checkpoint
+- **review** is the main quality gate before promoting code
+
+## Future Plans (not in scope)
+
+- **map-codebase**: Fallow dependency graph + metrics for architecture/concerns mappers
+- **refactor Step 0**: Data-driven refactoring candidate discovery
+- **plan-work**: Impact estimation via module graph
+- **extract**: Duplication detection for component discovery
+- **Serena**: Separate evaluation pending user decision

--- a/.planning/designs/review-2026-03-25-fallow-cli-integration.md
+++ b/.planning/designs/review-2026-03-25-fallow-cli-integration.md
@@ -1,0 +1,88 @@
+# Plan Review: Fallow CLI Integration (Plan 11)
+
+**Date:** 2026-03-25
+**Mode:** HOLD SCOPE
+**Plan reviewed:** `.planning/11-PLAN.md`
+
+## Completion Summary
+
+```
++====================================================================+
+|            PLAN REVIEW — COMPLETION SUMMARY                        |
++====================================================================+
+| Mode selected        | HOLD SCOPE                                  |
+| System Audit         | Clean branch, no TODOs in touched files      |
+| Step 0               | Premise valid, must_haves solid, scope right |
+| Section 1  (Arch)    | 3 issues found, all resolved                |
+| Section 2  (Errors)  | 6 error paths mapped, 4 GAPS → resolved     |
+| Section 3  (Security)| 0 issues (no new attack surface)            |
+| Section 4  (Data/UX) | 1 edge case (dupes/health no --changed-since)|
+| Section 5  (Tests)   | Adequate for markdown changes                |
+| Section 6  (Future)  | Reversibility: 5/5, 0 debt items            |
++--------------------------------------------------------------------+
+| PLAN.md updated      | 2 truths added, 1 artifact added            |
+| CONTEXT.md updated   | N/A (no phase-level CONTEXT.md exists)      |
+| Error/rescue registry| 7 error types, 4 GAPS rescued via Issue 4   |
+| Failure modes        | 0 CRITICAL GAPS remaining                   |
+| Diagrams produced    | 2 (architecture, data flow)                 |
+| Unresolved decisions | 0                                           |
++====================================================================+
+```
+
+## Review Decisions (locked for executor)
+
+1. **1A — Output filtering + size caps:** Fallow dupes and health output must be post-filtered to files in the diff, then capped at 200 lines. Prevents context blowout on large codebases.
+
+2. **3A — build/SKILL.md added to scope:** Fallow orchestration (CLI invocation + injection) belongs in `build/SKILL.md` Step 3b, not as comments in the spec-gate template. Templates consume; orchestrators produce.
+
+3. **4A — Error fallback pattern:** All fallow commands use `|| VAR=""` to ensure failed commands produce empty strings. Only non-empty outputs are injected into agent prompts. Pattern: `FALLOW_X=$(fallow ... 2>/dev/null) || FALLOW_X=""`
+
+4. **5A — Post-filtering for dupes/health:** Since `fallow dupes` and `fallow health` don't support `--changed-since`, orchestrators must post-filter their output to entries involving files in the diff before injection.
+
+5. **Base ref standardized:** All `--changed-since` refs use the review skill's existing robust pattern: `git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null || echo "HEAD~10"`
+
+## What Already Exists
+
+- Review skill's base-ref resolution pattern (line 31) — reused in simplify and build
+- All 3 skills already have orchestrator → subagent → prompt injection architecture
+- Spec-gate already checks for unwired code (lines 59-63) — Fallow replaces LLM inference here
+- Review-prompt already has DRY and Dependency Direction sections — Fallow data supplements them
+
+## Dream State Delta
+
+This plan establishes the "optional static analysis tool" pattern:
+```
+check availability → run CLI → filter output → inject into agent context → fallback if missing
+```
+This same pattern applies to any future tool (Serena, npm audit, semgrep). The convention is set; future integrations follow the template.
+
+## Diagrams
+
+### Architecture (post-review)
+```
+Orchestrator (simplify/review/build)
+  │
+  ├─ command -v fallow?
+  │   ├─ YES → run CLI commands (|| "" on failure)
+  │   │         ├─ post-filter to diff files
+  │   │         ├─ cap at 200 lines
+  │   │         └─ inject non-empty outputs into agent prompts
+  │   └─ NO  → skip silently
+  │
+  └─ dispatch agents (with or without Fallow data)
+      ├─ Agent reads diff + optional "## Static Analysis Findings"
+      └─ Agent uses Fallow as ground truth, LLM for judgment
+```
+
+### Data Flow (all 4 paths)
+```
+fallow CLI ──▶ JSON stdout ──▶ Shell variable ──▶ Post-filter ──▶ Agent prompt
+    │               │               │                 │              │
+    ▼               ▼               ▼                 ▼              ▼
+[not found]    [malformed/     [|| "" sets     [>200 lines   [LLM reads as
+ → skip]        crash → exit    to empty]       → truncate]   ground truth]
+                 nonzero]
+               [empty output                   [0 diff-
+                → empty var]                    relevant
+                                                → empty → skip]
+```

--- a/.planning/designs/review-2026-03-25-sync-upstream-validation.md
+++ b/.planning/designs/review-2026-03-25-sync-upstream-validation.md
@@ -1,0 +1,90 @@
+# Plan Review: Sync-Upstream Validation & Regression Detection
+
+**Date:** 2026-03-25
+**Plan:** `.planning/phases/02-upstream-sync/02-01-PLAN.md`
+**Mode:** HOLD SCOPE
+
+## Completion Summary
+
+```
++====================================================================+
+|            PLAN REVIEW — COMPLETION SUMMARY                        |
++====================================================================+
+| Mode selected        | HOLD SCOPE                                  |
+| System Audit         | Clean baseline, no prior review cycles       |
+| Step 0               | HOLD — well-scoped infrastructure fix        |
+| Section 1  (Arch)    | 1 issue: git stash missing --include-untrack |
+| Section 2  (Errors)  | 8 error paths mapped, 3 CRITICAL GAPS fixed  |
+| Section 3  (Security)| 0 issues — internal tooling, low surface     |
+| Section 4  (Data/UX) | 1 issue: forked_to → eval mapping ambiguity  |
+| Section 5  (Tests)   | 4 evals planned, 1 gap noted (stash failure) |
+| Section 6  (Future)  | Reversibility: 5/5, debt items: 0            |
++--------------------------------------------------------------------+
+| PLAN.md updated      | 5 truths added, 2 artifacts added            |
+| CONTEXT.md updated   | 6 decisions locked, 2 items deferred         |
+| Error/rescue registry| 8 methods, 3 CRITICAL GAPS → PLAN.md         |
+| Failure modes        | 8 total, 0 remaining CRITICAL GAPS           |
+| Diagrams produced    | 1 (sync flow architecture)                   |
+| Unresolved decisions | 0                                            |
++====================================================================+
+```
+
+## What Already Exists
+
+- Sync skill (Steps 0-7): complete workflow for checking, fetching, diffing, patching, documenting
+- Upstream registry: 8 entries with forked_to mappings
+- PATCHES.md + COMPATIBILITY.md: well-maintained
+- Eval runner: `fhhs-skills-workspace/run_all_evals.py` with LLM grading
+- 1 existing sync-upstream eval
+
+## Key Review Findings
+
+1. **git stash --include-untracked** — plain stash misses new snapshot directories
+2. **4 path patterns** — validation must handle PROMPT.md, SKILL.md, bare .md, and command paths
+3. **Missing eval runner filter** — no `--commands` flag existed, added as Task 3
+4. **Explicit eval_commands** — registry needs explicit mapping instead of runtime inference
+5. **Stash failure handling** — must warn user, not silently proceed
+
+## Architecture Diagram
+
+```
+Step 0: Load Registry
+    │
+    ▼
+*Step 0.5: Pre-Sync Validation ◄── registry.forked_to paths
+    │                                  upstream/ snapshots
+    │                                  PATCHES.md sections
+    ▼
+Step 1: Check for Updates (gh API)
+    │
+    ▼
+Step 2: Fetch & Summarize Changes
+    │
+    ▼
+Step 3: Cross-Reference Patches
+    │
+    ▼
+*Step 3.5: Git Checkpoint ◄── git stash push --include-untracked
+    │
+    ▼
+Step 4: Apply Updates (snapshot swap + patch reapply)
+    │
+    ▼
+*Step 4.5: Post-Sync Regression ◄── registry.eval_commands
+    │                                  run_all_evals.py --commands
+    ├── PASS → Step 5
+    └── FAIL → offer rollback (git stash pop)
+    │
+    ▼
+Step 5-7: Opportunities, Docs, Summary
+```
+
+## Dream State Delta
+
+```
+CURRENT STATE                    THIS PLAN                      12-MONTH IDEAL
+Manual sync, no validation  →  Validated sync with             →  CI alerts on new
+No regression detection        regression check + rollback        upstream versions,
+Silent failures possible       Targeted eval runs                 auto-PR with sync
+                               Explicit eval_commands mapping     + eval results
+```

--- a/.planning/phases/02-upstream-sync/02-01-PLAN.md
+++ b/.planning/phases/02-upstream-sync/02-01-PLAN.md
@@ -1,0 +1,324 @@
+---
+phase: 02-upstream-sync
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - .claude/skills/sync-upstream/SKILL.md
+  - .claude/skills/sync-upstream/references/upstream-registry.md
+  - evals/evals.json
+  - fhhs-skills-workspace/run_all_evals.py
+autonomous: true
+
+must_haves:
+  truths:
+    - "Sync-upstream skill validates all forked_to paths exist on disk before modifying any files"
+    - "Sync-upstream skill validates snapshot directories match registry entries before proceeding"
+    - "Sync-upstream skill creates a git stash checkpoint (with --include-untracked) before modifying files in Step 4"
+    - "Sync-upstream skill reads eval_commands from registry and runs targeted evals after patch reapplication"
+    - "Sync-upstream skill blocks commit and offers rollback when post-sync evals report failures"
+    - "At least 4 new evals cover sync-upstream pre-validation, post-regression, and conflict classification"
+    - "[review] Git stash uses --include-untracked to capture new snapshot directories"
+    - "[review] Pre-validation handles all 4 path patterns: {path}/PROMPT.md, {path}/SKILL.md, {path}.md, {path}/"
+    - "[review] If git stash fails, warn user and ask whether to continue without checkpoint"
+    - "[review] Eval runner supports --commands flag for targeted eval runs"
+    - "[review] Registry has explicit eval_commands field per upstream instead of inferred mapping"
+  artifacts:
+    - path: ".claude/skills/sync-upstream/SKILL.md"
+      provides: "pre-validation (Step 0.5), git checkpoint (Step 3.5), and post-sync regression detection (Step 4.5)"
+      contains: "Step 0.5"
+    - path: "evals/evals.json"
+      provides: "sync-upstream eval coverage for validation and regression flows"
+      contains: "pre-validation"
+    - path: ".claude/skills/sync-upstream/references/upstream-registry.md"
+      provides: "explicit eval_commands mapping per upstream"
+      contains: "eval_commands"
+    - path: "fhhs-skills-workspace/run_all_evals.py"
+      provides: "targeted eval runs via --commands flag"
+      contains: "--commands"
+  key_links:
+    - from: ".claude/skills/sync-upstream/SKILL.md"
+      to: ".claude/skills/sync-upstream/references/upstream-registry.md"
+      via: "Step 0.5 reads registry forked_to paths to validate"
+    - from: ".claude/skills/sync-upstream/SKILL.md"
+      to: "evals/evals.json"
+      via: "Step 4.5 maps upstream forked skills to eval commands"
+
+requirements:
+  - REQ-08
+  - REQ-09
+  - REQ-10
+---
+
+<objective>
+Add pre-sync validation, git checkpoint, and post-sync regression detection to the sync-upstream skill. Add evals to verify these flows work correctly. This closes the core Phase 2 gap: ensuring upstream updates don't break patched skills.
+</objective>
+
+<context>
+@.claude/skills/sync-upstream/SKILL.md
+@.claude/skills/sync-upstream/references/upstream-registry.md
+@evals/evals.json
+@PATCHES.md
+@fhhs-skills-workspace/run_all_evals.py
+@.planning/phases/02-upstream-sync/02-CONTEXT.md
+
+## Review Decisions (locked — do not re-decide)
+
+### Git stash must use --include-untracked
+Plain `git stash` only captures modified tracked files. Step 4 creates NEW untracked
+directories (`upstream/{name}-{new_version}/`). Without `--include-untracked`, rollback
+leaves orphaned new directories and loses deleted old directories.
+
+### Pre-validation must handle 4 path patterns
+The `forked_to` paths use different file conventions:
+- `skills/{name}` → check `skills/{name}/PROMPT.md` (internal skills)
+- `.claude/skills/{name}` → check `.claude/skills/{name}/SKILL.md` (shipped skills)
+- `agents/{name}` → check `agents/{name}.md` (agent definitions, bare .md)
+- `commands/{name}` or `.claude/commands/{name}` → check `{path}.md`
+Do NOT check all patterns for all paths — use the correct pattern per type.
+
+### Stash failure is a user decision
+If `git stash push --include-untracked` fails (lock file, conflicted state), you MUST
+warn the user and ask whether to continue without a checkpoint. Never silently proceed.
+
+### Eval runner failure is non-blocking
+If `python3 fhhs-skills-workspace/run_all_evals.py` fails to execute (missing python,
+script error, import failure), warn but do NOT block the sync. The user can run evals
+manually. Only eval *results* (pass/fail) should block.
+
+### Registry eval_commands are the source of truth
+Step 4.5 reads `eval_commands` directly from the upstream's registry entry. Do NOT
+attempt to infer the mapping from `forked_to` paths at runtime — that mapping is
+ambiguous for internal skills and agents.
+
+## Error & Rescue Map
+
+```
+CODEPATH                        | ERROR              | RESCUED | ACTION
+Step 0.5: path check            | PathMismatch       | Y       | Use 4-pattern check above
+Step 0.5: path check            | SilentCorruption   | N       | File exists but empty — accepted risk
+Step 0.5: snapshot check         | PartialSnapshot    | N       | Dir exists but incomplete — accepted risk
+Step 3.5: git stash              | GitLockError       | Y       | Warn user, ask continue/fix
+Step 4.5: eval runner            | RunnerMissing      | Y       | Warn, don't block sync
+Step 4.5: eval runner            | EvalTimeout        | N       | Accepted risk (runner has own timeout)
+Step 4.5: eval results           | FalsePositive      | N       | Not rescuable (eval quality issue)
+```
+
+## Architecture Diagram
+
+```
+Step 0: Load Registry
+    │
+    ▼
+Step 0.5: Pre-Sync Validation ◄── registry.forked_to + 4 path patterns
+    │                                upstream/ snapshot dirs
+    │                                PATCHES.md section headers
+    ▼
+Step 1: Check for Updates (gh API)
+    ▼
+Step 2: Fetch & Summarize Changes
+    ▼
+Step 3: Cross-Reference Patches
+    ▼
+Step 3.5: Git Checkpoint ◄── git stash push --include-untracked
+    │                          (fails → warn + ask, never silent)
+    ▼
+Step 4: Apply Updates (snapshot swap + patch reapply)
+    ▼
+Step 4.5: Post-Sync Regression ◄── registry.eval_commands (explicit)
+    │                                run_all_evals.py --commands
+    ├── PASS → Step 5
+    ├── FAIL → offer rollback (git stash pop)
+    └── RUNNER ERROR → warn, don't block
+    ▼
+Step 5-7: Opportunities, Docs, Summary
+```
+
+## NOT in scope (do not implement)
+- Evals for git checkpoint step itself (low-value guard logic)
+- Automated retry of failed evals (user decides)
+- CI alerts for new upstream versions (future phase)
+- Interactive conflict resolution UI (requires Conductor features)
+</context>
+
+<tasks>
+<task type="auto">
+  <name>Task 1: Add pre-validation and git checkpoint to sync-upstream skill</name>
+  <files>.claude/skills/sync-upstream/SKILL.md</files>
+  <action>
+  Add three new steps to the sync-upstream skill:
+
+  **Step 0.5: Pre-Sync Validation** (insert between Step 0 and Step 1):
+  1. For each targeted upstream, read its `forked_to` list from the registry
+  2. Verify every forked path exists on disk using the correct pattern for each path type:
+     - `skills/{name}` → check `skills/{name}/PROMPT.md` (internal skills)
+     - `.claude/skills/{name}` → check `.claude/skills/{name}/SKILL.md` (shipped skills)
+     - `agents/{name}` → check `agents/{name}.md` (agent definitions)
+     - `commands/{name}` or `.claude/commands/{name}` → check `commands/{name}.md` or `.claude/commands/{name}.md`
+  3. Verify the snapshot directory exists in `upstream/` matching the `snapshot_pattern`
+  4. Verify PATCHES.md has a section header matching the upstream name
+  5. If any check fails: report all failures in a table, ask user to fix before continuing or force-proceed
+  6. Format:
+  ```
+  Pre-sync validation:
+    superpowers  forked paths: 15/15 OK  snapshot: OK  patches: OK
+    gsd          forked paths: 32/33 FAIL  snapshot: OK  patches: OK
+      MISSING: agents/gsd-foo.md
+  ```
+
+  **Step 3.5: Git Checkpoint** (insert between Step 3 and Step 4):
+  1. Create a git stash with a descriptive message: `git stash push --include-untracked -m "sync-upstream checkpoint before {upstream} {old_version} -> {new_version}"`
+     - `--include-untracked` is required to capture new snapshot directories created in Step 4
+  2. If working tree is clean (nothing to stash), note "Working tree clean, no checkpoint needed" and record the current HEAD SHA instead: `git rev-parse HEAD`
+  3. If `git stash` fails (lock file, conflicted state, etc.): warn the user "Could not create checkpoint — continuing without rollback safety net." Ask: (a) continue anyway, (b) fix git state first. Do NOT silently proceed.
+  4. Store the checkpoint reference (stash ref or HEAD SHA) for use in Step 4.5
+
+  **Step 4.5: Post-Sync Regression Check** (insert between Step 4 and Step 5):
+  1. Read the `eval_commands` field from the updated upstream's registry entry (added in Task 1b). This gives the explicit list of eval commands affected by this upstream.
+  2. Report: "Running targeted evals for: build, plan-work, fix, review (N evals)"
+  3. Run: `python3 fhhs-skills-workspace/run_all_evals.py --commands {comma-separated-commands}`
+     - The `--commands` flag filters evals to only those matching the listed commands (added in Task 3)
+  4. If evals pass: "All N evals passed. Safe to commit."
+  5. If evals fail: "N evals failed. Recommend reverting:" then show the git restore command:
+     - If stash was created: `git stash pop`
+     - If HEAD was recorded: `git reset --hard {SHA}`
+  6. If eval runner fails to execute (missing python, script error): warn "Eval runner failed — cannot verify automatically. Run evals manually before committing." Do NOT block the sync.
+  7. Ask user: (a) fix and re-run, (b) revert to checkpoint, (c) commit anyway (not recommended)
+  </action>
+  <verify>
+  - SKILL.md contains "Step 0.5: Pre-Sync Validation" section
+  - SKILL.md contains "Step 3.5: Git Checkpoint" section
+  - SKILL.md contains "Step 4.5: Post-Sync Regression Check" section
+  - Step numbering is consistent (0, 0.5, 1, 2, 3, 3.5, 4, 4.5, 5, 6, 7)
+  - No existing steps were removed or reordered
+  </verify>
+  <done>Sync-upstream skill validates forked paths and snapshots before modifying files, creates git checkpoint before changes, and runs targeted evals after patch reapplication with rollback guidance on failure.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add eval_commands to upstream registry</name>
+  <files>.claude/skills/sync-upstream/references/upstream-registry.md</files>
+  <action>
+  Add an `eval_commands` field to each upstream entry in the registry. This is the explicit list of eval command names that should be run when this upstream is updated.
+
+  Derive from `forked_to` → `.claude/skills/{name}` mappings and agent → composite relationships:
+
+  - **superpowers**: `build, plan-work, fix, refactor, review, simplify, quick` (composites that reference internal superpowers skills)
+  - **impeccable**: `polish, normalize, harden, adapt, ui-animate, ui-critique, ui-redesign, distill, bolder, quieter, extract, colorize, audit, clarify, onboard, optimize, delight` (all design commands)
+  - **gsd**: `build, fix, plan-work, progress, quick, review, map-codebase, todos, tracker` (GSD workflow commands)
+  - **gstack**: `plan-review, ui-test, review` (gstack-derived skills)
+  - **feature-dev**: `review` (code-reviewer agent used by review composite)
+  - **vercel-react**: `nextjs-perf`
+  - **playwright**: `playwright-testing`
+  - **claude-md**: `revise-claude-md`
+
+  Add the field as a new row in each upstream's table, after `forked_to`.
+  </action>
+  <verify>
+  - All 8 upstreams have an `eval_commands` row
+  - Every command listed exists in the COMMAND_MAP in `fhhs-skills-workspace/run_all_evals.py`
+  - No internal-only skills (brainstorming, test-driven-development) appear in eval_commands
+  </verify>
+  <done>Registry has explicit eval_commands per upstream, eliminating runtime inference of which evals to run after a sync.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Add --commands filter to eval runner</name>
+  <files>fhhs-skills-workspace/run_all_evals.py</files>
+  <action>
+  Add a `--commands` argument to the eval runner's argparse:
+
+  1. Add argument: `parser.add_argument("--commands", type=str, default=None, help="Comma-separated list of commands to filter evals (e.g., 'build,review,fix')")`
+  2. In the main function, after loading evals from JSON, if `--commands` is provided:
+     - Split the value by comma, strip whitespace
+     - Filter `evals_list` to only include evals where `eval["command"]` is in the provided commands set
+     - Log: `"Filtered to N evals for commands: {commands}"`
+  3. If `--commands` results in 0 evals, print warning and exit 0 (not an error — the upstream may not have evals yet)
+  </action>
+  <verify>
+  - `python3 fhhs-skills-workspace/run_all_evals.py --help` shows `--commands` flag
+  - `python3 -c "..."` dry-run parse test passes
+  </verify>
+  <done>Eval runner supports targeted runs via --commands flag, enabling post-sync regression checks to run only affected evals.</done>
+</task>
+
+<task type="auto">
+  <name>Task 4: Add sync-upstream evals for validation and regression flows</name>
+  <files>evals/evals.json</files>
+  <action>
+  Add 4 new evals (next available IDs after current max). Check current max ID first.
+
+  **Eval A: Pre-validation catches missing forked file**
+  - command: "sync-upstream"
+  - prompt: "sync upstream superpowers" (in a project where one forked skill path has been deleted)
+  - expected_output: Should run pre-sync validation, detect the missing forked path, report it in the validation table, and ask user to fix before proceeding
+  - assertions:
+    1. "Runs pre-sync validation before checking for updates" (behavioral)
+    2. "Detects missing forked skill path" (behavioral)
+    3. "Reports missing path in validation table" (output)
+    4. "Does not proceed to Step 1 without user confirmation" (guard)
+    5. "Suggests fixing the missing path or force-proceeding" (output)
+
+  **Eval B: Pre-validation catches missing snapshot directory**
+  - command: "sync-upstream"
+  - prompt: "sync upstream gsd" (in a project where upstream/gsd-* directory is missing)
+  - expected_output: Should detect missing snapshot, report it, suggest re-downloading or skipping
+  - assertions:
+    1. "Detects missing snapshot directory for gsd" (behavioral)
+    2. "Reports snapshot status as FAIL in validation table" (output)
+    3. "Does not proceed to fetch changes without snapshot baseline" (guard)
+    4. "Suggests downloading current snapshot first" (output)
+
+  **Eval C: Post-sync regression detection runs targeted evals**
+  - command: "sync-upstream"
+  - prompt: "sync upstream impeccable" (after successful patch reapplication)
+  - expected_output: Should map impeccable's forked_to paths to eval commands (polish, normalize, harden, adapt, etc.), announce targeted eval run, and report results
+  - assertions:
+    1. "Maps impeccable forked skills to eval commands" (behavioral)
+    2. "Runs targeted evals only for affected commands, not full suite" (behavioral)
+    3. "Reports eval pass/fail count" (output)
+    4. "Creates git checkpoint before modifying files" (behavioral)
+    5. "Offers rollback if evals fail" (behavioral)
+
+  **Eval D: Post-sync regression failure triggers rollback offer**
+  - command: "sync-upstream"
+  - prompt: "sync upstream gsd" (after patch reapplication where evals report failures)
+  - expected_output: Should detect eval failures, show which evals failed, offer git rollback (stash pop or reset), and NOT auto-commit
+  - assertions:
+    1. "Detects eval failures after patch reapplication" (behavioral)
+    2. "Shows which specific evals failed" (output)
+    3. "Offers git rollback to pre-sync checkpoint" (behavioral)
+    4. "Does not commit changes when evals fail" (guard)
+    5. "Presents options: fix and re-run, revert, or commit anyway" (output)
+  </action>
+  <verify>
+  - 4 new evals exist with unique IDs
+  - Each has: id, command, prompt, expected_output, files, assertions
+  - Each has 5 assertions
+  - evals.json is valid JSON
+  - sync-upstream now has 5 total evals (1 existing + 4 new)
+  </verify>
+  <done>Sync-upstream has 5 evals covering pre-validation (missing files, missing snapshots), post-sync regression detection, and rollback on failure.</done>
+</task>
+</tasks>
+
+<verification>
+- `python3 -c "import json; json.load(open('evals/evals.json'))"` — valid JSON
+- `python3 -c "import json; d=json.load(open('evals/evals.json')); print(len([e for e in d['evals'] if e['command']=='sync-upstream']))"` — should be 5
+- `grep -c 'Step 0.5\|Step 3.5\|Step 4.5' .claude/skills/sync-upstream/SKILL.md` — should be 3
+- All existing sync-upstream steps (0-7) still present and unmodified in content
+- `grep -c 'eval_commands' .claude/skills/sync-upstream/references/upstream-registry.md` — should be 8
+- `python3 fhhs-skills-workspace/run_all_evals.py --help 2>&1 | grep -c 'commands'` — should be 1
+</verification>
+
+<success_criteria>
+- Sync-upstream skill validates all forked_to paths exist on disk before modifying any files
+- Sync-upstream skill validates snapshot directories match registry entries before proceeding
+- Sync-upstream skill creates a git stash checkpoint before modifying files in Step 4
+- Sync-upstream skill runs targeted evals for affected commands after patch reapplication
+- Sync-upstream skill blocks commit and offers rollback when post-sync evals report failures
+- At least 4 new evals cover sync-upstream pre-validation, post-regression, and conflict classification
+</success_criteria>
+
+<output>.planning/phases/02-upstream-sync/02-01-SUMMARY.md</output>

--- a/.planning/phases/03.5-pipeline-depth/03.5-01-PLAN.md
+++ b/.planning/phases/03.5-pipeline-depth/03.5-01-PLAN.md
@@ -1,0 +1,241 @@
+---
+phase: 03.5-pipeline-depth
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - .claude/skills/plan-work/SKILL.md
+  - .claude/skills/plan-review/SKILL.md
+  - evals/evals.json
+autonomous: true
+
+must_haves:
+  truths:
+    - "When plan-work encounters a complex task in an unfamiliar domain, it suggests deep research (phase-researcher) before brainstorming"
+    - "plan-work Step 3 produces CONTEXT.md with explicit locked/discretion/deferred decision categories for multi-task plans"
+    - "plan-review always runs both business alignment (CEO) AND engineering rigor (architecture, code quality, tests, performance) in a single review"
+    - "plan-work Step 7 handoff strongly defaults to /fh:plan-review — only skips for trivially obvious work (single-file rename, typo fix)"
+  artifacts:
+    - path: ".claude/skills/plan-work/SKILL.md"
+      provides: "complexity-aware planning pipeline"
+      contains: "Complexity Assessment"
+    - path: ".claude/skills/plan-review/SKILL.md"
+      provides: "unified plan review with CEO + engineering sections"
+      contains: "Engineering Review"
+  key_links:
+    - from: ".claude/skills/plan-work/SKILL.md"
+      to: ".claude/skills/plan-review/SKILL.md"
+      via: "Step 7 handoff strongly defaults to plan-review"
+    - from: ".claude/skills/plan-review/SKILL.md"
+      to: "upstream/gstack-0.3.3/plan-eng-review/UPSTREAM-SKILL.md"
+      via: "eng review sections adapted from gstack"
+---
+
+<objective>
+Make plan-work smarter about when to involve deeper research, discussion, and review.
+Currently plan-work treats all tasks the same — simple rename or complex greenfield app
+both get the same lightweight flow. After this change, plan-work assesses complexity and
+suggests appropriate depth: deeper research for unfamiliar domains, explicit decision-locking
+for multi-session features. Also integrates engineering review sections (architecture, code
+quality, tests, performance) into plan-review so every review covers both business alignment
+and engineering rigor. Plan-work handoff strongly defaults to plan-review for all non-trivial work.
+</objective>
+
+<context>
+@.claude/skills/plan-work/SKILL.md (current plan-work skill)
+@.claude/skills/plan-review/SKILL.md (current plan-review skill — CEO-style)
+@upstream/gstack-0.3.3/plan-eng-review/UPSTREAM-SKILL.md (eng review methodology to adapt)
+@.planning/upstream/INDEX.md (gap registry for reference)
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add complexity assessment and depth suggestion to plan-work</name>
+  <files>.claude/skills/plan-work/SKILL.md</files>
+  <action>
+  Add a new **Step 0.5: Complexity Assessment** between Step 0 (Phase Matching) and Step 1 (Research).
+
+  This step evaluates the task and suggests appropriate depth to the user:
+
+  **Complexity signals to check:**
+  - Task count estimate: how many files/components will this touch?
+  - Domain familiarity: does the codebase already have patterns for this? (check with quick glob/grep)
+  - Architectural impact: does this introduce new dependencies, data flows, or system boundaries?
+  - Multi-session likelihood: will this span multiple conversations?
+
+  **Depth suggestion matrix:**
+
+  | Complexity | Research | Discussion | Review |
+  |-----------|----------|------------|--------|
+  | **Simple** (1-3 tasks, familiar patterns, single file area) | Skip | Skip | Suggest `/fh:plan-review` (can skip for trivial: rename, typo) |
+  | **Medium** (4-8 tasks, some unfamiliar patterns) | Inline research | Identify gray areas | Strongly suggest `/fh:plan-review` |
+  | **Complex** (9+ tasks, unfamiliar domain, new architecture, multi-session) | Suggest deep research via phase-researcher agent | Full discussion with decision-locking | Strongly suggest `/fh:plan-review` |
+
+  Present the assessment to the user: "This looks [simple/medium/complex] — I suggest [depth]. Want to proceed with that depth, or adjust?"
+
+  **Then modify Step 1 (Research):**
+  - Add a "Deep research" path: when complexity assessment suggests it, offer to spawn a gsd-phase-researcher subagent that produces structured RESEARCH.md (stack patterns, architecture approaches, pitfalls, code examples from authoritative sources). This is heavier than inline research but produces reusable artifacts.
+  - Add a "Codebase exploration" path: when working in an unfamiliar codebase, suggest dispatching code-explorer agent before brainstorming to understand existing patterns.
+  - Keep the current inline research as the default for medium complexity.
+
+  **Then modify Step 3 (Discuss Implementation):**
+  - Formalize the decision output format. After discussing gray areas, explicitly categorize each decision into:
+    - **Locked** — Claude must follow this in all subsequent sessions. No re-deciding.
+    - **Discretion** — Claude decides within stated bounds. Document the bounds.
+    - **Deferred** — Tracked for later. Not in scope for this plan.
+  - Write these to CONTEXT.md using a clear three-section format with headers: `## Locked Decisions`, `## Discretion Areas`, `## Deferred Ideas`
+  - Add a note that these locked decisions are injected into build subagent prompts via the implementer-prompt template, preventing downstream re-deciding.
+
+  **Then modify Step 7 (Handoff):**
+  - Default to `/fh:plan-review` for ALL plans. The review now covers both business alignment and engineering rigor in one pass.
+  - Only skip review for trivially obvious work: single-file renames, typo fixes, config changes with no behavioral impact.
+  - Rewrite the handoff options:
+    1. **`/fh:plan-review`** (default) — "Review before building. Covers business alignment, architecture, code quality, tests, and performance."
+    2. **`/fh:build`** — "Skip review — only if this is trivially obvious (rename, typo, config-only change)."
+    3. **Continue planning** — Plan more phases before building.
+  - Remove the old complexity-based tiering for review. Review is the default, not a suggestion.
+  </action>
+  <verify>
+  - Read the modified SKILL.md and verify Step 0.5 exists with complexity signals and depth matrix
+  - Verify Step 1 has "Deep research" and "Codebase exploration" paths
+  - Verify Step 3 has locked/discretion/deferred categorization
+  - Verify Step 7 references complexity-based review depth including --eng
+  </verify>
+  <done>plan-work assesses complexity and suggests appropriate depth for research, discussion, and review</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Integrate engineering review sections into plan-review</name>
+  <files>.claude/skills/plan-review/SKILL.md</files>
+  <action>
+  Add engineering review sections to plan-review so that EVERY review covers both business alignment AND engineering rigor. This is not a separate mode — it's an expansion of the standard review.
+
+  **Changes to make:**
+
+  1. Update the Philosophy section to reflect the dual perspective:
+  - The reviewer evaluates from TWO perspectives in every review:
+    - **Business alignment (CEO lens):** "Is this the right thing to build?" — scope, strategic fit, failure modes
+    - **Engineering rigor (EM lens):** "Can we build this reliably?" — architecture, code quality, tests, performance
+  - The existing scope challenge (Step 0) and review modes (SCOPE EXPANSION/HOLD/REDUCTION) remain unchanged — they apply to both lenses.
+
+  2. After the existing review sections (which cover the CEO/business lens), add engineering review sections adapted from gstack plan-eng-review:
+
+  **Engineering Section 1: Architecture Review**
+  - System design and component boundaries
+  - Dependency graph and coupling concerns
+  - Data flow patterns and potential bottlenecks
+  - Scaling characteristics and single points of failure
+  - Security architecture (auth, data access, API boundaries)
+  - For each new codepath: one realistic production failure scenario and whether the plan accounts for it
+  - ASCII diagrams for non-trivial flows
+
+  **Engineering Section 2: Code Quality Review**
+  - DRY violations (flag aggressively)
+  - Error handling patterns and missing edge cases
+  - Over-engineered or under-engineered areas
+  - Existing code/patterns that already solve sub-problems (reuse vs rebuild)
+  - Existing ASCII diagrams in touched files — still accurate?
+
+  **Engineering Section 3: Test Review**
+  - Diagram ALL new UX, data flows, codepaths, branching
+  - For each item in diagram: verify test exists
+  - For skill/prompt changes: verify eval coverage exists
+  - Produce ASCII "test diagram" showing coverage status
+
+  **Engineering Section 4: Performance Review**
+  - N+1 queries and database access patterns
+  - Memory-usage concerns
+  - Caching opportunities
+  - Slow or high-complexity code paths
+
+  Each section follows the same interactive protocol as existing sections: present issues one at a time via AskUserQuestion, state recommendation + WHY + lettered options.
+
+  3. For SMALL CHANGE mode (compressed review): pick one issue from each engineering section in addition to the existing business sections. Keep the single-batch format but extend it.
+
+  4. Update Required Outputs to include:
+  - "Test diagram" — ASCII art of all new codepaths and their test coverage status (always, not just eng mode)
+  - Keep all existing required outputs (NOT in scope, What already exists, failure modes, TODOS.md)
+
+  5. Update completion summary template to include engineering section counts.
+
+  6. Update the description frontmatter to mention engineering review coverage.
+
+  7. Add attribution line at bottom: `_Engineering review sections adapted from gstack plan-eng-review (v0.3.3)_`
+  </action>
+  <verify>
+  - Read the modified SKILL.md and verify 4 engineering sections exist after existing CEO sections
+  - Verify the interactive protocol (AskUserQuestion per issue) is preserved for all sections
+  - Verify existing CEO sections are unchanged (business alignment, scope challenge, failure modes)
+  - Verify SMALL CHANGE mode mentions engineering sections
+  - Verify Required Outputs includes test diagram
+  - Verify completion summary includes engineering section counts
+  </verify>
+  <done>plan-review always runs both business alignment AND engineering rigor in every review</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Add evals for new plan-work and plan-review behaviors</name>
+  <files>evals/evals.json</files>
+  <action>
+  Add evals that verify the new behaviors. Add entries to evals/evals.json following the existing format (check a few existing entries for the pattern).
+
+  **Evals to add:**
+
+  1. **plan-work complexity assessment triggers on complex task**
+     - Input: "Plan building a real-time collaboration system with WebSocket, CRDT, and presence indicators"
+     - Expected: output mentions complexity assessment, suggests deep research, mentions unfamiliar domain
+     - Command: plan-work
+
+  2. **plan-work complexity assessment for simple task**
+     - Input: "Plan renaming the /fh:tracker command to /fh:dashboard"
+     - Expected: output treats as simple, doesn't suggest deep research
+     - Command: plan-work
+
+  3. **plan-work decision-locking produces CONTEXT.md format**
+     - Input: "Plan a new authentication system" (with mock .planning/ fixture)
+     - Expected: output mentions locked decisions, discretion, deferred
+     - Command: plan-work
+
+  4. **plan-work handoff defaults to plan-review**
+     - Input: any non-trivial plan
+     - Expected: handoff defaults to /fh:plan-review, presents /fh:build as skip-review option only for trivial work
+     - Command: plan-work
+
+  5. **plan-review includes engineering sections**
+     - Input: plan reference
+     - Expected: output covers BOTH business alignment (scope challenge, strategic fit) AND engineering rigor (architecture, code quality, test coverage, performance)
+     - Command: plan-review
+
+  6. **plan-review engineering sections produce test diagram**
+     - Input: plan reference with new codepaths
+     - Expected: output includes ASCII test diagram showing coverage status
+     - Command: plan-review
+
+  Follow the existing eval format in evals.json. Use realistic mock project fixtures where needed.
+  </action>
+  <verify>
+  - Verify new eval entries are valid JSON
+  - Verify eval IDs don't conflict with existing ones
+  - Verify expected_output patterns are specific enough to distinguish behaviors
+  </verify>
+  <done>eval coverage exists for complexity assessment, decision-locking, eng review, and handoff depth</done>
+</task>
+
+</tasks>
+
+<verification>
+- Read .claude/skills/plan-work/SKILL.md and verify Step 0.5, enhanced Step 1, enhanced Step 3, enhanced Step 7
+- Read .claude/skills/plan-review/SKILL.md and verify 4 engineering review sections integrated into standard flow
+- Run `python3 evals/run_all_evals.py --commands plan-work,plan-review` to verify new evals parse correctly
+</verification>
+
+<success_criteria>
+- plan-work assesses complexity and suggests appropriate depth for research, discussion, and review
+- plan-work Step 3 produces CONTEXT.md with locked/discretion/deferred categories
+- plan-review always runs both business alignment AND engineering rigor sections in every review
+- plan-work handoff strongly defaults to /fh:plan-review — only skips for trivially obvious work
+</success_criteria>
+
+<output>.planning/phases/03.5-pipeline-depth/03.5-01-SUMMARY.md</output>

--- a/.planning/phases/03.5-pipeline-depth/03.5-02-PLAN.md
+++ b/.planning/phases/03.5-pipeline-depth/03.5-02-PLAN.md
@@ -1,0 +1,183 @@
+---
+phase: 03.5-pipeline-depth
+plan: 02
+type: execute
+wave: 1
+depends_on: [01]
+files_modified:
+  - .claude/skills/build/SKILL.md
+  - .claude/skills/fix/SKILL.md
+  - evals/evals.json
+autonomous: true
+
+must_haves:
+  truths:
+    - "build Step 5 (Self-Check) runs verification-before-completion gate before writing SUMMARY — no success claims without fresh evidence"
+    - "fix Step 4 (Post-Fix Review) runs verification-before-completion gate before generating summary"
+    - "build Step 4 suggests /fh:audit for frontend-heavy builds and /fh:harden for production-bound frontend features"
+  artifacts:
+    - path: ".claude/skills/build/SKILL.md"
+      provides: "build pipeline with verification gate and design quality suggestions"
+      contains: "verification-before-completion"
+    - path: ".claude/skills/fix/SKILL.md"
+      provides: "fix pipeline with verification gate"
+      contains: "verification-before-completion"
+  key_links:
+    - from: ".claude/skills/build/SKILL.md"
+      to: "skills/verification-before-completion/PROMPT.md"
+      via: "Step 5 reads and follows verification gate"
+    - from: ".claude/skills/fix/SKILL.md"
+      to: "skills/verification-before-completion/PROMPT.md"
+      via: "Step 4 reads and follows verification gate"
+---
+
+<objective>
+Wire verification-before-completion into build and fix pipelines so success claims
+require fresh evidence. Also suggest /fh:audit and /fh:harden in build's design gates
+for frontend work. Addresses audit gaps G2, G6, G7.
+</objective>
+
+<context>
+@.claude/skills/build/SKILL.md (build pipeline — Steps 4, 5, 9 are modification targets)
+@.claude/skills/fix/SKILL.md (fix pipeline — Step 4 is modification target)
+@skills/verification-before-completion/PROMPT.md (gate function to wire in)
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Wire verification gate into build and fix</name>
+  <files>.claude/skills/build/SKILL.md, .claude/skills/fix/SKILL.md</files>
+  <action>
+  **In build SKILL.md, modify Step 5 (Self-Check + Generate SUMMARY.md):**
+
+  Before the existing self-check file/commit verification, add a verification gate:
+
+  ```
+  ### Verification gate
+
+  Before claiming build success, read `skills/verification-before-completion/PROMPT.md`
+  and follow its gate function:
+
+  1. **IDENTIFY** verification commands for this build:
+     - Test suite: run the project's test command (from package.json or CLAUDE.md)
+     - Build check: if the project has a build step, run it
+     - Lint: if the project has a linter, run it
+  2. **RUN** each command fresh and complete
+  3. **READ** full output — check exit codes, count failures
+  4. **VERIFY** all pass before proceeding to SUMMARY generation
+
+  If any verification fails: flag in SUMMARY under "Issues Encountered" with the
+  actual output. Do NOT claim the build succeeded if verification failed.
+  ```
+
+  **In fix SKILL.md, modify Step 4 (Post-Fix Review):**
+
+  Add a verification gate before the existing review suggestion. Insert at the beginning of Step 4:
+
+  ```
+  ### Verification gate
+
+  Before claiming the fix is complete, read `skills/verification-before-completion/PROMPT.md`
+  and follow its gate function:
+
+  1. **IDENTIFY** the verification command that proves the fix works:
+     - The test written in Step 2 must pass
+     - The original reproduction must no longer occur
+     - Related test suites must still pass (no regressions)
+  2. **RUN** each command fresh
+  3. **READ** full output — check exit code, count failures
+  4. **VERIFY** the fix is confirmed before proceeding
+
+  If verification fails: return to Step 2 and iterate. Do NOT proceed to review
+  or summary if the fix isn't verified.
+  ```
+
+  Keep all existing content in both files — these are additions, not replacements.
+  </action>
+  <verify>
+  - Grep for "verification-before-completion" in both SKILL.md files
+  - Verify the gate references skills/verification-before-completion/PROMPT.md
+  - Verify existing Step 5 and Step 4 content is preserved
+  </verify>
+  <done>build and fix pipelines require fresh verification evidence before claiming success</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add audit and harden suggestions to build design gates</name>
+  <files>.claude/skills/build/SKILL.md</files>
+  <action>
+  **In build SKILL.md, modify Step 4 (Design Gates):**
+
+  After the existing "Consider Animate" section and before Step 4b, add:
+
+  ```
+  ### Consider Audit (frontend-heavy builds)
+  If the build involved 5+ frontend files and the work is user-facing:
+  Suggest `/fh:audit` for comprehensive quality checks (accessibility, performance, theming, responsive).
+  "Frontend-heavy build detected. Run `/fh:audit` for a11y/perf/responsive quality check?"
+  Don't auto-run — ask user.
+
+  ### Consider Harden (production-bound frontend)
+  If the build is for production deployment (not a prototype or internal tool):
+  Suggest `/fh:harden` for production resilience (text overflow, i18n, RTL, network errors, edge cases).
+  "Production-bound frontend work. Run `/fh:harden` for edge case resilience?"
+  Don't auto-run — ask user.
+  ```
+
+  These are suggestions like the existing "Consider Animate" — they respect user choice.
+  </action>
+  <verify>
+  - Grep for "Consider Audit" and "Consider Harden" in build SKILL.md
+  - Verify they appear after "Consider Animate" and before Step 4b
+  - Verify they are suggestions (ask user), not auto-runs
+  </verify>
+  <done>build suggests /fh:audit and /fh:harden for frontend-heavy and production builds</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Add evals for verification gate and design quality suggestions</name>
+  <files>evals/evals.json</files>
+  <action>
+  Add evals covering the new behaviors. Follow the existing eval format.
+
+  1. **build verification gate runs before success claim**
+     - Expected: build output references verification-before-completion, runs verification commands before SUMMARY
+     - Command: build
+
+  2. **fix verification gate runs before completion**
+     - Expected: fix output references verification-before-completion, verifies fix before summary
+     - Command: fix
+
+  3. **build suggests audit for frontend-heavy work**
+     - Expected: build output suggests /fh:audit when frontend files are prominent
+     - Command: build
+
+  4. **build suggests harden for production frontend**
+     - Expected: build output suggests /fh:harden for production deployment
+     - Command: build
+
+  Use IDs starting from 204 (after Plan 01's 198-203).
+  </action>
+  <verify>
+  - Validate JSON: python3 -c "import json; json.load(open('evals/evals.json'))"
+  - Check IDs don't conflict
+  </verify>
+  <done>eval coverage exists for verification gates and design quality suggestions</done>
+</task>
+
+</tasks>
+
+<verification>
+- grep "verification-before-completion" in build/SKILL.md and fix/SKILL.md
+- grep "Consider Audit" and "Consider Harden" in build/SKILL.md
+- python3 -c "import json; json.load(open('evals/evals.json'))"
+</verification>
+
+<success_criteria>
+- build Step 5 runs verification gate before writing SUMMARY
+- fix Step 4 runs verification gate before generating summary
+- build Step 4 suggests /fh:audit and /fh:harden for frontend work
+</success_criteria>
+
+<output>.planning/phases/03.5-pipeline-depth/03.5-02-SUMMARY.md</output>

--- a/.planning/phases/03.5-pipeline-depth/03.5-03-PLAN.md
+++ b/.planning/phases/03.5-pipeline-depth/03.5-03-PLAN.md
@@ -1,0 +1,430 @@
+---
+phase: 03.5-pipeline-depth
+plan: 03
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - .claude/skills/plan-work/SKILL.md
+  - .claude/skills/new-project/SKILL.md
+  - .claude/skills/plan-review/SKILL.md
+  - .claude/skills/build/SKILL.md
+  - .claude/skills/build/references/implementer-prompt.md
+  - .planning/phases/02-upstream-sync/02-CONTEXT.md
+  - .planning/phases/03-capability-audit/03-CONTEXT.md
+  - evals/evals.json
+autonomous: true
+
+must_haves:
+  truths:
+    - "When plan-work assesses a task as Complex, it spawns a gsd-phase-researcher agent that writes XX-RESEARCH.md to the phase directory before brainstorming"
+    - "When plan-work assesses a task as Medium with unfamiliar domain, it spawns an inline research subagent"
+    - "When new-project reaches requirements definition, it offers domain research — spawning project researchers then synthesizer — with Features always offered and Stack/Architecture/Pitfalls conditional on stack clarity"
+    - "Research output paths are phase-scoped (.planning/phases/XX-name/XX-RESEARCH.md) for plan-work and project-scoped (.planning/research/) for new-project, matching what downstream consumers expect"
+    - "plan-review loads CONTEXT.md decisions before reviewing, checks RESEARCH.md alignment when research exists, and may flag decision concerns with evidence using respect-but-flag protocol"
+    - "[review] All core loop skills use 3 canonical CONTEXT.md sections aligned to the CLI template: Decisions, Discretion Areas, Deferred Ideas"
+    - "[review] plan-review updates the Decisions section directly (with [review] prefix) instead of creating a separate Review Decisions section"
+    - "[review] build reads all 3 CONTEXT.md sections and injects them into subagent prompts via implementer-prompt.md"
+    - "[review] plan-work contains a CONTEXT.md Contract comment documenting canonical sections and listing all consumers"
+  artifacts:
+    - path: ".claude/skills/plan-work/SKILL.md"
+      provides: "Phase research agent integration + CONTEXT.md contract definition"
+      contains: "gsd-phase-researcher"
+    - path: ".claude/skills/new-project/SKILL.md"
+      provides: "Project research agent integration in bootstrapping workflow"
+      contains: "gsd-project-researcher"
+    - path: ".claude/skills/plan-review/SKILL.md"
+      provides: "Research-aware plan review with respect-but-flag and unified Decisions section"
+      contains: "RESEARCH.md"
+    - path: ".claude/skills/build/SKILL.md"
+      provides: "Aligned CONTEXT.md section reading matching CLI template"
+      contains: "Discretion Areas"
+    - path: ".claude/skills/build/references/implementer-prompt.md"
+      provides: "Aligned placeholder injection scope"
+      contains: "Discretion Areas"
+    - path: "evals/evals.json"
+      provides: "Keyword-presence evals for contract alignment"
+      contains: "research-agent-integration"
+  key_links:
+    - from: ".claude/skills/plan-work/SKILL.md"
+      to: "agents/gsd-phase-researcher.md"
+      via: "Task(subagent_type=gsd-phase-researcher)"
+    - from: ".claude/skills/new-project/SKILL.md"
+      to: "agents/gsd-project-researcher.md"
+      via: "Task(subagent_type=gsd-project-researcher)"
+    - from: ".claude/skills/new-project/SKILL.md"
+      to: "agents/gsd-research-synthesizer.md"
+      via: "Task(subagent_type=gsd-research-synthesizer)"
+    - from: ".claude/skills/plan-review/SKILL.md"
+      to: ".planning/phases/XX-name/XX-CONTEXT.md"
+      via: "reads Decisions section (respects locks, may flag with evidence), appends [review] decisions"
+    - from: ".claude/skills/plan-review/SKILL.md"
+      to: ".planning/phases/XX-name/XX-RESEARCH.md"
+      via: "reads research findings, checks plan alignment"
+    - from: ".claude/skills/build/SKILL.md"
+      to: ".planning/phases/XX-name/XX-CONTEXT.md"
+      via: "reads Decisions, Discretion Areas, Deferred Ideas → injects into {DESIGN_DECISIONS}"
+
+requirements: []
+---
+
+<objective>
+Wire existing research/discovery agents into plan-work and new-project, make plan-review research-aware with respect-but-flag, and align CONTEXT.md section names across the entire core loop (plan-work → plan-review → build) to match the CLI template's canonical sections. Eliminates the separate "Review Decisions" section — plan-review now updates the unified "Decisions" section directly.
+</objective>
+
+<context>
+@.claude/skills/plan-work/SKILL.md
+@.claude/skills/new-project/SKILL.md
+@.claude/skills/plan-review/SKILL.md
+@.claude/skills/build/SKILL.md
+@.claude/skills/build/references/implementer-prompt.md
+@agents/gsd-phase-researcher.md
+@agents/gsd-project-researcher.md
+@agents/gsd-research-synthesizer.md
+@upstream/gsd-1.22.4/workflows/new-project.md (Step 6 — research spawning pattern)
+@upstream/gsd-1.22.4/workflows/discovery-phase.md (depth levels)
+@bin/lib/commands.cjs (line ~495 — CLI template, canonical source for section names)
+@.planning/phases/02-upstream-sync/02-CONTEXT.md (needs section rename)
+@.planning/phases/03-capability-audit/03-CONTEXT.md (needs section rename)
+
+CONTEXT.md Contract (canonical sections, aligned to CLI template in bin/lib/commands.cjs):
+  ## Decisions          — all locked choices (plan-work creates, plan-review updates with [review] prefix)
+  ## Discretion Areas   — bounds for executor decisions (plan-work creates)
+  ## Deferred Ideas     — out of scope items (plan-work creates, plan-review appends)
+Consumers: build/SKILL.md (lines ~106, ~294), build/references/implementer-prompt.md
+</context>
+
+<tasks>
+<task type="auto">
+  <name>Task 1: Wire phase research into plan-work + add CONTEXT.md contract</name>
+  <files>.claude/skills/plan-work/SKILL.md</files>
+  <action>
+  Two changes to plan-work:
+
+  **A. Rewrite Step 1 (Research) to actually spawn agents based on complexity:**
+
+  1. **Fix the output path reference** — change `.planning/research/YYYY-MM-DD-<topic>-RESEARCH.md` to `.planning/phases/XX-name/XX-RESEARCH.md` (matching what gsd-phase-researcher actually writes).
+
+  2. **Deep research path (Complex tasks):** Replace the "offer to spawn" text with actual spawning instructions:
+     ```
+     Task(
+       prompt="Research Phase [X]: [name]. Goal: [phase goal].
+       <files_to_read>
+       .planning/phases/XX-name/XX-CONTEXT.md (if exists)
+       </files_to_read>
+       Phase requirements: [list from ROADMAP.md]
+       Write to: .planning/phases/XX-name/XX-RESEARCH.md",
+       subagent_type="gsd-phase-researcher",
+       description="Phase research"
+     )
+     ```
+     After agent completes, read the RESEARCH.md and carry its findings into Step 2 (Brainstorm).
+
+  3. **Medium tasks (inline research):** Keep the existing inline subagent approach but clarify the output path is `.planning/phases/XX-name/XX-RESEARCH.md` (not `.planning/research/`).
+
+  4. **Simple tasks:** Keep skip behavior unchanged.
+
+  5. **Add confidence gate after research:** After research completes, if confidence is LOW on any critical finding, suggest escalating to deeper research before proceeding.
+
+  **B. Align CONTEXT.md sections to CLI template + add contract comment:**
+
+  1. In Step 3 (Discuss Implementation), rename `## Locked Decisions` to `## Decisions` in the template format.
+
+  2. Keep `## Discretion Areas` unchanged (already matches CLI).
+
+  3. Keep `## Deferred Ideas` unchanged (already matches CLI).
+
+  4. Add a contract comment block before the section format:
+     ```markdown
+     > **CONTEXT.md Contract** — Canonical sections (source: bin/lib/commands.cjs):
+     > - `## Decisions` — all locked choices (consumers: plan-review reads+updates, build injects into subagents)
+     > - `## Discretion Areas` — bounds for executor decisions (consumers: build)
+     > - `## Deferred Ideas` — out of scope items (consumers: build as scope boundary)
+     > plan-review appends to Decisions with `[review]` prefix and to Deferred Ideas.
+     > Any rename MUST be mirrored in: plan-review (PRE-REVIEW + Step B),
+     > build (SKILL.md lines ~106, ~294), implementer-prompt.md, and bin/lib/commands.cjs.
+     ```
+  </action>
+  <verify>
+  - Grep plan-work/SKILL.md for `gsd-phase-researcher` — must appear in Step 1
+  - Grep for `.planning/research/YYYY-MM-DD` — must NOT appear (old path removed)
+  - Grep for `CONTEXT.md Contract` — must appear
+  - Grep for `## Locked Decisions` — must NOT appear (renamed to `## Decisions`)
+  - Grep for `## Decisions` — must appear in template
+  - Grep for `## Deferred Ideas` — must appear (unchanged)
+  </verify>
+  <done>plan-work Step 1 spawns gsd-phase-researcher for complex tasks with correct paths and confidence gate. Step 3 uses canonical section names (Decisions, Discretion Areas, Deferred Ideas) with contract comment block.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Wire project research into new-project</name>
+  <files>.claude/skills/new-project/SKILL.md</files>
+  <action>
+  Add a new Step 4.5 (Research) between Step 4 (CLAUDE.md) and Step 5 (Requirements + Roadmap). Follow the upstream pattern from new-project.md Step 6 but with conditional logic:
+
+  1. **Add Step 4.5: Domain Research (optional)** with this flow:
+     - Check if the stack was fully specified in Step 2. If yes, skip Stack research.
+     - Ask user: "Research the domain ecosystem before defining requirements? This discovers standard features, architecture patterns, and pitfalls."
+       - "Research first (Recommended)" → proceed with research
+       - "Skip research" → jump to Step 5
+
+  2. **If researching, determine which dimensions to spawn:**
+     - **Features** — always spawn (table stakes vs differentiators)
+     - **Pitfalls** — always spawn (critical for roadmap quality)
+     - **Stack** — only if stack wasn't fully decided in Step 2
+     - **Architecture** — only if stack wasn't fully decided in Step 2
+
+  3. **Spawn researchers in parallel** using the upstream pattern:
+     ```
+     mkdir -p .planning/research
+
+     Task(prompt="Project Research — Features dimension for [domain]. [project context]
+     Write to: .planning/research/FEATURES.md",
+     subagent_type="gsd-project-researcher", description="Features research")
+
+     Task(prompt="Project Research — Pitfalls dimension for [domain]. [project context]
+     Write to: .planning/research/PITFALLS.md",
+     subagent_type="gsd-project-researcher", description="Pitfalls research")
+
+     # Conditional:
+     Task(prompt="Project Research — Stack dimension...",
+     subagent_type="gsd-project-researcher", description="Stack research")
+
+     Task(prompt="Project Research — Architecture dimension...",
+     subagent_type="gsd-project-researcher", description="Architecture research")
+     ```
+
+  4. **After all researchers complete, spawn synthesizer:**
+     ```
+     Task(prompt="Synthesize research outputs into SUMMARY.md.
+     <files_to_read>
+     .planning/research/FEATURES.md
+     .planning/research/PITFALLS.md
+     .planning/research/STACK.md (if exists)
+     .planning/research/ARCHITECTURE.md (if exists)
+     </files_to_read>
+     Write to: .planning/research/SUMMARY.md",
+     subagent_type="gsd-research-synthesizer", description="Synthesize research")
+     ```
+
+  5. **Feed research into Step 5:** Add instruction that if research exists, Step 5 should read `.planning/research/SUMMARY.md` and use it to inform requirements definition and roadmap phase structure.
+
+  6. **Renumber Steps 5-7 to 6-8** to accommodate the new step.
+  </action>
+  <verify>
+  - Grep new-project/SKILL.md for `gsd-project-researcher` — must appear
+  - Grep for `gsd-research-synthesizer` — must appear
+  - Grep for `.planning/research/FEATURES.md` — must appear
+  - Grep for `SUMMARY.md` — must appear in both research step and requirements step
+  - Step numbering is sequential with no gaps
+  </verify>
+  <done>new-project contains a research step that conditionally spawns project researchers (Features+Pitfalls always, Stack+Architecture conditional), synthesizes results, and feeds them into requirements/roadmap definition</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Make plan-review research-aware, context-aware, and unified</name>
+  <files>.claude/skills/plan-review/SKILL.md</files>
+  <action>
+  Four changes to plan-review:
+
+  1. **Add CONTEXT.md loading to PRE-REVIEW SYSTEM AUDIT** — After the git commands and before "Report findings", add:
+     ```
+     ### Load Phase Context
+     Read `.planning/phases/{phase}/{phase}-CONTEXT.md` if it exists.
+     This contains decisions from plan-work's discussion phase.
+
+     **Respect-but-flag protocol for locked decisions:**
+     - Default: respect decisions. Do NOT suggest alternatives.
+     - Exception: if during review you find evidence that a decision causes
+       a problem (research contradicts it, architecture review reveals a flaw,
+       security concern), you MAY surface it as:
+       "Decision concern: [decision X] was locked in planning, but [evidence Y]
+       suggests reconsidering. Confirm or unlock for revision?"
+     - Present as an AskUserQuestion with options: Keep decision / Revise.
+     - If user keeps it, move on. Do not revisit.
+     ```
+
+  2. **Add Research alignment check** — After CONTEXT.md loading, add:
+     ```
+     ### Research Alignment Check
+     Check if `.planning/phases/{phase}/{phase}-RESEARCH.md` exists.
+     If it does, read it and verify during the review that:
+     - The plan uses the recommended stack from research (or documents why not)
+     - The plan addresses pitfalls identified in research (Common Pitfalls section)
+     - The plan doesn't hand-roll solutions for problems listed in "Don't Hand-Roll"
+     - LOW confidence findings from research are handled with appropriate caution
+     If misalignment is found, surface it as an issue during Architecture Review (Section 1).
+     ```
+
+  3. **Update Section 1 (Architecture Review)** — Add a bullet point:
+     ```
+     * Research alignment — if RESEARCH.md exists, does the plan follow its
+       recommendations? Flag any deviation from recommended stack, ignored pitfalls,
+       or hand-rolled solutions for solved problems.
+     ```
+
+  4. **Rewrite Step B to use unified Decisions section** — Replace the current Step B that creates separate "Review Decisions" and "NOT in scope" sections. Instead:
+     ```
+     ### Step B: Update CONTEXT.md
+
+     Append to `.planning/phases/{phase}/{phase}-CONTEXT.md` (create section if missing):
+
+     **"Decisions" section** — Append new decisions made during review to the
+     existing ## Decisions section. Prefix each with `[review]` so the source
+     is traceable:
+       - [review] [Decision]: [What was decided and why]
+
+     If a decision was unlocked and revised via respect-but-flag, update the
+     original entry in-place and add `[revised in review]` suffix.
+
+     **"Deferred Ideas" section** — Append items considered and explicitly
+     deferred during review, with one-line rationale each.
+     ```
+
+     Also update the delight opportunities section (line ~473) to reference
+     "Deferred Ideas" instead of "NOT in scope".
+
+     Remove all references to "Review Decisions" as a section name.
+     Remove the reference to "Design Decisions" on line ~448.
+  </action>
+  <verify>
+  - Grep plan-review/SKILL.md for `RESEARCH.md` — must appear in PRE-REVIEW section
+  - Grep for `Respect-but-flag` or `respect-but-flag` — must appear
+  - Grep for `Decision concern` — must appear (the escalation format)
+  - Grep for `Review Decisions` as a section name — must NOT appear
+  - Grep for `NOT in scope` — must NOT appear
+  - Grep for `Design Decisions` — must NOT appear
+  - Grep for `[review]` — must appear in Step B
+  - Grep for `Deferred Ideas` — must appear in Step B
+  </verify>
+  <done>plan-review loads CONTEXT.md with respect-but-flag, checks RESEARCH.md alignment, updates the unified Decisions section with [review] prefix, and appends to Deferred Ideas — no separate Review Decisions section</done>
+</task>
+
+<task type="auto">
+  <name>Task 4: Align build + implementer-prompt + existing CONTEXT.md files</name>
+  <files>.claude/skills/build/SKILL.md, .claude/skills/build/references/implementer-prompt.md, .planning/phases/02-upstream-sync/02-CONTEXT.md, .planning/phases/03-capability-audit/03-CONTEXT.md</files>
+  <action>
+  Align build's CONTEXT.md reading with the 3 canonical sections:
+
+  1. **Update build/SKILL.md line ~106** — Change:
+     `include the "Design Decisions" and "Review Decisions" sections`
+     To:
+     `include the "Decisions" and "Discretion Areas" sections`
+     And change `"NOT in scope"` to `"Deferred Ideas"`.
+
+  2. **Update build/SKILL.md line ~294** — Same rename:
+     `"Design Decisions" and "Review Decisions"` → `"Decisions" and "Discretion Areas"`.
+
+  3. **Update implementer-prompt.md** — The description near `{DESIGN_DECISIONS}`:
+     ```
+     ### Decisions & Scope Boundary
+
+     The following decisions are locked — do not contradict them.
+     Discretion areas define bounds within which you may decide.
+     "Deferred Ideas" items must not be implemented.
+
+     {DESIGN_DECISIONS}
+     ```
+
+  4. **Fix Phase 02 CONTEXT.md** — Rename `## Locked Decisions` to `## Decisions`.
+     Also rename `## Review Decisions` to fold those entries into `## Decisions` with `[review]` prefix on each entry.
+     Rename `## NOT in scope` to `## Deferred Ideas`.
+
+  5. **Fix Phase 03 CONTEXT.md** — Rename `## Design Decisions` to `## Decisions`.
+     Also rename `## Review Decisions` to fold those entries into `## Decisions` with `[review]` prefix on each entry.
+     Rename `## NOT in scope` to `## Deferred Ideas`.
+  </action>
+  <verify>
+  - Grep build/SKILL.md for `"Design Decisions"` — must NOT appear
+  - Grep build/SKILL.md for `"Review Decisions"` — must NOT appear
+  - Grep build/SKILL.md for `"NOT in scope"` — must NOT appear
+  - Grep build/SKILL.md for `"Decisions"` — must appear (2 occurrences: ~106 and ~294)
+  - Grep build/SKILL.md for `"Discretion Areas"` — must appear
+  - Grep build/SKILL.md for `"Deferred Ideas"` — must appear
+  - Grep implementer-prompt.md for `Discretion` — must appear
+  - Grep implementer-prompt.md for `NOT in scope` — must NOT appear
+  - Grep 02-CONTEXT.md for `Locked Decisions` — must NOT appear
+  - Grep 02-CONTEXT.md for `Review Decisions` as section header — must NOT appear
+  - Grep 02-CONTEXT.md for `## Decisions` — must appear
+  - Grep 03-CONTEXT.md for `Design Decisions` — must NOT appear
+  - Grep 03-CONTEXT.md for `## Decisions` — must appear
+  </verify>
+  <done>build reads 3 canonical sections (Decisions, Discretion Areas, Deferred Ideas) and injects them into subagent prompts. Both existing CONTEXT.md files use unified Decisions section with [review] prefixed entries.</done>
+</task>
+
+<task type="auto">
+  <name>Task 5: Add keyword-presence evals for contract alignment</name>
+  <files>evals/evals.json</files>
+  <action>
+  Add ~6 keyword-presence evals that verify the core loop contract:
+
+  1. **plan-work researcher integration:** Assert plan-work/SKILL.md contains `gsd-phase-researcher` and `XX-RESEARCH.md`
+  2. **plan-work contract block:** Assert plan-work/SKILL.md contains `CONTEXT.md Contract`
+  3. **new-project researcher integration:** Assert new-project/SKILL.md contains `gsd-project-researcher` and `gsd-research-synthesizer`
+  4. **plan-review research awareness:** Assert plan-review/SKILL.md contains `RESEARCH.md` in content before `## Step 0` (PRE-REVIEW section)
+  5. **plan-review unified decisions:** Assert plan-review/SKILL.md contains `[review]` in Step B and does NOT contain `Review Decisions` as a section name or `NOT in scope`
+  6. **build section alignment:** Assert build/SKILL.md contains `"Decisions"` and `"Discretion Areas"` and `"Deferred Ideas"` and does NOT contain `"Design Decisions"` or `"NOT in scope"`
+
+  Follow the existing eval format in evals.json. Use the next available eval IDs.
+  </action>
+  <verify>
+  - Count new evals in evals.json — should be ~6
+  - Each eval has assertions checking keyword presence in the correct skill file
+  - No eval references removed concepts ("Design Decisions", "NOT in scope", "Review Decisions")
+  </verify>
+  <done>6 keyword-presence evals verify the core loop contract: researcher integration, contract block, unified decisions, and canonical section names</done>
+</task>
+</tasks>
+
+<verification>
+# Research agent integration
+grep -c "gsd-phase-researcher" .claude/skills/plan-work/SKILL.md          # ≥ 1
+grep -c "gsd-project-researcher" .claude/skills/new-project/SKILL.md      # ≥ 1
+grep -c "gsd-research-synthesizer" .claude/skills/new-project/SKILL.md    # ≥ 1
+
+# Path correction
+grep "YYYY-MM-DD" .claude/skills/plan-work/SKILL.md                       # should NOT match
+
+# CONTEXT.md contract
+grep "CONTEXT.md Contract" .claude/skills/plan-work/SKILL.md              # should match
+
+# Canonical section names — OLD names must not appear in shipped skills
+grep -r "Design Decisions" .claude/skills/ --include="*.md"               # should be empty
+grep -r "Review Decisions" .claude/skills/ --include="*.md"               # should be empty
+grep -r "NOT in scope" .claude/skills/ --include="*.md"                   # should be empty
+grep -r "Locked Decisions" .claude/skills/ --include="*.md"               # should be empty
+
+# Canonical section names — NEW names must appear
+grep "Discretion Areas" .claude/skills/build/SKILL.md                     # should match
+grep "Deferred Ideas" .claude/skills/build/SKILL.md                       # should match
+
+# plan-review unified
+grep "\\[review\\]" .claude/skills/plan-review/SKILL.md                   # should match in Step B
+
+# Existing CONTEXT.md files aligned
+grep "## Design Decisions" .planning/phases/03-capability-audit/03-CONTEXT.md   # should NOT match
+grep "## Locked Decisions" .planning/phases/02-upstream-sync/02-CONTEXT.md      # should NOT match
+grep "## Decisions" .planning/phases/02-upstream-sync/02-CONTEXT.md             # should match
+grep "## Decisions" .planning/phases/03-capability-audit/03-CONTEXT.md          # should match
+</verification>
+
+<success_criteria>
+- plan-work spawns gsd-phase-researcher for Complex tasks with correct phase-scoped output path
+- plan-work contains CONTEXT.md Contract block referencing CLI template as canonical source
+- plan-work uses canonical section names: Decisions, Discretion Areas, Deferred Ideas
+- new-project offers domain research before requirements, spawning parallel researchers then synthesizer
+- new-project conditionally skips Stack/Architecture research when stack is already decided
+- Research outputs feed into downstream steps (brainstorm for plan-work, requirements for new-project)
+- plan-review loads CONTEXT.md with respect-but-flag protocol
+- plan-review checks RESEARCH.md alignment when research exists
+- plan-review updates the unified Decisions section with [review] prefix (no separate Review Decisions)
+- plan-review appends to Deferred Ideas (no separate NOT in scope)
+- build reads 3 canonical sections: Decisions, Discretion Areas, Deferred Ideas
+- build injects all sections into subagent prompts via implementer-prompt.md
+- Existing Phase 02 and 03 CONTEXT.md files use canonical section names with [review] prefixed entries
+- No shipped skill contains old terms: "Design Decisions", "Review Decisions", "Locked Decisions", "NOT in scope"
+- 6 keyword-presence evals verify the core loop contract
+- bin/lib/commands.cjs requires NO changes (it is the canonical source)
+</success_criteria>
+
+<output>.planning/phases/03.5-pipeline-depth/03.5-03-SUMMARY.md</output>

--- a/.planning/phases/03.5-pipeline-depth/03.5-CONTEXT.md
+++ b/.planning/phases/03.5-pipeline-depth/03.5-CONTEXT.md
@@ -1,0 +1,57 @@
+---
+phase: 03.5-pipeline-depth
+type: context
+created: "2026-03-25"
+---
+
+# Phase 3.5 Context: Pipeline Depth & Intelligence
+
+## Decisions
+
+### Complexity-driven research (not config-driven)
+plan-work's complexity assessment (Step 0.5) determines research depth. No config.json `workflow.research` check needed.
+Rationale: Complexity assessment already exists and is context-aware; config flag is a blunt instrument.
+
+### Conditional project research dimensions
+new-project always offers Features + Pitfalls research. Stack + Architecture research only when stack wasn't fully specified in Step 2.
+Rationale: Most new projects come with a predefined stack; researching known decisions wastes tokens.
+
+### Agent spawning via subagent_type
+Use `Task(subagent_type="gsd-phase-researcher")` etc. Agents auto-discovered from `agents/` directory by name field in frontmatter.
+Rationale: Verified working — matches how code-reviewer and other agents are already spawned.
+
+### 3 canonical CONTEXT.md sections aligned to CLI template
+Sections match what `bin/lib/commands.cjs` generates (it is the canonical source):
+- `## Decisions` — all locked choices (plan-work creates, plan-review updates with `[review]` prefix)
+- `## Discretion Areas` — bounds for executor (plan-work creates)
+- `## Deferred Ideas` — out of scope (plan-work creates, plan-review appends)
+No separate "Review Decisions" section. plan-review updates the unified Decisions section directly.
+Rationale: Eliminates ambiguity of two decision sections. CLI template is upstream-adjacent — aligning to it avoids modifying GSD internals.
+
+### [review] Respect-but-flag protocol for decisions
+plan-review defaults to respecting decisions but MAY surface concerns with evidence: "Decision concern: [X] was locked, but [Y] suggests reconsidering. Confirm or unlock?" User decides.
+Rationale: Decisions prevent cross-session drift, but plan-review is the last checkpoint — critical flaws must be surfaceable.
+
+### [review] CONTEXT.md Contract comment block
+plan-work Step 3 must contain a comment block documenting canonical section names and listing all consumer skills. References CLI template as the authoritative source. Prevents future drift.
+
+### [review] Consumption key_links in plans
+Plan key_links track both spawning direction (skill → agent) and consumption direction (plan-review → CONTEXT.md, build → CONTEXT.md) to catch silent breakage when producers change output paths.
+
+### [review] Phase 02 + 03 CONTEXT.md retroactive fix
+Existing CONTEXT.md files must be updated to use canonical names. Review Decisions entries folded into Decisions section with [review] prefix.
+
+## Discretion Areas
+
+### Research prompt wording
+Exact wording of research opt-in prompts and progress banners — follow upstream style but adapt to fhhs-skills tone.
+
+### Eval assertion specifics
+Exact assertion patterns for keyword-presence evals — executor decides grep patterns vs. substring checks.
+
+## Deferred Ideas
+
+- Discovery-phase as a standalone `/fh:discovery` skill — can be added later if integrated research proves insufficient
+- Behavioral evals testing full orchestration flow (mock Complex task → verify researcher spawned) — high effort, flaky
+- `{DESIGN_DECISIONS}` placeholder rename to `{CONTEXT_SECTIONS}` in implementer-prompt.md — cosmetic, would require updating build orchestrator logic
+- `/fh:quick` section name alignment — quick has its own isolated CONTEXT.md pipeline, not a regression risk for core loop

--- a/.planning/research/existing-skills-audit.md
+++ b/.planning/research/existing-skills-audit.md
@@ -1,0 +1,331 @@
+# Existing Skills Audit: Code Analysis Capabilities
+
+**Audited:** 2026-03-25
+**Scope:** All skills in `.claude/skills/` that perform code analysis, exploration, or understanding
+**Total skills examined:** 44
+**Skills with code analysis capabilities:** 18
+
+---
+
+## Executive Summary
+
+The fhhs-skills plugin has **no static analysis tooling**. Every skill that analyzes code relies on one or more of these mechanisms:
+
+1. **LLM pattern matching on raw text** -- Claude reads source code and applies judgment (the dominant approach)
+2. **grep/Glob text search** -- finding patterns by string matching (file names, content patterns)
+3. **git diff** -- scoping analysis to changed code
+4. **LSP calls** -- `findReferences`, `goToDefinition`, `hover`, `documentSymbol`, `workspaceSymbol`, `rename` (used by fix, refactor, extract, plan-work, build subagents)
+5. **Runtime commands** -- `npm test`, `npm run build`, `npm run lint`, `tsc` (evidence collection, not analysis)
+6. **Sentry local store** -- querying runtime errors from SQLite
+
+**LSP is the closest thing to semantic analysis**, but it is used opportunistically ("use LSP first" appears in fix, refactor, extract, plan-work, and the implementer-prompt template). It provides type info and reference resolution but NOT:
+- Call graph analysis beyond direct callers/callees
+- Dead code detection
+- Complexity metrics
+- Dependency cycle detection
+- Data flow analysis
+- Impact analysis across transitive dependencies
+
+---
+
+## Skills with Code Analysis Capabilities
+
+### Tier 1: Primary Code Analysis Skills
+
+These skills exist specifically to analyze code quality, structure, or correctness.
+
+| Skill | Purpose | Analysis Method | LSP? | Grep? | Diff? | Runtime? |
+|-------|---------|----------------|------|-------|-------|----------|
+| **review** | Code review (quality, security, gaps) | LLM reads diff + subagents | No | Yes (TS `any`/`as` patterns) | Yes (branch diff) | Yes (test/build/lint) |
+| **secure** | OWASP security scan | 4 parallel LLM agents read files | No | No | Yes (changed files) | No |
+| **audit** | UI quality audit (a11y, perf, theming) | LLM reads component files | No | No | No | No |
+| **simplify** | Code reuse/quality/efficiency review | 3 parallel LLM agents read diff | No | No | Yes | No |
+| **plan-review** | Plan stress-testing | LLM reads plan + codebase | No | Yes (FIXME/TODO) | Yes (branch diff) | No |
+
+### Tier 2: Skills That Analyze Code as Part of a Larger Workflow
+
+These skills include code analysis as a step within a broader operation.
+
+| Skill | Purpose | Analysis Method | LSP? | Grep? | Diff? | Runtime? |
+|-------|---------|----------------|------|-------|-------|----------|
+| **fix** | Bug triage and fix | LLM + LSP for triage, TDD for fix | **Yes** (findReferences, hover, goToDefinition, diagnostics) | Yes (error search) | No | Yes (test suite) |
+| **refactor** | Code restructuring | LLM + LSP for scope analysis | **Yes** (findReferences, incomingCalls, outgoingCalls, documentSymbol, rename) | No | No | Yes (test suite) |
+| **build** | Plan execution | Subagents use LSP per implementer-prompt | **Yes** (via subagent template) | No | Yes (per-wave) | Yes (test/build) |
+| **build (spec-gate)** | Post-wave verification | Code-reviewer agent reads wave diff | No | No | Yes (wave diff) | No |
+| **map-codebase** | Codebase documentation | 4 mapper agents explore files | No | Yes (file discovery) | No | No |
+| **plan-work** | Feature planning | LLM scouts codebase for reuse | **Yes** (workspaceSymbol, findReferences) | No | No | No |
+| **extract** | Design system extraction | LLM finds patterns + LSP for migration | **Yes** (workspaceSymbol, findReferences, rename) | Yes (pattern discovery) | No | No |
+
+### Tier 3: Skills With Incidental Code Reading
+
+These skills read code but don't perform structured analysis.
+
+| Skill | Purpose | How it reads code |
+|-------|---------|-------------------|
+| **normalize** | Design system alignment | Reads components to find deviations from tokens |
+| **optimize** | Performance improvement | Reads code for perf anti-patterns |
+| **harden** | Edge case resilience | Reads code for error handling gaps |
+| **nextjs-perf** | Next.js patterns reference | Reference doc, not active analyzer |
+| **observability** | Runtime error inspection | Queries Sentry SQLite store |
+| **progress** | State integrity check | Compares STATE.md claims vs disk files |
+
+---
+
+## Detailed Analysis by Skill Category
+
+### Code Review: `review`
+
+**How it analyzes code:**
+- Step 1: `git diff --stat` to scope the diff
+- Step 1.5: Sentry local store query for runtime errors in changed files
+- Step 2: Dispatches 3 parallel subagents that **read the raw diff text**:
+  - Agent 1 (code-reviewer): Reads diff, applies review-prompt.md criteria
+  - Agent 2 (security): 4 sub-scanners read changed files against OWASP checklist
+  - Agent 3 (gap analysis): Reads diff for untested paths, unhandled errors
+- Step 3: Goal verification via grep/file-exists checks against must_haves
+- Step 4: Runs `npm test`, `npm run build`, `npm run lint`
+- Step 5: `grep` for `any` and `as` keywords in diff added lines
+
+**What it catches:** Naming issues, structural problems, error handling gaps, DRY violations, security patterns, TypeScript strictness violations, missing tests.
+
+**Gaps where static analysis would help:**
+- **Circular dependency detection** -- review checks "dependency direction" but relies on LLM reading imports. A tool like `madge` or `dpdm` would catch cycles definitively.
+- **Dead code detection** -- review checks for "unwired code" but the LLM can only see what's in the diff. Static analysis (e.g., `ts-prune`, `knip`) catches unused exports project-wide.
+- **Complexity metrics** -- review evaluates "complexity" subjectively. Cyclomatic complexity scores would give objective thresholds.
+- **Type coverage** -- grep for `any` catches explicit `any` but misses implicit `any` from missing annotations. `typescript-coverage-report` or `type-coverage` would catch both.
+- **Bundle size impact** -- no analysis of import cost. `import-cost` or bundle analyzer integration would surface this.
+
+**Priority for static analysis improvement: HIGH** -- review is the quality gate. False negatives here propagate.
+
+---
+
+### Security Scan: `secure`
+
+**How it analyzes code:**
+- Scopes to changed files via `git diff --name-only`
+- 4 parallel LLM agents each read the full file contents
+- Each agent has a category assignment (injection, auth, data exposure, access control)
+- Agents pattern-match against their OWASP checklist categories
+
+**What it catches:** SQL injection, XSS, hardcoded secrets, missing auth, IDOR, CSRF, verbose errors, permissive CORS.
+
+**Gaps where static analysis would help:**
+- **Secret detection** -- LLM-based secret scanning has false negatives. Tools like `gitleaks`, `trufflehog`, or `detect-secrets` use entropy analysis and known patterns more reliably.
+- **Dependency vulnerability scanning** -- `npm audit`, `snyk`, or `osv-scanner` catch known CVEs in dependencies. The skill doesn't check this at all.
+- **SQL injection detection** -- taint analysis tools can trace user input to query construction paths more reliably than LLM pattern matching.
+- **Regex-based pattern scanning** -- `semgrep` with OWASP rules would catch patterns the LLM misses when reading large diffs.
+
+**Priority for static analysis improvement: HIGH** -- security findings must not have false negatives.
+
+---
+
+### Bug Fixing: `fix`
+
+**How it analyzes code:**
+- Step 0: Sentry local store for runtime errors
+- Step 1 (Triage): **Uses LSP extensively** -- `findReferences` on error site, `hover` for type info, `goToDefinition` to trace imports, `diagnostics` for type/lint errors
+- Dispatches debugger agents for PARALLEL/COMPLEX bugs
+- Step 2: TDD fix cycle (run tests)
+
+**What it catches:** Bugs via symptom tracing, type mismatches, import chains, caller relationships.
+
+**Gaps where static analysis would help:**
+- **Call graph visualization** -- LSP gives immediate callers/callees but not the full transitive graph. For COMPLEX bugs spanning multiple subsystems, a full call graph would help triage faster.
+- **Data flow tracing** -- "where does this value come from?" requires manual LSP-hopping through multiple goToDefinition calls. Static taint/data-flow analysis would surface the full chain.
+- **Change impact analysis** -- "what breaks if I change this function signature?" requires findReferences + reading each site. Static impact analysis tools handle this systematically.
+
+**Priority for static analysis improvement: MEDIUM** -- LSP already provides good coverage. Improvements would help COMPLEX-tier bugs most.
+
+---
+
+### Refactoring: `refactor`
+
+**How it analyzes code:**
+- Step 0: Delegates to `simplify` to find candidates (LLM reads code)
+- Step 1 (Scope): **Uses LSP heavily** -- `findReferences`, `incomingCalls`/`outgoingCalls` for call graph, `documentSymbol` for file structure, `rename` for atomic multi-file renames
+- Step 2: Characterization tests via test suite
+- Step 4: Uses `findReferences` before each modification, LSP `rename` for symbol renames
+
+**What it catches:** Blast radius of changes, all usage sites, call relationships.
+
+**Gaps where static analysis would help:**
+- **Dependency graph visualization** -- LSP gives call relationships, but a full module dependency graph (like `dependency-cruiser` output) would help plan large refactors across subsystems.
+- **Code duplication detection** -- `simplify` uses LLM agents to find duplicates, but tools like `jscpd` can detect copy-paste patterns with exact line ranges more systematically.
+- **Unused exports/dead code** -- after refactoring, some exports may become unused. `knip` or `ts-prune` would catch these.
+- **Complexity before/after** -- no metrics to prove the refactoring actually reduced complexity.
+
+**Priority for static analysis improvement: MEDIUM** -- LSP is well-leveraged here. Static analysis would add metrics and systematic detection.
+
+---
+
+### Codebase Mapping: `map-codebase`
+
+**How it analyzes code:**
+- 4 parallel mapper agents explore the codebase by reading files
+- Tech mapper: reads config files, package.json, dependency files
+- Architecture mapper: reads directory structure, entry points, data flow
+- Quality mapper: reads conventions, test patterns
+- Concerns mapper: reads for tech debt, fragile areas
+
+**What it catches:** Project structure, tech stack, conventions, known concerns.
+
+**Gaps where static analysis would help:**
+- **Dependency graph** -- mappers describe architecture textually. An actual dependency graph (module-level) would be authoritative rather than inferred.
+- **Code metrics** -- lines of code, complexity per module, test coverage percentages would ground the mapping in data.
+- **Hotspot analysis** -- `git log` + churn metrics identify which files change most frequently (fragility indicators).
+- **Architecture boundary enforcement** -- tools like `dependency-cruiser` with rules can verify architectural layers aren't violated.
+
+**Priority for static analysis improvement: HIGH** -- codebase mapping produces reference documents used by all other skills. Grounding them in data rather than LLM inference would improve everything downstream.
+
+---
+
+### Plan Work: `plan-work`
+
+**How it analyzes code:**
+- Step 3 (Discuss Implementation): Uses LSP `workspaceSymbol` to find reusable abstractions, `findReferences` to see usage patterns
+- Checks for `playwright.config.*` existence
+
+**Gaps where static analysis would help:**
+- **Reusable asset discovery** -- `workspaceSymbol` searches by name, but doesn't surface similar implementations or duplicate patterns. AST-level similarity analysis would find reuse candidates more reliably.
+- **Impact estimation** -- "how many files will this touch?" requires LSP reference-hopping. A dependency graph would answer this immediately.
+
+**Priority for static analysis improvement: MEDIUM** -- LSP provides basic scouting. Better tooling would improve estimation accuracy.
+
+---
+
+### Build (Spec Gate): `build/spec-gate-prompt`
+
+**How it analyzes code:**
+- Reads `git diff` for the wave
+- LLM compares implementation against task specifications
+- Checks for stubs, placeholders, unwired code, TypeScript strictness
+- Lightweight security scan (string concatenation in SQL, hardcoded secrets, auth bypass, XSS)
+
+**Gaps where static analysis would help:**
+- **Stub/placeholder detection** -- currently LLM-based. AST analysis could definitively identify functions that return hardcoded values, empty catch blocks, or TODO comments.
+- **Unwired code detection** -- "files created but never imported" could be caught by `knip` or dead-code analysis rather than LLM inference.
+- **TypeScript strictness** -- `tsc --noImplicitAny` output would be more reliable than LLM grep.
+
+**Priority for static analysis improvement: HIGH** -- the spec gate is the build pipeline's quality checkpoint. Automated checks would be faster and more reliable than LLM inference.
+
+---
+
+### Simplify: `simplify` (internal skill)
+
+**How it analyzes code:**
+- 3 parallel LLM review agents read the git diff
+- Agent 1: Code reuse (finds duplicates of existing utilities)
+- Agent 2: Code quality (parameter sprawl, copy-paste, nesting)
+- Agent 3: Efficiency (redundant computations, N+1, concurrency)
+
+**Gaps where static analysis would help:**
+- **Duplicate detection** -- `jscpd` would find exact/near-exact copy-paste patterns more reliably.
+- **Complexity metrics** -- objective numbers instead of subjective "this feels complex."
+- **Unused import detection** -- `eslint` with `no-unused-imports` would catch this automatically.
+
+**Priority for static analysis improvement: MEDIUM** -- simplify runs as a pipeline step in build/refactor/fix. Faster automated checks could replace some LLM agent work.
+
+---
+
+### Extract (Design System): `extract`
+
+**How it analyzes code:**
+- Uses LSP `workspaceSymbol` to find existing components/utilities
+- Falls back to grep for pattern discovery
+- Uses `findReferences` during migration to find all usage sites
+- Uses LSP `rename` for atomic updates
+
+**Gaps where static analysis would help:**
+- **Component similarity detection** -- finding "similar UI patterns used multiple times" currently relies on LLM reading code. AST-based component structure comparison would be more systematic.
+- **Design token extraction** -- finding "hard-coded values that should be tokens" requires reading CSS/JSX. A tool that parses all color/spacing/font values and clusters them would be more complete.
+
+**Priority for static analysis improvement: LOW** -- extract is a specialized UI skill used infrequently.
+
+---
+
+## Summary: Where Static Analysis Would Help Most
+
+### Priority Rankings
+
+| Rank | Skill | Current Gap | Static Analysis Opportunity | Impact |
+|------|-------|-------------|----------------------------|--------|
+| 1 | **review** | Circular deps, dead code, complexity, type coverage, bundle size -- all LLM-guessed | `dependency-cruiser`, `knip`, complexity metrics, `type-coverage` | HIGH -- quality gate for all code |
+| 2 | **build (spec-gate)** | Stubs, unwired code, TS strictness -- LLM-inferred from diff | Dead code analysis, `tsc --noImplicitAny`, stub detection | HIGH -- build pipeline checkpoint |
+| 3 | **map-codebase** | Architecture described textually, no metrics | Dependency graph, code metrics, churn analysis | HIGH -- reference docs for all skills |
+| 4 | **secure** | Secret detection, dependency vulns, injection tracing -- LLM pattern match | `gitleaks`, `npm audit`, `semgrep` | HIGH -- security false negatives are dangerous |
+| 5 | **fix** | Full call graph, data flow tracing for complex bugs | Call graph analysis, taint analysis | MEDIUM -- LSP covers simple/moderate cases |
+| 6 | **refactor** | Dependency graph, duplication detection, complexity metrics | `dependency-cruiser`, `jscpd`, complexity tools | MEDIUM -- LSP well-leveraged already |
+| 7 | **simplify** | Duplicate detection, complexity metrics | `jscpd`, complexity metrics | MEDIUM -- pipeline step, speed matters |
+| 8 | **plan-work** | Reusable asset discovery, impact estimation | Similarity analysis, dependency graph | MEDIUM -- planning accuracy |
+| 9 | **extract** | Component similarity, token extraction | AST component comparison | LOW -- specialized, infrequent |
+
+---
+
+## Current Analysis Approach Patterns
+
+### What Works Well
+
+1. **LSP integration in fix/refactor/extract/plan-work** -- provides real semantic understanding (type info, references, definitions). These skills are meaningfully better than grep-only approaches.
+
+2. **Parallel subagent architecture** -- review, secure, simplify, and map-codebase all dispatch multiple agents in parallel, each with fresh context and focused scope. This scales analysis without context exhaustion.
+
+3. **Git diff scoping** -- most analysis skills scope to changed code via `git diff`, avoiding the "analyze everything" trap.
+
+4. **Runtime evidence collection** -- review runs `npm test/build/lint` for ground-truth evidence. Sentry local store integration in fix/review/build provides runtime error context.
+
+### What Is Missing
+
+1. **No persistent code model** -- every skill re-reads and re-analyzes from scratch. There is no shared understanding of the codebase's dependency graph, complexity profile, or coverage map that persists across skills or sessions.
+
+2. **No quantitative metrics** -- all quality assessments are qualitative (LLM judgment). No cyclomatic complexity, no test coverage percentages, no bundle size numbers, no dependency depth counts.
+
+3. **No architectural rule enforcement** -- the architecture is described in text (via map-codebase) but never enforced. There are no dependency rules preventing layer violations.
+
+4. **No differential impact analysis** -- "what will this change break?" requires manual LSP-hopping. A precomputed dependency graph would answer this instantly.
+
+5. **No dead code detection** -- multiple skills look for "unwired code" or "unused exports" but always via LLM inference rather than definitive tooling.
+
+6. **No automated security scanning beyond LLM** -- the `secure` skill is LLM-only. No integration with `npm audit`, `gitleaks`, `semgrep`, or similar tools that have deterministic rulesets.
+
+---
+
+## Concrete Opportunities for Static Analysis Integration
+
+### Quick Wins (could be added to existing skills with minimal restructuring)
+
+| Tool/Check | Where to Add | What It Provides | Effort |
+|------------|-------------|------------------|--------|
+| `tsc --noEmit --strict` output | review Step 5, spec-gate | Definitive TS strictness violations | Low |
+| `npm audit --json` | secure Step 2 | Known dependency vulnerabilities | Low |
+| `npx knip --reporter json` | review, spec-gate | Unused exports, files, dependencies | Low |
+| `git log --format="%H" --diff-filter=M -- {file} \| wc -l` | map-codebase (concerns agent) | File churn/hotspot data | Low |
+| `npx jscpd --reporters json` | simplify Agent 1 | Exact duplicate detection | Low |
+
+### Medium Effort (new tooling integration)
+
+| Tool/Check | Where to Add | What It Provides | Effort |
+|------------|-------------|------------------|--------|
+| `dependency-cruiser` with rules | review (architecture), map-codebase | Module dependency graph, cycle detection, layer violation detection | Medium |
+| `semgrep` with OWASP rules | secure Step 2 (alongside LLM agents) | Deterministic pattern-based security scanning | Medium |
+| `gitleaks` | secure Step 2 or pre-commit | Secret detection with entropy analysis | Medium |
+| Complexity metrics (e.g., `es-complexity`) | review, simplify | Cyclomatic/cognitive complexity per function | Medium |
+
+### Larger Investments (new infrastructure)
+
+| Investment | Benefits | Skills Affected |
+|------------|---------|-----------------|
+| Persistent dependency graph (build once, query many times) | Instant impact analysis, architectural enforcement, dead code detection | review, fix, refactor, plan-work, map-codebase, build |
+| Test coverage integration (`c8`/`istanbul` JSON output) | Coverage-aware review, TDD verification, gap detection | review, fix, build (spec-gate) |
+| AST-based code analysis service | Component similarity, pattern detection, structural metrics | extract, simplify, map-codebase, normalize |
+
+---
+
+## Key Insight
+
+The plugin's strength is its **orchestration architecture** -- parallel subagents, lean orchestrators, fresh context per domain. Static analysis tools would slot naturally into this architecture as **pre-computed inputs** to existing LLM agents rather than replacing them. For example:
+
+- The `review` skill's code-reviewer agent would become more effective if it received a dependency graph and complexity report alongside the diff
+- The `secure` skill's 4 scanner agents would be more reliable if they received `npm audit` and `gitleaks` output as pre-filtered findings to verify
+- The `spec-gate` would be faster and more reliable if `knip` output (unused exports) and `tsc --strict` output replaced the LLM's grep-based TS checks
+
+The LLM agents would still provide the judgment layer (is this finding actually a problem? what's the right fix?). Static analysis provides the **ground truth layer** (these are definitively the unused exports, these are the exact cyclomatic complexity scores, these are the known CVEs).

--- a/.planning/research/fallow-integration-points.md
+++ b/.planning/research/fallow-integration-points.md
@@ -1,0 +1,737 @@
+# Fallow CLI Integration Points Analysis
+
+**Analyzed:** 2026-03-25
+**Scope:** Every skill in fhhs-skills that performs code analysis
+**Fallow commands referenced:**
+- `fallow check --format json` -- dead code: unused exports, files, deps, types
+- `fallow dupes --format json` -- code duplication detection
+- `fallow dupes --mode semantic --format json` -- semantic clone detection (renamed variables)
+- `fallow health --format json` -- complexity metrics, hotspots
+- `fallow check --changed-since HEAD~1 --format json` -- incremental dead code on recent changes
+
+---
+
+## Integration Impact Summary
+
+| Skill | Integration Points | Highest Impact | Overall Value |
+|-------|-------------------|----------------|---------------|
+| **review** | 4 | HIGH | HIGH |
+| **simplify** | 3 | HIGH | HIGH |
+| **refactor** | 3 | HIGH | HIGH |
+| **build (spec-gate)** | 2 | HIGH | HIGH |
+| **map-codebase** | 3 | HIGH | HIGH |
+| **plan-work** | 2 | MEDIUM | MEDIUM |
+| **plan-review** | 2 | MEDIUM | MEDIUM |
+| **fix** | 2 | MEDIUM | MEDIUM |
+| **extract** | 2 | MEDIUM | MEDIUM |
+| **secure** | 1 | MEDIUM | LOW |
+| **audit** | 2 | MEDIUM | MEDIUM |
+| **optimize** | 1 | MEDIUM | LOW |
+| **health** | 0 | -- | NONE |
+| **harden** | 0 | -- | NONE |
+| **normalize** | 1 | LOW | LOW |
+
+---
+
+## Skill-by-Skill Analysis
+
+---
+
+### 1. review (HIGH impact)
+
+**File:** `.claude/skills/review/SKILL.md`
+
+#### Integration Point 1: Code Quality + Architecture Agent (Step 2, Agent 1)
+
+**Exact section (SKILL.md lines 75-80):**
+```
+**Agent 1 -- Code Quality + Architecture** (`subagent_type: "code-reviewer"`)
+- Covers: naming, structure, error handling, DRY, complexity, test quality,
+  cross-file consistency, dependency direction, separation of concerns,
+  abstraction quality, API design, cross-cutting concerns
+```
+
+**What the skill currently does:** The subagent reads the full diff and uses LLM inference to assess DRY violations, complexity, and dependency direction. No tooling -- pure pattern matching by the model.
+
+**Fallow command:** `fallow check --changed-since $BASE_BRANCH --format json` + `fallow dupes --format json` + `fallow health --format json`
+
+**How output feeds in:** Include Fallow JSON output in the Agent 1 prompt alongside the diff. The agent gets:
+- **Dead code from `check`:** Unused exports introduced in this branch, newly orphaned files. The agent can flag "you added `export function processOrder()` in `src/utils/orders.ts` but nothing imports it."
+- **Duplication from `dupes`:** Instead of LLM guessing at DRY violations, Fallow provides exact file:line ranges of duplicated blocks. The agent reports precise locations rather than vague "this looks similar to..."
+- **Complexity from `health`:** Cyclomatic complexity scores per function. The agent flags functions exceeding thresholds (e.g., >15) with exact metrics, not subjective "this is complex."
+
+**Impact:** HIGH -- transforms three subjective LLM assessments (DRY, complexity, dependency direction) into evidence-backed findings with exact locations.
+
+#### Integration Point 2: Architecture Criteria in review-prompt.md
+
+**Exact section (review-prompt.md lines 49-52):**
+```
+### Dependency Direction
+- Do dependencies flow in one direction (e.g., UI -> service -> data)?
+- Are there circular imports? Check for A imports B imports A patterns.
+- Do lower-level modules depend on higher-level abstractions?
+```
+
+**What the skill currently does:** LLM reads the diff and tries to infer circular dependencies from import statements. This is unreliable -- the LLM only sees the diff, not the full import graph.
+
+**Fallow command:** `fallow check --format json` (includes circular dependency detection)
+
+**How output feeds in:** Fallow's circular dependency report is authoritative -- it traces the full import graph, not just the diff. Inject the circularity findings into Agent 1's prompt. The review can now definitively say "Circular dependency: `src/services/auth.ts` -> `src/middleware/session.ts` -> `src/services/auth.ts`" instead of guessing.
+
+**Impact:** HIGH -- circular dependency detection is fundamentally impossible from diff-only LLM analysis. Fallow makes it accurate.
+
+#### Integration Point 3: Gap Analysis Agent (Step 2, Agent 3)
+
+**Exact section (review-prompt.md lines 57-65):**
+```
+### Unwired code
+- Files created but never imported
+- Functions defined but never called
+- State defined but never rendered
+- API routes defined but never fetched from
+```
+
+**What the skill currently does:** LLM infers "unwired code" by reading the diff. Unreliable because the LLM cannot see the full codebase to know whether something IS imported elsewhere.
+
+**Fallow command:** `fallow check --format json` (unused exports, unused files)
+
+**How output feeds in:** Fallow definitively identifies files created but never imported and exports defined but never referenced. This replaces LLM guesswork with certainty. Agent 3 receives the Fallow unused-exports list filtered to files in the diff, then only needs to assess whether the "unused" status is intentional (public API) or a bug.
+
+**Impact:** HIGH -- "unwired code" detection goes from unreliable LLM inference to ground truth.
+
+#### Integration Point 4: Production Safety Checklist (Pass 2)
+
+**Exact section (production-safety-checklist.md lines 42-44):**
+```
+### Dead Code & Consistency
+- Variables assigned but never read
+```
+
+**What the skill currently does:** LLM scans diff for assigned-but-unused variables. This is limited to what the model can see in the diff context window.
+
+**Fallow command:** `fallow check --changed-since $BASE_BRANCH --format json`
+
+**How output feeds in:** Fallow catches dead code at module level (unused exports, files) while the checklist catch is more granular (variables). These are complementary -- Fallow covers the module-level blind spot that LLMs miss.
+
+**Impact:** MEDIUM -- supplements rather than replaces.
+
+---
+
+### 2. simplify (HIGH impact)
+
+**File:** `.claude/skills/simplify/SKILL.md`
+
+**Note:** The SKILL.md is a thin wrapper -- it says "runs 3 parallel review agents on the git diff -- code reuse, code quality, and efficiency." The actual agent prompts are inline. But we know the three domains:
+
+#### Integration Point 1: Code Reuse Agent
+
+**Exact section (SKILL.md line 7-8 + build/SKILL.md lines 402-406):**
+```
+- **Code reuse**: newly written code that duplicates existing utilities or helpers
+```
+
+**What the skill currently does:** LLM reads the diff and tries to identify if new code duplicates existing code. The LLM would need to have seen the entire codebase to know this -- it cannot.
+
+**Fallow command:** `fallow dupes --format json` + `fallow dupes --mode semantic --format json`
+
+**How output feeds in:** Fallow's duplication report identifies exact blocks of duplicated code across the entire codebase, not just the diff. The reuse agent receives concrete evidence: "Lines 15-45 in `src/utils/format.ts` are 87% similar to lines 22-52 in `src/helpers/string.ts`." The agent then decides whether to extract a shared utility.
+
+Semantic mode catches clones where variables were renamed but logic is identical -- something no LLM can reliably detect across a full codebase.
+
+**Impact:** HIGH -- this is the core mission of the reuse agent, and Fallow provides the data it currently lacks.
+
+#### Integration Point 2: Code Quality Agent
+
+**Exact section (build/SKILL.md line 407):**
+```
+- **Code hygiene**: parameter sprawl, copy-paste with variation, stringly-typed code
+```
+
+**What the skill currently does:** LLM infers copy-paste patterns from the diff alone.
+
+**Fallow command:** `fallow dupes --mode semantic --format json`
+
+**How output feeds in:** "Copy-paste with variation" is exactly what semantic duplication detection catches. Fallow provides the evidence; the agent recommends the consolidation.
+
+**Impact:** MEDIUM -- supplements the quality agent's already reasonable LLM analysis.
+
+#### Integration Point 3: Efficiency Agent
+
+**Exact section (build/SKILL.md line 407):**
+```
+- **Efficiency**: redundant computations, missed concurrency, N+1 patterns, hot-path bloat
+```
+
+**What the skill currently does:** LLM reads the diff looking for N+1 and redundancy patterns.
+
+**Fallow command:** `fallow health --format json`
+
+**How output feeds in:** Complexity hotspots from `fallow health` identify the highest-complexity functions. The efficiency agent can focus its attention on the most complex functions rather than scanning everything equally.
+
+**Impact:** LOW -- complexity metrics point the agent in the right direction but don't directly identify N+1 patterns.
+
+---
+
+### 3. refactor (HIGH impact)
+
+**File:** `.claude/skills/refactor/SKILL.md`
+
+#### Integration Point 1: Analysis Mode (Step 0)
+
+**Exact section (SKILL.md lines 25-33):**
+```
+## Step 0: Analysis Mode (no target specified)
+
+If the user asks to "refactor this codebase", "clean up", or "find things to refactor"
+without specifying a target, invoke `skills/simplify/` first to identify refactoring
+candidates. It runs 3 parallel review agents that scan for:
+
+- **God components/classes** -- files doing too many things
+- **Kitchen-sink utilities** -- catch-all modules that should be split
+- **Duplicate patterns** -- copy-pasted logic with minor variations
+- **Redundant abstractions** -- wrappers that add no value
+```
+
+**What the skill currently does:** Delegates to simplify agents which use LLM inference on the diff to find candidates. No structural analysis of the codebase.
+
+**Fallow commands:**
+- `fallow health --format json` -- identifies god files via complexity metrics (high cyclomatic complexity + many exports = god module)
+- `fallow dupes --mode semantic --format json` -- identifies duplicate patterns precisely
+- `fallow check --format json` -- identifies redundant abstractions (exports that wrap other exports with no added logic can be detected as unused if the wrapper is bypassed)
+
+**How output feeds in:** Before spawning simplify agents, run all three Fallow commands and inject results into the analysis. The agents now have:
+- God files: sorted by complexity score -- top 10 most complex files
+- Kitchen-sink utilities: files with 20+ exports (from `check` output's export enumeration)
+- Duplicate patterns: exact locations and similarity percentages
+- Dead code: exports nobody uses -- candidates for removal rather than refactoring
+
+**Impact:** HIGH -- transforms "find things to refactor" from a vague LLM scan into a data-driven prioritized list.
+
+#### Integration Point 2: Scope Mapping (Step 1)
+
+**Exact section (SKILL.md lines 41-48):**
+```
+## Step 1: Scope
+
+1. Find all files involved in the refactoring target. Use LSP first:
+   - findReferences on the target symbol
+   - incomingCalls/outgoingCalls to map the call graph
+2. Map dependencies: what imports/calls the target
+3. Estimate: how many files change, which subsystems affected
+```
+
+**What the skill currently does:** LSP-based reference finding. Good for single-symbol refactors, but doesn't reveal the broader dependency structure.
+
+**Fallow command:** `fallow check --format json` (dependency graph and circular dependency data)
+
+**How output feeds in:** Fallow's dependency graph supplements LSP. When refactoring a module, Fallow shows:
+- Whether the module is involved in any circular dependency chains (refactoring must break cycles, not preserve them)
+- Unused exports in the target that can be removed as part of the refactor
+- Whether the refactoring target is itself dead code (why refactor something nobody uses?)
+
+**Impact:** MEDIUM -- valuable context for scoping, but LSP already covers the primary use case.
+
+#### Integration Point 3: Post-Refactor Simplify (Step 5)
+
+**Exact section (SKILL.md lines 97-104):**
+```
+## Step 5: Simplify
+
+After execution, invoke `skills/simplify/`. Refactoring often introduces new abstractions
+or moves code around -- simplify catches:
+
+- Extracted utilities that duplicate existing ones elsewhere
+- Restructured code with missed efficiency opportunities
+- Copy-paste remnants from the restructuring
+```
+
+**What the skill currently does:** Same as simplify analysis -- LLM inference on the diff.
+
+**Fallow command:** `fallow check --changed-since $WAVE_START_SHA --format json` + `fallow dupes --format json`
+
+**How output feeds in:** After refactoring, run Fallow to verify:
+- No new dead code was introduced (common when moving code -- old location still exported but nobody imports it)
+- No new duplicates were created (common when extracting shared utilities that overlap with existing ones)
+- Circular dependencies were broken, not created
+
+**Impact:** HIGH -- refactoring is the #1 source of accidentally introduced dead code. Fallow catches what LLMs miss.
+
+---
+
+### 4. build / spec-gate (HIGH impact)
+
+**File:** `.claude/skills/build/SKILL.md` + `references/spec-gate-prompt.md`
+
+#### Integration Point 1: Spec Gate Unwired Code Check
+
+**Exact section (spec-gate-prompt.md lines 62-68):**
+```
+**Unwired code:**
+- Files created but never imported
+- Functions defined but never called
+- State defined but never rendered
+- API routes defined but never fetched from
+```
+
+**What the skill currently does:** The spec gate reviewer reads the wave diff and tries to identify unwired code by LLM inference. It cannot see the full codebase import graph.
+
+**Fallow command:** `fallow check --changed-since $WAVE_START_SHA --format json`
+
+**How output feeds in:** Run Fallow after each wave completes, before the spec gate agent. Include the unused-exports/files list in the spec gate prompt. The reviewer now has authoritative data: "These 3 exports were added in this wave but are not imported anywhere in the codebase." The reviewer can then check whether they are supposed to be consumed by a future wave (expected) or are genuinely unwired (BLOCKING).
+
+**Impact:** HIGH -- the spec gate's unwired code detection is currently its weakest check (LLM inference on partial diff). Fallow makes it definitive.
+
+#### Integration Point 2: Post-Build Simplify (Step 8)
+
+**Exact section (build/SKILL.md lines 402-408):**
+```
+## Step 8: Simplify
+
+After all tasks complete, invoke `skills/simplify/` on the implementation diff. This catches:
+- Code reuse: newly written code that duplicates existing utilities
+- Efficiency: redundant computations, missed concurrency, N+1 patterns
+- Code hygiene: parameter sprawl, copy-paste with variation
+```
+
+Same integration as simplify skill above. Run `fallow dupes` + `fallow check --changed-since` before simplify agents.
+
+**Impact:** HIGH (same rationale as simplify).
+
+---
+
+### 5. map-codebase (HIGH impact)
+
+**File:** `.claude/skills/map-codebase/SKILL.md`
+
+#### Integration Point 1: Architecture Mapper (Agent 2)
+
+**Exact section (SKILL.md lines 116-131):**
+```
+**Agent 2: Architecture Focus**
+prompt="Focus: arch
+Analyze this codebase architecture and directory structure.
+Write these documents to .planning/codebase/:
+- ARCHITECTURE.md - Pattern, layers, data flow, abstractions, entry points
+- STRUCTURE.md - Directory layout, key locations, naming conventions"
+```
+
+**What the skill currently does:** The mapper agent explores the codebase via file reads and grep to infer architecture. Entirely LLM-driven exploration.
+
+**Fallow command:** `fallow check --format json` (dependency graph, circular dependencies, module boundaries)
+
+**How output feeds in:** Include Fallow output in the architecture mapper's prompt. The agent now has:
+- The full dependency graph -- which modules import which, enabling accurate layer diagrams
+- Circular dependency chains -- architectural smells to document in ARCHITECTURE.md
+- Unused files/exports -- dead code percentage, which informs the "health" narrative
+
+The architecture mapper's ARCHITECTURE.md becomes data-driven: "Layer violations: `src/components/` imports from `src/api/` (3 files), creating a circular dependency between UI and data layers."
+
+**Impact:** HIGH -- architecture mapping without dependency data is guesswork. Fallow provides the structural facts.
+
+#### Integration Point 2: Concerns Mapper (Agent 4)
+
+**Exact section (SKILL.md lines 155-170):**
+```
+**Agent 4: Concerns Focus**
+prompt="Focus: concerns
+Analyze this codebase for technical debt, known issues, and areas of concern.
+Write this document to .planning/codebase/:
+- CONCERNS.md - Tech debt, bugs, security, performance, fragile areas"
+```
+
+**What the skill currently does:** LLM explores files looking for TODO/FIXME, code smells, etc.
+
+**Fallow commands:**
+- `fallow check --format json` -- dead code count = tech debt metric
+- `fallow dupes --format json` -- duplication hotspots = maintenance burden
+- `fallow health --format json` -- complexity hotspots = fragility indicators
+
+**How output feeds in:** The concerns mapper receives quantified tech debt:
+- "42 unused exports across 15 files (dead code debt)"
+- "8 duplicated code blocks averaging 35 lines each (duplication debt)"
+- "5 functions with cyclomatic complexity >20 (fragility hotspots)"
+- "3 circular dependency chains (architectural debt)"
+
+CONCERNS.md becomes evidence-based rather than LLM-impression-based.
+
+**Impact:** HIGH -- transforms subjective "this feels like tech debt" into quantified metrics.
+
+#### Integration Point 3: Tech Mapper (Agent 1)
+
+**Exact section (SKILL.md lines 94-112):**
+```
+**Agent 1: Tech Focus**
+prompt="Focus: tech
+Analyze this codebase for technology stack and external integrations.
+Write these documents to .planning/codebase/:
+- STACK.md - Languages, runtime, frameworks, dependencies, configuration"
+```
+
+**What the skill currently does:** Reads package.json, config files, etc. to enumerate the stack.
+
+**Fallow command:** `fallow check --format json` (unused dependencies detection)
+
+**How output feeds in:** Fallow identifies unused dependencies -- packages in `package.json` that are never imported. The tech mapper can flag these in STACK.md: "Dependencies: 45 total, 7 unused (candidates for removal)."
+
+**Impact:** MEDIUM -- useful data point but not the core mission of the tech mapper.
+
+---
+
+### 6. plan-work (MEDIUM impact)
+
+**File:** `.claude/skills/plan-work/SKILL.md`
+
+#### Integration Point 1: Step 3 -- Codebase Scouting
+
+**Exact section (SKILL.md lines 108-109):**
+```
+1. **Scout codebase** for reusable assets -- existing components, utilities, patterns
+   that could be leveraged. Use LSP workspaceSymbol to find relevant abstractions
+```
+
+**What the skill currently does:** LSP workspace symbol search and findReferences to find existing code to reuse.
+
+**Fallow command:** `fallow dupes --format json`
+
+**How output feeds in:** During planning, Fallow's duplication report reveals which patterns are already duplicated in the codebase. If the plan involves building something similar to existing duplicated code, the planner can recommend extracting a shared abstraction first, then building on it -- rather than creating yet another duplicate.
+
+**Impact:** MEDIUM -- informs better planning decisions but doesn't fundamentally change the workflow.
+
+#### Integration Point 2: Step 6 -- Plan-Check (Scope Sanity)
+
+**Exact section (SKILL.md line 271):**
+```
+4. **Scope sanity**: 2-3 tasks, 5-8 files in files_modified, plan body under 1500 words.
+```
+
+**What the skill currently does:** Checks task count and file count mechanically.
+
+**Fallow command:** `fallow check --format json`
+
+**How output feeds in:** Before finalizing the plan, run Fallow to check if any files in `files_modified` are already dead code (unused). If the plan modifies dead files, it should either remove them or question why they exist. Also flag if the plan creates files that would introduce circular dependencies based on the existing dependency graph.
+
+**Impact:** LOW -- edge case but prevents wasted effort on dead code.
+
+---
+
+### 7. plan-review (MEDIUM impact)
+
+**File:** `.claude/skills/plan-review/SKILL.md`
+
+#### Integration Point 1: Architecture Review (Section 1)
+
+**Exact section (plan-review/SKILL.md lines 161-170):**
+```
+### Section 1: Architecture Review
+- Data flow -- all four paths.
+- Coupling concerns. Which components are now coupled that weren't before?
+- Single points of failure.
+```
+
+**What the skill currently does:** LLM reads the plan and codebase to assess coupling. Manual analysis.
+
+**Fallow command:** `fallow check --format json` (dependency graph, circular dependencies)
+
+**How output feeds in:** The plan reviewer receives the current dependency graph and can evaluate whether the plan's proposed changes would create new circular dependencies or increase coupling. "The plan proposes `src/services/billing.ts` importing from `src/components/PricingCard.tsx` -- this would create a service->component layer violation."
+
+**Impact:** MEDIUM -- valuable for architectural review but the plan-review skill is already interactive and thorough.
+
+#### Integration Point 2: Long-Term Trajectory (Section 6)
+
+**Exact section (plan-review/SKILL.md lines 306-311):**
+```
+### Section 6: Long-Term Trajectory Review
+- Technical debt introduced.
+- Path dependency. Does this make future changes harder?
+```
+
+**What the skill currently does:** LLM assessment of debt trajectory.
+
+**Fallow commands:** `fallow health --format json` + `fallow check --format json`
+
+**How output feeds in:** Current complexity and dead code metrics provide a baseline. The reviewer can assess: "Current dead code: 5%. This plan adds 12 new exports -- if N of them go unwired, dead code rises to X%."
+
+**Impact:** LOW -- nice context but doesn't fundamentally change the review.
+
+---
+
+### 8. fix (MEDIUM impact)
+
+**File:** `.claude/skills/fix/SKILL.md`
+
+#### Integration Point 1: Triage (Step 1)
+
+**Exact section (SKILL.md lines 46-51):**
+```
+## Step 1: Triage
+1. **Search** for error message or symptom in codebase. Use LSP first:
+   - findReferences on the error site to see all callers
+   - diagnostics to surface type errors
+```
+
+**What the skill currently does:** LSP-driven investigation starting from the error site.
+
+**Fallow command:** `fallow check --format json` (circular dependencies)
+
+**How output feeds in:** If the bug is caused by circular dependencies (a common source of "undefined is not a function" errors at import time), Fallow instantly identifies the cycle. The triage step can check: "Is the error site involved in any circular dependency chain?" If yes, the root cause is likely the cycle, not the code logic.
+
+**Impact:** MEDIUM -- only relevant for a subset of bugs, but when relevant, it's a huge timesaver.
+
+#### Integration Point 2: Post-Fix Review (Step 4)
+
+**Exact section (SKILL.md lines 107-113):**
+```
+## Step 4: Post-Fix Review
+**For MODERATE+ fixes:** Invoke `skills/simplify/` on the fix diff.
+```
+
+**What the skill currently does:** Simplify pass on the fix diff (LLM-only).
+
+**Fallow command:** `fallow check --changed-since HEAD~1 --format json`
+
+**How output feeds in:** After fixing a bug, verify no dead code was introduced (common when fixing by moving logic to a new location but forgetting to remove the old export).
+
+**Impact:** LOW -- small incremental improvement.
+
+---
+
+### 9. extract (MEDIUM impact)
+
+**File:** `.claude/skills/extract/SKILL.md`
+
+#### Integration Point 1: Discover Phase
+
+**Exact section (SKILL.md lines 21-28):**
+```
+2. **Identify patterns**: Look for:
+   - **Repeated components**: Similar UI patterns used multiple times
+   - **Hard-coded values**: Colors, spacing, typography, shadows
+   - **Inconsistent variations**: Multiple implementations of the same concept
+   - **Reusable patterns**: Layout patterns, composition patterns
+```
+
+**What the skill currently does:** LLM reads code and tries to identify repetition. Limited by context window.
+
+**Fallow command:** `fallow dupes --mode semantic --format json`
+
+**How output feeds in:** Fallow provides the exact list of duplicated code blocks. The extract skill receives: "These 4 button implementations across `src/components/` share 78% semantic similarity." The discover phase becomes data-driven rather than exploratory.
+
+**Impact:** HIGH for the discover phase specifically -- this is duplication detection, which is Fallow's core strength.
+
+#### Integration Point 2: Migrate Phase
+
+**Exact section (SKILL.md lines 74-79):**
+```
+## Migrate
+- **Find all instances**: Use LSP findReferences on each extracted symbol
+- **Delete dead code**: Remove the old implementations
+```
+
+**What the skill currently does:** LSP findReferences + manual verification.
+
+**Fallow command:** `fallow check --format json` (after extraction, verify old exports are now unused)
+
+**How output feeds in:** After extracting a shared component and migrating consumers, run Fallow to verify the old implementations are genuinely dead (no remaining references). Confirms migration completeness.
+
+**Impact:** MEDIUM -- safety net for migration completeness.
+
+---
+
+### 10. secure (LOW impact)
+
+**File:** `.claude/skills/secure/SKILL.md`
+
+#### Integration Point 1: Dependency Scanning
+
+**Exact section (SKILL.md lines 50-55):**
+```
+### Agent 3: Data Exposure
+Categories: ... unused dependencies
+```
+
+**What the skill currently does:** The data exposure scanner looks for hardcoded secrets, PII in logs, etc. Dependency auditing is not its primary focus.
+
+**Fallow command:** `fallow check --format json` (unused dependencies)
+
+**How output feeds in:** Fallow identifies unused dependencies. While not a security tool per se, unused dependencies increase attack surface -- they are in `node_modules`, can have vulnerabilities, and serve no purpose. The security scan could flag: "7 unused dependencies in `package.json` -- each increases attack surface with zero value."
+
+**Impact:** MEDIUM for attack surface reduction, but this is not the secure skill's primary mission. Better suited as a separate check.
+
+---
+
+### 11. audit (MEDIUM impact)
+
+**File:** `.claude/skills/audit/SKILL.md`
+
+#### Integration Point 1: Performance -- Bundle Size
+
+**Exact section (SKILL.md lines 27-28):**
+```
+- **Bundle size**: Unnecessary imports, unused dependencies
+```
+
+**What the skill currently does:** LLM reads code looking for unnecessary imports. No tooling.
+
+**Fallow command:** `fallow check --format json` (unused exports, unused deps)
+
+**How output feeds in:** Fallow quantifies unused code that contributes to bundle size. The audit reports: "23 unused exports across 8 files contribute to dead code in the bundle. 4 unused dependencies add X KB to `node_modules`."
+
+**Impact:** MEDIUM -- provides quantified data for the performance section.
+
+#### Integration Point 2: Patterns & Systemic Issues
+
+**Exact section (SKILL.md lines 84-89):**
+```
+### Patterns & Systemic Issues
+Identify recurring problems:
+- "Hard-coded colors appear in 15+ components"
+```
+
+**What the skill currently does:** LLM tries to identify patterns across the codebase.
+
+**Fallow command:** `fallow dupes --format json` + `fallow health --format json`
+
+**How output feeds in:** Duplication patterns are systemic issues by definition. Fallow quantifies: "Duplicated code appears in N clusters, averaging M lines each." Complexity hotspots: "5 files exceed complexity threshold of 20."
+
+**Impact:** MEDIUM -- adds quantitative backing to systemic issue detection.
+
+---
+
+### 12. optimize (LOW impact)
+
+**File:** `.claude/skills/optimize/SKILL.md`
+
+#### Integration Point 1: Bundle Size Reduction
+
+**Exact section (SKILL.md lines 52-57):**
+```
+**Reduce JavaScript Bundle**:
+- Tree shaking (remove unused code)
+- Remove unused dependencies
+- Lazy load non-critical code
+```
+
+**What the skill currently does:** Provides guidance but doesn't run analysis.
+
+**Fallow command:** `fallow check --format json`
+
+**How output feeds in:** Fallow identifies what tree shaking should catch but might not (barrel file re-exports, side-effect-ful modules). Also identifies unused deps to remove.
+
+**Impact:** MEDIUM for the specific bundle-size task, but optimize is a broad skill and this is one small section.
+
+---
+
+### 13. health (NONE)
+
+**File:** `.claude/skills/health/SKILL.md`
+
+This skill validates `.planning/` directory integrity (GSD state health), not codebase health. It runs `gsd-tools.cjs validate health` to check PROJECT.md, ROADMAP.md, STATE.md, etc.
+
+**No Fallow integration points.** The skill is about planning metadata, not code.
+
+---
+
+### 14. harden (NONE)
+
+**File:** `.claude/skills/harden/SKILL.md`
+
+This skill is about UI resilience -- text overflow, i18n, error handling, edge cases. It operates at the component/interaction level, not the module/dependency level.
+
+**No Fallow integration points.** Fallow analyzes module-level structure; harden analyzes runtime behavior.
+
+---
+
+### 15. normalize (LOW impact)
+
+**File:** `.claude/skills/normalize/SKILL.md`
+
+#### Integration Point 1: Clean Up Phase
+
+**Exact section (SKILL.md lines 57-59):**
+```
+## Clean Up
+- **Remove orphaned code**: Delete unused implementations, styles, or files
+```
+
+**What the skill currently does:** LLM identifies orphaned code after normalization.
+
+**Fallow command:** `fallow check --format json`
+
+**How output feeds in:** After normalizing components to use design system equivalents, Fallow confirms which old implementations are now genuinely unused and safe to delete.
+
+**Impact:** LOW -- small cleanup verification step.
+
+---
+
+## Cross-Cutting Integration Recommendations
+
+### 1. Create a shared Fallow runner utility
+
+Rather than embedding Fallow commands in every skill, create a shared utility that skills can reference:
+
+```
+skills/fallow-analysis/SKILL.md
+```
+
+This skill would:
+- Accept a mode flag: `--full` (all checks) or `--changed` (incremental)
+- Run the appropriate combination of `fallow check`, `fallow dupes`, `fallow health`
+- Output a structured JSON summary
+- Be invokable from other skills as `skills/fallow-analysis/`
+
+### 2. Priority integration order
+
+Based on impact and usage frequency:
+
+1. **simplify** -- highest leverage because it's called by build, refactor, and fix
+2. **review (spec-gate unwired-code check)** -- catches the most impactful class of bugs
+3. **map-codebase** -- runs once but sets the foundation for all planning
+4. **refactor (Step 0 analysis mode)** -- data-driven refactoring targets
+5. **review (full review)** -- evidence-backed code quality findings
+6. **extract (discover phase)** -- duplication detection is extract's core mission
+
+### 3. Fallow availability check pattern
+
+Every integration should gracefully degrade when Fallow is not installed:
+
+```bash
+if command -v fallow &>/dev/null; then
+  FALLOW_OUTPUT=$(fallow check --format json 2>/dev/null)
+  # ... use output
+else
+  # proceed without -- all current behavior preserved
+fi
+```
+
+### 4. What NOT to integrate
+
+- **health** -- wrong domain (planning state, not code)
+- **harden** -- wrong level (runtime behavior, not module structure)
+- **todos** -- task tracking, not analysis
+- **onboard**, **delight**, **colorize**, **ui-animate**, **ui-critique**, **ui-redesign** -- UI/UX skills that don't analyze code structure
+- **setup**, **settings**, **help**, **progress**, **resume-work**, **tracker** -- workflow/meta skills
+
+---
+
+## Fallow Command Reference for Implementers
+
+| Command | What it returns | Skills that consume it |
+|---------|----------------|----------------------|
+| `fallow check --format json` | Unused exports, files, deps, types; circular deps | review, simplify, refactor, build/spec-gate, map-codebase, plan-work, extract, secure, audit, optimize, normalize |
+| `fallow check --changed-since SHA --format json` | Same as above, scoped to changed files | review (incremental), build/spec-gate (per-wave), fix (post-fix) |
+| `fallow dupes --format json` | Duplicated code blocks with locations | simplify, refactor, extract, map-codebase, audit |
+| `fallow dupes --mode semantic --format json` | Semantic clones (renamed variables) | simplify, refactor, extract |
+| `fallow health --format json` | Complexity metrics, hotspot files | review, simplify, refactor, map-codebase, plan-review, audit |
+
+---
+
+## Confidence Assessment
+
+| Finding | Confidence | Rationale |
+|---------|-----------|-----------|
+| Fallow `check` fits review/spec-gate unwired code | HIGH | The current LLM-only approach is a known weakness; Fallow directly addresses it |
+| Fallow `dupes` fits simplify/extract | HIGH | Duplication detection is Fallow's core feature and the skills explicitly ask for it |
+| Fallow `health` fits map-codebase concerns | HIGH | Complexity metrics are standard tech debt indicators |
+| Fallow circular dep detection fits review arch criteria | HIGH | LLM cannot trace full import graphs from diffs |
+| Fallow `check` fits secure skill | LOW | Unused deps are a minor attack surface concern; not security-critical |
+| Fallow JSON output format specifics | LOW | Based on web search; verify exact flags and output schema against Fallow docs |

--- a/.planning/research/fallow-tools-research.md
+++ b/.planning/research/fallow-tools-research.md
@@ -1,0 +1,443 @@
+# Fallow Tools Research
+
+**Researched:** 2026-03-25
+**Overall confidence:** MEDIUM (docs site confirmed, no npm package name verified, no community discussion found outside official sources)
+
+---
+
+## 1. Overview and Purpose
+
+Fallow is a Rust-native static analyzer for TypeScript and JavaScript that identifies unused code, circular dependencies, code duplication, and complexity hotspots. Its tagline captures the philosophy: **"AI writes code. Nobody deletes it."**
+
+While linters enforce style and formatters ensure consistency, Fallow enforces **code relevance** -- it finds artifacts that accumulate during development and AI-assisted coding that nobody cleans up.
+
+**What it is NOT:** Fallow is not a code understanding tool in the LSP sense. It does not provide go-to-definition, find-references, type inference, hover information, or call graphs. It is a specialized dead-code and code-health analyzer.
+
+### Key Stats
+
+| Metric | Value |
+|--------|-------|
+| Language | Rust |
+| Parser | Oxc (JS/TS parser) |
+| Parallelism | Rayon |
+| Config | Zero-config with auto-detection |
+| Speed | 3,000+ file monorepo in ~300ms |
+| vs knip | 3-46x faster |
+| vs jscpd | 20-33x faster |
+| vs madge/dpdm | 3-32x faster |
+| Memory | 3-6x less than alternatives |
+
+---
+
+## 2. Architecture
+
+### Technical Stack
+
+- **Parser:** Oxc -- the same Rust-based JS/TS parser used by oxlint. Provides AST and scope-aware binding analysis via `oxc_semantic`.
+- **Parallelism:** Rayon for concurrent file parsing.
+- **Duplicate detection:** Suffix array with LCP (Longest Common Prefix) algorithm -- a classical string-matching approach adapted for token sequences.
+- **Circular dependency detection:** Tarjan's algorithm on the module graph.
+- **Module graph:** Full resolution including barrel files, re-export chains, and conditional exports.
+
+### How It Works
+
+1. **Entry point discovery** -- Auto-detects from `package.json` fields (`main`, `module`, `types`, `bin`, `exports`) plus 84 framework plugins (Next.js, Vite, Jest, etc.).
+2. **Module graph construction** -- Parses all reachable files, resolves imports/exports, builds a complete dependency graph.
+3. **Reachability analysis** -- Traces from entry points through the graph to determine which exports are actually consumed.
+4. **Reporting** -- Flags unreachable code as unused, detects cycles, finds duplicates.
+
+### Analysis is Syntactic Only
+
+**Critical limitation:** Fallow performs syntactic analysis only -- no type information. The Oxc parser gives AST and scope bindings, but Fallow does not run a type checker. This is a deliberate tradeoff for speed. Consequences:
+- No type-level dead code detection beyond exported type declarations
+- No understanding of generic instantiations or conditional types
+- Dynamic imports are only partially resolved (template literals, `import.meta.glob`, `require.context`)
+
+---
+
+## 3. Key Features and Capabilities
+
+### 3.1 Dead Code Detection (13 issue types)
+
+| Issue Type | What It Finds |
+|------------|---------------|
+| `unused-files` | Files not reachable from any entry point |
+| `unused-exports` | Exported symbols never imported elsewhere |
+| `unused-types` | Exported type declarations never used |
+| `unused-deps` | `dependencies` in package.json never imported |
+| `unused-optional-deps` | Unused `optionalDependencies` |
+| `unused-enum-members` | Enum values never referenced |
+| `unused-class-members` | Class methods/properties never called externally |
+| `unresolved-imports` | Import paths that don't resolve |
+| `unlisted-deps` | Imports of packages not in package.json |
+| `duplicate-exports` | Same symbol exported multiple times |
+| `circular-deps` | Circular import chains |
+| `type-only-deps` | Runtime deps that could be `devDependencies` |
+
+### 3.2 Code Duplication (4 modes)
+
+| Mode | Description |
+|------|-------------|
+| **strict** | Exact token matches |
+| **mild** | AST-based (ignores formatting differences) |
+| **weak** | Tolerates different literal values |
+| **semantic** | Tolerates renamed variables (structural clones) |
+
+Configuration: `minTokens`, `minLines`, `threshold`.
+
+### 3.3 Code Health
+
+- **Cyclomatic complexity** per function
+- **Cognitive complexity** per function
+- **File maintainability score** (0-100)
+- **Hotspot detection** combining git churn with complexity
+- Configurable thresholds and top-N ranking
+
+### 3.4 Auto-Fix
+
+```bash
+fallow fix              # Remove unused exports and dependencies
+fallow fix --dry-run    # Preview what would be removed
+```
+
+### 3.5 Framework Support (84 plugins)
+
+Auto-detects: Next.js, Nuxt, Remix, SvelteKit, Vite, Webpack, Jest, Vitest, Playwright, ESLint, Tailwind, Prisma, Turborepo, and many more. Custom plugins can be defined in config.
+
+### 3.6 Non-JS File Support
+
+- Vue/Svelte SFC `<script>` block extraction
+- Astro frontmatter parsing
+- MDX import/export statements
+- CSS/SCSS `@import`, `@use`, `@forward`, `@apply`/`@tailwind`
+- CSS Modules class name tracking
+
+---
+
+## 4. CLI Reference
+
+### Commands
+
+```bash
+fallow check          # Dead code + circular deps (default command)
+fallow dupes          # Duplication + complexity hotspots
+fallow health         # Complexity metrics and maintainability
+fallow fix            # Auto-remove unused exports/deps
+fallow fix --dry-run  # Preview fixes
+fallow watch          # Real-time analysis (file watcher)
+fallow init           # Create config file
+fallow migrate        # Convert knip/jscpd configs
+fallow list           # Show detected entry points
+```
+
+### Key Flags
+
+| Flag | Purpose |
+|------|---------|
+| `-f, --format <FMT>` | Output: `human`, `json`, `sarif`, `compact`, `markdown` |
+| `--ci` | CI mode (SARIF + fail-on-issues + quiet) |
+| `--changed-since <REF>` | Only analyze files changed since git ref |
+| `--baseline <PATH>` | Compare against saved baseline |
+| `--save-baseline <PATH>` | Save current results as baseline |
+| `--production` | Exclude test/story/dev files |
+| `--trace <FILE:EXPORT>` | Debug why an export appears unused |
+| `--trace-file <PATH>` | Show all imports/exports for a file |
+| `--trace-dependency <PKG>` | Show where a dependency is used |
+| `--performance` | Display timing metrics |
+| `--explain` | Include metric descriptions and doc links |
+| `-q, --quiet` | Hide progress messages |
+| `--fail-on-issues` | Exit 1 when issues found |
+
+### Issue Type Filters
+
+Each issue type has a corresponding `--<type>` flag (e.g., `--unused-files`, `--circular-deps`) to isolate specific checks.
+
+---
+
+## 5. Output Formats
+
+| Format | Use Case |
+|--------|----------|
+| `human` | Terminal display (default) |
+| `json` | Programmatic consumption, AI agents |
+| `sarif` | GitHub Code Scanning integration |
+| `compact` | Scripting, piping |
+| `markdown` | PR comments |
+
+JSON output is the key format for agent integration. The `--format json` flag produces structured output suitable for parsing.
+
+---
+
+## 6. MCP Server Integration
+
+### Architecture
+
+The MCP server (`fallow-mcp`) is a **stdio subprocess wrapper** around the CLI binary. All analysis logic stays in the CLI; the MCP crate only handles protocol framing and argument mapping. CLI and MCP always produce identical results.
+
+### Setup
+
+For Claude Code, add to `.claude/settings.json`:
+```json
+{
+  "mcpServers": {
+    "fallow": {
+      "command": "fallow-mcp"
+    }
+  }
+}
+```
+
+Custom binary path via `FALLOW_BIN` environment variable.
+
+### Available MCP Tools (7 tools)
+
+| Tool | Purpose |
+|------|---------|
+| `analyze` | Full dead code analysis |
+| `check_changed` | Analyze only changed files (git-aware) |
+| `find_dupes` | Duplication detection |
+| `fix_preview` | Preview auto-fix results |
+| `fix_apply` | Apply auto-fixes |
+| `check_health` | Complexity and maintainability metrics |
+| `project_info` | Project structure and entry point info |
+
+---
+
+## 7. Configuration
+
+### File Formats (searched in order)
+
+1. `.fallowrc.json` (JSONC with comments)
+2. `fallow.toml`
+3. `.fallow.toml`
+4. Embedded in `package.json`
+
+### Key Config Fields
+
+```jsonc
+{
+  // Additional entry points beyond auto-detected
+  "entry": ["src/**/*.ts"],
+
+  // Files to exclude entirely
+  "ignorePatterns": ["**/*.generated.ts"],
+
+  // Packages always considered used
+  "ignoreDependencies": ["@types/node"],
+
+  // Fine-grained export ignoring
+  "ignoreExports": {
+    "src/public-api.ts": ["*"]
+  },
+
+  // Severity per issue type: "error" | "warn" | "off"
+  "rules": {
+    "unused-files": "error",
+    "unused-exports": "warn",
+    "circular-deps": "error"
+  },
+
+  // Duplication settings
+  "duplicates": {
+    "mode": "mild",
+    "minTokens": 50,
+    "minLines": 5
+  },
+
+  // Complexity thresholds
+  "health": {
+    "maxCyclomatic": 15,
+    "maxCognitive": 20
+  },
+
+  // Focus on production code only
+  "production": false,
+
+  // Config inheritance
+  "extends": "./base-fallow.json",
+
+  // Per-pattern rule overrides
+  "overrides": [
+    {
+      "patterns": ["**/*.test.ts"],
+      "rules": { "unused-exports": "off" }
+    }
+  ]
+}
+```
+
+### Inline Suppression
+
+```typescript
+// fallow-ignore-next-line
+export const legacyApi = ...;
+
+// fallow-ignore-file  (at top of file)
+```
+
+---
+
+## 8. Comparison with LSP for Code Understanding
+
+This is the critical comparison for the fhhs-skills context.
+
+| Capability | Fallow | TypeScript LSP |
+|------------|--------|----------------|
+| **Go-to-definition** | NO | YES |
+| **Find references** | NO | YES |
+| **Hover / type info** | NO | YES |
+| **Call graph** | NO (module graph only) | Partial (via references) |
+| **Rename symbol** | NO | YES |
+| **Code completion** | NO | YES |
+| **Unused exports** | YES (primary feature) | Basic (via `noUnusedLocals`) |
+| **Unused files** | YES | NO |
+| **Unused dependencies** | YES | NO |
+| **Circular dependencies** | YES | NO |
+| **Code duplication** | YES | NO |
+| **Complexity metrics** | YES | NO |
+| **Module graph** | YES (full) | NO (per-file only) |
+| **Auto-fix dead code** | YES | NO |
+| **Framework awareness** | YES (84 plugins) | NO |
+| **Speed on large codebases** | Very fast (300ms for 3k files) | Slower (type checking overhead) |
+| **Type-level analysis** | NO (syntactic only) | YES (full type system) |
+
+### Verdict
+
+**Fallow and LSP serve completely different purposes and are complementary, not competitive.**
+
+- **LSP** is for code navigation, understanding, and editing -- "What does this symbol mean? Where is it used? What type does it have?"
+- **Fallow** is for code hygiene and health -- "What code is dead? What's duplicated? What's too complex? What dependencies are unused?"
+
+For a Claude Code skill focused on helping developers understand and navigate code, **LSP is the right tool**. Fallow would be valuable as a separate, complementary skill for code cleanup and health monitoring.
+
+---
+
+## 9. Integration Patterns for Claude Code Skills
+
+### Pattern A: MCP Server (recommended for persistent analysis)
+
+```json
+// .claude/settings.json
+{
+  "mcpServers": {
+    "fallow": { "command": "fallow-mcp" }
+  }
+}
+```
+
+Then in skill instructions, reference the MCP tools directly. The agent can call `analyze`, `check_changed`, etc.
+
+### Pattern B: CLI with JSON output (simpler, no MCP dependency)
+
+```bash
+# In a skill, shell out to fallow
+fallow check --format json --quiet
+fallow dupes --format json --quiet
+fallow health --format json --quiet
+```
+
+Parse the JSON output in the skill's logic.
+
+### Pattern C: CI/PR workflow
+
+```bash
+# Check only changed files in a PR
+fallow check --changed-since origin/main --format markdown
+```
+
+Output markdown directly usable in PR comments.
+
+---
+
+## 10. Installation
+
+```bash
+# Via npm (prebuilt binaries)
+npm install -g fallow
+
+# Via npx (no install)
+npx fallow check
+
+# Via cargo
+cargo install fallow-cli
+
+# Binary download
+# Available for macOS (arm64, x64), Linux (x64, arm64), Windows (x64)
+```
+
+No Node.js runtime dependency -- the npm package just contains the prebuilt binary.
+
+---
+
+## 11. Strengths
+
+1. **Extremely fast** -- sub-second on large codebases where competitors take 10-60 seconds or crash.
+2. **Zero config** -- auto-detects entry points and frameworks, works out of the box.
+3. **Comprehensive dead code detection** -- 13 issue types covering files, exports, types, deps, enums, class members.
+4. **Excellent CI integration** -- SARIF output, baseline comparison, changed-since for incremental checks.
+5. **MCP server** -- first-class AI agent integration with 7 structured tools.
+6. **Deterministic** -- results traceable to concrete import graph paths (not heuristic).
+7. **Auto-fix** -- can actually remove dead code, not just report it.
+8. **Framework-aware** -- 84 plugins prevent false positives from framework conventions.
+
+---
+
+## 12. Weaknesses and Gaps
+
+1. **No code navigation** -- cannot do go-to-definition, find-references, hover, or any LSP-like code understanding.
+2. **Syntactic only** -- no type information means it misses type-level dead code and cannot reason about generic usage.
+3. **Dynamic imports partially resolved** -- template literal imports, `import.meta.glob`, and `require.context` are best-effort.
+4. **Svelte exports may go undetected** without compiler semantics (acknowledged limitation).
+5. **No call graph** -- builds a module/import graph but not a function-level call graph.
+6. **New tool** -- limited community discussion found; web searches return zero results for "fallow.tools" or "fallow-rs" outside the official docs site. This could mean it is very new, or the names I searched may not match the actual npm/crate package names.
+7. **No dependency on TypeScript compiler** -- this is both a strength (speed) and weakness (no type analysis).
+
+---
+
+## 13. Confidence Assessment
+
+| Claim | Confidence | Source |
+|-------|------------|--------|
+| Core features (dead code, dupes, health) | HIGH | Official docs (fetched and confirmed) |
+| Performance claims (3-46x faster) | MEDIUM | Official docs only, no independent benchmarks found |
+| MCP server with 7 tools | HIGH | Official docs (fetched and confirmed) |
+| 84 framework plugins | MEDIUM | Official docs, not independently verified |
+| npm package name is "fallow" | LOW | Docs say `npx fallow` but npm search did not surface it; may use a different package name |
+| GitHub repo at fallow-rs/fallow | LOW | URL returned content via WebFetch but web search found no references to this org; may be a different actual URL |
+| Community adoption | LOW | Zero community discussion found in web searches |
+
+---
+
+## 14. Open Questions
+
+1. **What is the actual npm package name?** The docs reference `npx fallow` but the package was not found in npm search results. It may be published under a different name, or may be very new / not yet indexed.
+2. **What is the actual GitHub repository URL?** Web searches found no references to `fallow-rs`. The repo may be private, very new, or under a different org.
+3. **Is Fallow generally available?** The lack of any community discussion, blog posts, or third-party references is unusual for a tool with these claimed capabilities. It may be in private beta or very early release.
+4. **MCP server binary distribution** -- is `fallow-mcp` included in the npm package or a separate install?
+5. **How does it handle monorepo workspaces?** Docs mention workspace support for npm/yarn/pnpm but specifics on cross-workspace unused detection were not found.
+
+---
+
+## 15. Relevance to fhhs-skills
+
+### For code understanding / navigation skills: NOT a replacement for LSP
+
+Fallow does not provide any of the capabilities needed for code understanding skills:
+- No symbol lookup, definition navigation, or reference finding
+- No type information or hover details
+- No call graphs or dependency chains at the function level
+
+### For a potential "code health" or "cleanup" skill: STRONG fit
+
+Fallow would be excellent for a skill like `/fh:cleanup` or `/fh:health` that:
+- Finds and removes dead code after refactoring
+- Detects circular dependencies that cause initialization bugs
+- Identifies duplicated code blocks for consolidation
+- Surfaces complexity hotspots needing attention
+- Runs as a PR check to prevent code rot
+
+The MCP server integration makes this particularly clean -- a skill could reference the MCP tools directly without shell-out orchestration.
+
+### Recommendation
+
+If the goal is to add code health / dead code detection capabilities to fhhs-skills, Fallow is the right tool. If the goal is to improve code understanding and navigation, stick with TypeScript LSP. These are complementary, not competing, tools.

--- a/.planning/research/serena-research.md
+++ b/.planning/research/serena-research.md
@@ -1,0 +1,457 @@
+# Serena Research Report
+
+**Researched:** 2026-03-25
+**Overall confidence:** HIGH (official docs confirmed, multiple independent sources, architecture verified via DeepWiki code analysis)
+
+---
+
+## 1. What Serena Is
+
+Serena is an open-source (MIT) coding agent toolkit that exposes IDE-like semantic code understanding to LLMs via MCP (Model Context Protocol). It wraps language servers (LSP) behind a higher-level abstraction called **SolidLSP**, providing symbol-level code navigation and editing tools that any MCP-compatible client can consume.
+
+**Key identity:** Serena is NOT a language server itself. It is an MCP server that delegates to real language servers (pylsp/Pyright, typescript-language-server, rust-analyzer, gopls, clangd, Eclipse JDTLS, etc.) and exposes their capabilities as structured MCP tools.
+
+### Key Stats
+
+| Metric | Value |
+|--------|-------|
+| GitHub stars | ~22.1K |
+| License | MIT |
+| Language | Python |
+| Commits | 2,358+ |
+| Approaching | v1.0.0 |
+| Supported languages | 40+ |
+| MCP transport | stdio (default), streamable-http |
+
+---
+
+## 2. How It Works -- Architecture
+
+### Layer Stack
+
+```
+MCP Client (Claude Code, Cursor, etc.)
+    |
+    v
+FastMCP Server (Python MCP SDK)
+    |
+    v
+SerenaAgent (tool orchestration, project state, modes)
+    |
+    v
+ToolRegistry (discovered via reflection at startup)
+    |
+    v
+SolidLSP (synchronous LSP abstraction over multilspy)
+    |
+    v
+Language Server subprocesses (pyright, ts-server, rust-analyzer, etc.)
+```
+
+### Core Design Decisions
+
+1. **SolidLSP** is a fork/extension of Microsoft's multilspy library. It adds:
+   - Synchronous (not async) operation -- suitable for agent task sequencing
+   - Two-tier caching (raw LSP responses + processed DocumentSymbols) in `.solidlsp/cache/`
+   - File buffer management with `didOpen`/`didChange`/`didClose` lifecycle
+   - Content-hash-based cache invalidation (edits automatically expire cached data)
+   - Symbolic reasoning layer on top of raw LSP responses
+
+2. **Tool execution is serialized** -- single-threaded TaskExecutor processes MCP calls sequentially. This avoids race conditions with language servers but means no parallel tool calls.
+
+3. **Dual backend** -- SolidLSP for most use cases, or JetBrains IDE plugin for environments where JetBrains is already running (superior polyglot indexing, type hierarchy support).
+
+4. **Context-aware tool exposure** -- different MCP clients get different tool sets. The `--context` flag controls which tools are exposed:
+   - `ide-assistant` (Claude Code, Cursor) -- editing tools enabled, shell command disabled
+   - `desktop-app` (Claude Desktop) -- more conservative
+   - `codex` -- Codex CLI compatibility
+
+5. **Modes** -- runtime tool filtering:
+   - `planning` mode -- excludes editing tools
+   - `editing` mode -- enables modifications
+   - Users can switch modes mid-session
+
+### Project Lifecycle
+
+1. First activation triggers **onboarding** -- agent explores codebase structure, documents findings in `.serena/memories/` as markdown files
+2. Subsequent sessions load persisted memories for long-term context
+3. Configuration at three levels: global (`~/.serena/serena_config.yml`), project (`.serena/project.yml`), and context/mode
+
+---
+
+## 3. Complete Tool Inventory
+
+### Symbol Tools (core value)
+
+| Tool | What It Does |
+|------|-------------|
+| `find_symbol` | Global/local symbol search via language server -- finds classes, functions, methods by name |
+| `find_referencing_symbols` | Finds all symbols that reference a given symbol (like LSP findReferences) |
+| `get_symbols_overview` | Lists top-level symbols in a file (like LSP documentSymbol) |
+| `replace_symbol_body` | Replaces a symbol's implementation while preserving its signature |
+| `insert_after_symbol` | Inserts content after a symbol's definition |
+| `insert_before_symbol` | Inserts content before a symbol's definition |
+| `rename_symbol` | Renames a symbol across the entire codebase (LSP rename refactoring) |
+| `restart_language_server` (optional) | Restarts LS when external edits desynchronize state |
+
+### JetBrains Tools (optional, requires running IDE)
+
+| Tool | What It Does |
+|------|-------------|
+| `jet_brains_find_symbol` | Symbol search via JetBrains backend |
+| `jet_brains_find_referencing_symbols` | Reference finding via JetBrains |
+| `jet_brains_get_symbols_overview` | Symbol overview via JetBrains |
+| `jet_brains_type_hierarchy` | Type hierarchy (supertypes + subtypes) -- unique to JetBrains backend |
+
+### File Tools
+
+| Tool | What It Does |
+|------|-------------|
+| `read_file` | Read a file within the project |
+| `create_text_file` | Create or overwrite files |
+| `find_file` | Find files by path pattern |
+| `list_dir` | Directory listing with optional recursion |
+| `search_for_pattern` | Grep-like pattern search |
+| `replace_content` | Find-and-replace with optional regex |
+| `delete_lines` (optional) | Delete line ranges |
+| `insert_at_line` (optional) | Insert at specific line |
+| `replace_lines` (optional) | Replace line ranges |
+
+### Memory Tools
+
+| Tool | What It Does |
+|------|-------------|
+| `write_memory` | Persist project knowledge for future sessions |
+| `read_memory` | Retrieve persisted knowledge |
+| `list_memories` | List available memory files |
+| `edit_memory` | Regex-based memory content replacement |
+| `delete_memory` | Remove memory files |
+| `rename_memory` | Move memories between project/global scope |
+
+### Workflow Tools
+
+| Tool | What It Does |
+|------|-------------|
+| `onboarding` | Initial project exploration and documentation |
+| `check_onboarding_performed` | Check if onboarding was already done |
+| `initial_instructions` | Provides usage instructions to the agent |
+| `prepare_for_new_conversation` | Context reset between sessions |
+| `summarize_changes` (optional) | Summarize codebase changes |
+| `think_about_collected_information` (optional) | Metacognitive tool: assess information completeness |
+| `think_about_task_adherence` (optional) | Metacognitive tool: check task alignment |
+| `think_about_whether_you_are_done` (optional) | Metacognitive tool: assess task completion |
+
+### Config/Command Tools
+
+| Tool | What It Does |
+|------|-------------|
+| `activate_project` | Switch active project |
+| `get_current_config` | Show current configuration state |
+| `execute_shell_command` | Run arbitrary shell commands (disabled in IDE contexts by default) |
+| `open_dashboard` (optional) | Open web dashboard |
+| `switch_modes` (optional) | Change between planning/editing modes |
+
+### Query Project Tools (optional)
+
+| Tool | What It Does |
+|------|-------------|
+| `list_queryable_projects` | List projects available for querying |
+| `query_project` | Execute read-only tools against external projects |
+
+---
+
+## 4. Language Support
+
+40+ languages via SolidLSP. The language servers are auto-downloaded on first use into `~/.serena/language_servers/static/`.
+
+**Tier 1 (well-tested):** Python (Pyright), TypeScript, JavaScript, Java (Eclipse JDTLS), Go (Gopls), Rust (rust-analyzer), C/C++ (Clangd), C# (Roslyn/OmniSharp)
+
+**Tier 2 (supported):** Ruby, Kotlin, Swift, Scala, Dart, PHP, Elixir, Haskell, Lua, Julia, Perl, R, Zig, Fortran, Clojure, Erlang, Elm, OCaml, Nix
+
+**Tier 3 (partial/experimental):** Bash, TOML, YAML, Markdown, GLSL, HLSL, WGSL, Groovy, F# (some bugs), AL, Ansible, Lean 4, Luau, Solidity, MATLAB, PowerShell
+
+---
+
+## 5. Comparison: Serena vs. LSP vs. Fallow
+
+### What Each Tool Actually Is
+
+| | Serena | TypeScript LSP (direct) | Fallow |
+|---|--------|------------------------|--------|
+| **Category** | MCP server wrapping language servers | Language server protocol | Dead code / code health CLI |
+| **Protocol** | MCP (stdio or HTTP) | LSP (stdio or TCP) | CLI with JSON output, or MCP |
+| **Core purpose** | Expose code understanding to AI agents | Provide code intelligence to editors | Find unused code, duplicates, complexity |
+| **Analysis type** | Semantic (via delegated LSP) | Semantic (type-aware) | Syntactic (AST only, no types) |
+
+### Capability Matrix
+
+| Capability | Serena | Claude Code built-in LSP | Fallow |
+|-----------|--------|--------------------------|--------|
+| Go-to-definition | YES (via `find_symbol`) | YES (`goToDefinition`) | NO |
+| Find references | YES (via `find_referencing_symbols`) | YES (`findReferences`) | NO |
+| Symbol overview | YES (via `get_symbols_overview`) | YES (`documentSymbol`) | NO |
+| Rename refactoring | YES (via `rename_symbol`) | NO | NO |
+| Type hierarchy | YES (JetBrains only) | NO | NO |
+| Symbol-level code editing | YES (replace/insert at symbol boundaries) | NO | NO |
+| Unused exports | NO | NO | YES (primary feature) |
+| Unused files | NO | NO | YES |
+| Unused dependencies | NO | NO | YES |
+| Circular dependencies | NO | NO | YES |
+| Code duplication | NO | NO | YES |
+| Complexity metrics | NO | NO | YES |
+| Auto-fix dead code | NO | NO | YES |
+| Module/import graph | NO | NO | YES |
+| Hover / type info | NO (not exposed) | YES | NO |
+| Diagnostics | NO (not exposed) | YES | NO |
+| Project memory/onboarding | YES | NO | NO |
+| Multi-language (40+) | YES | TypeScript only | JS/TS only |
+| Agent metacognition tools | YES | NO | NO |
+
+### Key Differentiators
+
+**Serena has that LSP does NOT:**
+1. **Symbol-level code editing** -- `replace_symbol_body`, `insert_after_symbol`, `insert_before_symbol`. This is the killer feature. Raw LSP provides read-only navigation; Serena turns it into structured write operations.
+2. **Cross-project rename** via `rename_symbol` -- leverages LSP rename but exposes it to agents
+3. **Persistent project memory** -- agents retain knowledge across sessions
+4. **Onboarding workflow** -- systematic project exploration and documentation
+5. **Metacognitive tools** -- help agents self-regulate task adherence
+6. **Multi-language** -- one MCP server handles 40+ languages, not just TypeScript
+7. **JetBrains backend option** -- type hierarchy, superior polyglot indexing
+
+**Serena has that Fallow does NOT:**
+- Everything related to code navigation and understanding
+- Code editing capabilities
+- Multi-language support beyond JS/TS
+
+**Fallow has that Serena does NOT:**
+- Dead code detection (unused exports, files, dependencies)
+- Code duplication detection
+- Complexity metrics and maintainability scoring
+- Module/import graph analysis
+- Auto-fix capabilities for dead code removal
+- Framework-aware entry point detection (84 plugins)
+
+### Verdict: Complementary, Not Competing
+
+```
+Serena  = "Understand and edit code at the symbol level" (navigation + refactoring)
+Fallow  = "Find and remove code that shouldn't exist" (hygiene + health)
+LSP     = "Raw protocol that Serena wraps" (foundation layer)
+```
+
+All three occupy different niches. Serena and Fallow together would cover both code understanding AND code health. Neither replaces the other.
+
+---
+
+## 6. Serena vs. Claude Code's Built-in LSP
+
+This is the most practically relevant comparison. Since Claude Code v2.0.74, there are built-in LSP tools:
+
+| Capability | Serena | Claude Code Built-in LSP |
+|-----------|--------|--------------------------|
+| Find definitions | `find_symbol` (name-path based, flexible) | `goToDefinition` (cursor-position based) |
+| Find references | `find_referencing_symbols` | `findReferences` |
+| Symbol overview | `get_symbols_overview` | `documentSymbol` |
+| Rename | YES | NO |
+| Symbol-level editing | YES | NO |
+| Project memory | YES | NO |
+| 40+ languages | YES | 11 languages |
+| Setup required | YES (uv, Python 3.11+) | NO (built-in) |
+| Token usage | Claimed 70% savings | Standard |
+
+**Serena maintainers' position:** "Claude's built-in LSP tools are not a replacement for Serena. They are significantly less powerful tools." The recommendation is to use Serena instead, not alongside, to avoid duplicate tool calls consuming context.
+
+**Key advantages of Serena over built-in LSP:**
+1. Name-path-based symbol lookup (more flexible than cursor-position-based)
+2. Symbol-level code editing (the built-in LSP is read-only)
+3. Rename refactoring across codebase
+4. Persistent project memory
+5. 40+ languages vs 11
+6. Onboarding and metacognitive tools
+
+**Key advantages of built-in LSP over Serena:**
+1. Zero setup -- just works
+2. No Python/uv dependency
+3. Hover information and diagnostics (Serena does not expose these)
+4. Lower overhead -- no separate process
+5. `ENABLE_LSP_TOOL=1` is all that's needed
+
+---
+
+## 7. Integration with Claude Code Skills/Plugins
+
+### Option A: MCP Server (recommended)
+
+Add Serena as an MCP server in the project's `.mcp.json` or via `claude mcp add`:
+
+```bash
+claude mcp add serena -- \
+  uvx --from git+https://github.com/oraios/serena \
+  serena start-mcp-server --context ide-assistant --project "$(pwd)"
+```
+
+Or in `.mcp.json`:
+```json
+{
+  "mcpServers": {
+    "serena": {
+      "command": "uvx",
+      "args": [
+        "--from", "git+https://github.com/oraios/serena",
+        "serena", "start-mcp-server",
+        "--context", "ide-assistant",
+        "--project-from-cwd"
+      ]
+    }
+  }
+}
+```
+
+**Pros:** Full tool access, persistent memory, mode switching, project onboarding.
+**Cons:** Requires Python 3.11+ and `uv`. Heavy dependency for a plugin that ships skills only.
+
+### Option B: Skills that reference Serena MCP tools
+
+An fhhs-skills plugin skill could instruct Claude to use Serena's MCP tools when available. This is a "documentation-only" integration -- the skill provides instructions, Serena provides the tools.
+
+Example: a `/fh:navigate` skill could say "Use `find_symbol` and `find_referencing_symbols` from the serena MCP server to navigate the codebase. If serena is not available, fall back to grep and file reading."
+
+**Pros:** No dependency on Serena being installed. Graceful degradation.
+**Cons:** Skill can't guarantee Serena is available. User must set up Serena separately.
+
+### Option C: NOT viable -- bundling Serena in a plugin
+
+Claude Code plugins ship `.claude/skills/` only. There are no postinstall hooks. You cannot install Python packages, start MCP servers, or run setup scripts at plugin install time. Serena cannot be bundled inside fhhs-skills.
+
+### Recommendation for fhhs-skills
+
+**Option B is the only viable path.** Skills can reference Serena tools when present and fall back gracefully. The plugin could include a `/fh:setup` step that documents how to add Serena as an MCP server, but cannot automate the installation.
+
+---
+
+## 8. Installation and Setup Requirements
+
+### Prerequisites
+
+| Requirement | Details |
+|-------------|---------|
+| Python | 3.11+ (NOT 3.12+ per some reports, but docs say 3.11+) |
+| `uv` | Python package manager (replaces pip for Serena) |
+| Language servers | Auto-downloaded on first use per language |
+| Disk space | Language server binaries stored in `~/.serena/language_servers/static/` |
+
+### Quick Install
+
+```bash
+# Run directly (no local install)
+uvx --from git+https://github.com/oraios/serena serena start-mcp-server --help
+
+# Or clone and run
+git clone https://github.com/oraios/serena
+cd serena
+uv run serena-mcp-server
+```
+
+### Per-Project Setup
+
+Serena creates `.serena/project.yml` in each project root. Recommended starting config:
+
+```yaml
+read_only: true
+project_name: my_project
+```
+
+---
+
+## 9. Limitations and Caveats
+
+### Technical Limitations
+
+1. **Synchronous only** -- single-threaded execution. No parallel tool calls. Can be slow on initial symbol resolution for large projects.
+2. **LSP subset only** -- Serena exposes find_symbol, find_references, document_symbols, rename, and text edits. It does NOT expose diagnostics, hover, completion, code actions, or many other LSP capabilities.
+3. **No incremental compilation** -- large projects may experience delays on first use until language servers index.
+4. **External runtime dependencies** -- Go, Rust, Java language servers require their respective runtimes installed on the system.
+5. **Language server stability varies** -- some language servers (Go in particular) have had initialization timeout issues.
+
+### Security Concerns
+
+A July 2025 security audit identified **HIGH risk** vulnerabilities:
+- `execute_shell_command` allows arbitrary command execution (mitigated: disabled by default in ide-assistant context)
+- Network exposure via streamable-http transport
+- Insufficient access controls in some configurations
+
+**Mitigation:** Use `read_only: true` in project config, use `ide-assistant` context (disables shell), and monitor tool executions.
+
+### Practical Caveats
+
+1. **Onboarding overhead** -- first session with a new project takes extra time for Serena to explore and document the codebase.
+2. **Token overhead from tool descriptions** -- Serena registers ~21+ tools, each with descriptions. This consumes context window just from tool definitions.
+3. **Conflict with Claude Code's built-in LSP** -- if both are enabled, duplicate capabilities waste context. Recommendation: use one or the other.
+4. **Memory files accumulate** -- `.serena/memories/` grows over time and may need pruning.
+5. **Not useful for greenfield** -- Serena shines on existing, large codebases. For new projects or small files, it adds overhead without value.
+6. **Python ecosystem dependency** -- requires `uv` and Python, which is an alien dependency in a Node.js/TypeScript plugin ecosystem.
+
+---
+
+## 10. Relevance to fhhs-skills
+
+### What Serena Adds Beyond Current Capabilities
+
+The fhhs-skills plugin currently relies on Claude Code's built-in tools (Read, Grep, Glob, Edit, Bash) plus the built-in LSP tools (when enabled). Serena would add:
+
+1. **Symbol-level editing** -- replace a function body without knowing line numbers, insert code relative to symbols rather than lines. This is genuinely new capability.
+2. **Cross-codebase rename** -- rename a symbol and update all references automatically.
+3. **Multi-language navigation** -- same tools work for Python, Go, Rust, Java, not just TypeScript.
+4. **Persistent project memory** -- agents remember project structure across sessions.
+
+### What It Does NOT Add
+
+1. Dead code detection (use Fallow for that)
+2. Code duplication detection (use Fallow)
+3. Complexity metrics (use Fallow)
+4. Type-level analysis beyond what the underlying LSP provides
+5. Call graphs (not exposed through Serena's tools)
+
+### Integration Feasibility
+
+| Approach | Feasible? | Notes |
+|----------|-----------|-------|
+| Bundle Serena in plugin | NO | No postinstall hooks, Python dependency |
+| MCP server alongside plugin | YES | User installs Serena separately, skills reference its tools |
+| Skills that gracefully use Serena | YES | Best approach -- detect availability, fall back to built-in tools |
+| Replace built-in LSP with Serena | MAYBE | Serena is more powerful but adds setup friction |
+
+### Bottom Line
+
+Serena is a powerful tool that provides genuine capabilities beyond what Claude Code offers natively. However, it is a **separate MCP server** requiring its own installation and setup. For fhhs-skills, the pragmatic path is:
+
+1. Skills can reference Serena tools as "enhanced mode" when available
+2. Skills must always work WITHOUT Serena via fallback to built-in tools
+3. A setup/documentation skill can guide users through Serena installation
+4. Serena and Fallow are complementary -- together they cover code understanding AND code health
+
+---
+
+## 11. Sources
+
+### Primary (HIGH confidence)
+
+- [Serena GitHub Repository](https://github.com/oraios/serena)
+- [Serena Official Documentation](https://oraios.github.io/serena/)
+- [Serena Tools Reference](https://oraios.github.io/serena/01-about/035_tools.html)
+- [DeepWiki: Serena Language Server Integration](https://deepwiki.com/oraios/serena/6-language-server-integration)
+- [DeepWiki: Serena Configuration and Workflow Tools](https://deepwiki.com/oraios/serena/5.5-configuration-and-workflow-tools)
+- [GitHub Issue #858: Claude Code built-in LSP overlap](https://github.com/oraios/serena/issues/858)
+
+### Secondary (MEDIUM confidence)
+
+- [ClaudeLog: Serena + Claude Code Setup](https://claudelog.com/claude-code-mcps/serena/)
+- [SmartScope: Serena MCP Setup Guide](https://smartscope.blog/en/generative-ai/claude/serena-mcp-implementation-guide/)
+- [SmartScope: Serena MCP Coding Agent Overview](https://smartscope.blog/en/generative-ai/claude/serena-mcp-coding-agent/)
+- [GitHub Discussion #219: Claude Code + Serena Workflow](https://github.com/oraios/serena/discussions/219)
+- [GitHub Discussion #380: Security Audit](https://github.com/oraios/serena/discussions/380)
+
+### Tertiary (LOW confidence)
+
+- [DEV Community: Serena MCP Tutorial](https://dev.to/webdeveloperhyper/how-to-use-ai-more-efficiently-for-free-serena-mcp-5gj6)
+- [PulseMCP: Serena Server Page](https://www.pulsemcp.com/servers/oraios-serena)

--- a/.planning/upstream/DEEP-AUDIT-2026-03-25.md
+++ b/.planning/upstream/DEEP-AUDIT-2026-03-25.md
@@ -1,0 +1,354 @@
+# Deep Upstream Capability Audit — 2026-03-25
+
+## Executive Summary
+
+This audit examines **6 upstream sources** containing **~80 distinct capabilities** (skills, agents, workflows, references). Of these, only **~15 are actively wired** into fhhs-skills execution paths. Another **~12 are conditionally available** but rarely triggered. The remaining **~53 are dead weight** — shipped or imported but never referenced in any pipeline.
+
+The most critical finding is significant **capability overlap** between GSD and Superpowers in research/planning/execution, with each taking a fundamentally different approach. Understanding these differences is key to deciding which to lean on.
+
+---
+
+## Part 1: The Research/Planning/Brainstorming Overlap
+
+### The Core Question: GSD vs Superpowers for thinking-before-coding
+
+Both systems solve the same problem ("don't jump into code without thinking") but with very different philosophies:
+
+| Dimension | GSD | Superpowers |
+|-----------|-----|-------------|
+| **Philosophy** | Process-heavy, agent-orchestrated, verification-driven | Discipline-heavy, human-guided, trust-the-engineer |
+| **Research** | 4 parallel researcher agents → synthesis → roadmap | Single conversation with web/doc search → writeup |
+| **Brainstorming** | `discuss-phase` → CONTEXT.md (locked decisions + discretion) | `brainstorming` → Socratic dialogue → design doc |
+| **Planning** | Planner agent → plan-checker agent → executor agent | `writing-plans` → human review → `executing-plans` |
+| **Execution** | Atomic commits, deviation rules, checkpoint protocol | Batch execution with human gates, or subagent-per-task |
+| **Verification** | Goal-backward verifier + Nyquist auditor + integration checker | `verification-before-completion` (run command, read output, claim) |
+| **Scale** | Large projects (multi-phase, multi-milestone) | Feature-sized work (single plan, single branch) |
+
+### Deep Comparison: Research
+
+**GSD `gsd-phase-researcher`**
+- Spawned as subagent with full tool access (web search, doc fetch)
+- Produces structured RESEARCH.md with: standard stack, architecture patterns, pitfalls, code examples, validation architecture
+- Honors locked decisions from CONTEXT.md — won't re-litigate
+- Runs before EVERY phase, not just project start
+- Also has `gsd-project-researcher` (4 parallel agents for initial project research covering stack, features, architecture, pitfalls)
+
+**Superpowers `research` (via fhhs `/fh:research`)**
+- Simple web + doc search → written summary
+- No structured output format
+- No decision-locking mechanism
+- Single-shot, not phase-aware
+
+**fhhs current usage:** `/fh:plan-work` Step 1 optionally invokes research. The GSD research infrastructure (phase researcher, project researcher, synthesizer) is **not wired** — fhhs uses a simplified research step instead.
+
+**Assessment:** GSD research is far more thorough but heavyweight. For a skills plugin project, the simpler Superpowers-style research is likely sufficient. The GSD research apparatus makes sense for greenfield apps, not for a plugin repo where you already know the stack.
+
+### Deep Comparison: Brainstorming / Discussion
+
+**GSD `discuss-phase`**
+- Structured workshop producing CONTEXT.md
+- Three output categories: **Locked decisions** (Claude must follow), **Discretion** (Claude decides within bounds), **Deferred** (track for later)
+- References `questioning.md` for elicitation techniques
+- Designed for consequential architectural decisions
+
+**Superpowers `brainstorming`**
+- Socratic dialogue: explore context → ask questions one-at-a-time → propose 2-3 approaches → present design → get approval → write design doc
+- Hard gate: NO code without approved design
+- Produces a design document saved to `docs/plans/`
+- Transitions directly to `writing-plans`
+
+**fhhs current usage:** `/fh:plan-work` references brainstorming in Step 2. The GSD discuss-phase is **not wired** at all.
+
+**Assessment:** Both are valuable but serve different moments. Brainstorming is for "what should we build and how?" Discussion is for "we know what to build, what decisions need to be locked?" fhhs currently only uses the brainstorming side. The discussion/decision-locking pattern would add value for larger features where you want to prevent Claude from re-deciding things across sessions.
+
+### Deep Comparison: Planning
+
+**GSD `gsd-planner`**
+- Goal-backward: starts from "what must be TRUE?" → derives tasks
+- Produces structured PLAN.md with frontmatter (phase, wave, dependencies, must_haves)
+- Each task has: Files, Action, Verify, Done
+- TDD-aware with RED/GREEN/REFACTOR phases
+- Verified by `gsd-plan-checker` before execution
+
+**Superpowers `writing-plans`**
+- Break design into bite-sized tasks (2-5 min each)
+- Each task has: exact file paths, complete code snippets, test commands, verification steps
+- Output to `docs/plans/YYYY-MM-DD-<feature>.md`
+- Requires plan approval before execution
+
+**fhhs current usage:** `/fh:plan-work` uses its own planning format that draws from both — GSD-style phase awareness with Superpowers-style task granularity.
+
+**Assessment:** The fhhs hybrid is likely the right call. Pure GSD planning is too heavy for plugin work. Pure Superpowers planning lacks phase awareness. The current blend works.
+
+### Deep Comparison: Execution
+
+**GSD `gsd-executor`**
+- Atomic commits per task
+- Deviation rules: auto-fix bugs (Rule 1-3), gate architectural changes (Rule 4)
+- Checkpoint protocol for human verification
+- Context management and continuation support
+- State tracking in STATE.md
+
+**Superpowers `executing-plans`**
+- Batch model (default 3 tasks at a time)
+- Human checkpoint between batches
+- Requires git worktree isolation
+- Companion: `subagent-driven-development` (fresh agent per task + two-stage review)
+
+**fhhs current usage:** `/fh:build` uses its own execution model that dispatches subagents per task, incorporates spec-gate review, and design gates. It's closer to Superpowers' subagent model but with GSD-style state tracking.
+
+**Assessment:** The fhhs build pipeline is already the best of both worlds. The Superpowers `subagent-driven-development` pattern (fresh agent per task) is what `/fh:build` actually implements.
+
+---
+
+## Part 2: Complete Capability Map with Usage Status
+
+### Legend
+- **ACTIVE**: Referenced in main execution paths, regularly triggered
+- **CONDITIONAL**: Wired but only triggers under specific conditions
+- **SUGGESTED**: Mentioned in output/recommendations but not auto-invoked
+- **INTERNAL**: Referenced by other internal skills only
+- **DEAD**: Imported/shipped but never referenced in any pipeline
+
+---
+
+### SUPERPOWERS (4.3.1) — Development Discipline System
+
+| Capability | Type | What It Does | Value Proposition | Status in fhhs |
+|-----------|------|-------------|-------------------|----------------|
+| **brainstorming** | Skill | Socratic design dialogue → approved design doc | Prevents coding without thinking; forces exploration of alternatives | **ACTIVE** — wired in `/fh:plan-work` Step 2 |
+| **writing-plans** | Skill | Break design into 2-5min tasks with exact paths/code/tests | Eliminates ambiguity; makes tasks parallelizable | **INTERNAL** — feeds executing-plans |
+| **executing-plans** | Skill | Batch execution (3 tasks) with human checkpoints | Controlled execution with review gates | **INTERNAL** — alternative to subagent model |
+| **subagent-driven-development** | Skill | Fresh agent per task + two-stage review (spec then quality) | Prevents context pollution; enables parallel work | **DEAD** — pattern absorbed into `/fh:build` but skill itself unused |
+| **dispatching-parallel-agents** | Skill | Identify independent domains → one agent per domain | Saves time on multi-domain problems | **ACTIVE** — wired in `/fh:build` |
+| **test-driven-development** | Skill | RED-GREEN-REFACTOR enforcement with rationalization barriers | Prevents untested code; catches design issues early | **ACTIVE** — wired in build, fix, plan-work |
+| **systematic-debugging** | Skill | 4-phase root cause methodology: investigate → analyze → hypothesize → implement | Prevents symptom-fixing; ensures real fixes | **ACTIVE** — wired in `/fh:fix` |
+| **verification-before-completion** | Skill | Run verification commands before claiming success | Prevents false completion claims | **DEAD** — never referenced in any pipeline |
+| **requesting-code-review** | Skill | When/how to dispatch code-reviewer subagent | Catches issues early with structured review | **DEAD** — pattern exists in build but skill unused |
+| **receiving-code-review** | Skill | Technical rigor when processing review feedback (no performative agreement) | Prevents blind implementation of bad suggestions | **DEAD** — never referenced |
+| **using-superpowers** | Skill | Meta-skill: check skills before any action | Ensures skill system is used | **DEAD** — fhhs has its own skill dispatch |
+| **using-git-worktrees** | Skill | Create isolated git worktrees with safety checks | Enables parallel branch work | **INTERNAL** — referenced in executing-plans |
+| **finishing-a-development-branch** | Skill | Verify tests → present merge/PR/keep/discard options → cleanup | Structured branch completion | **CONDITIONAL** — referenced in `/fh:review` |
+| **writing-skills** | Skill | TDD for skill creation: write failing test → write skill → close loopholes | Quality skill authoring | **DEAD** — never referenced |
+| **simplify** | Skill | Review changed code for reuse, quality, efficiency | Catches duplication and anti-patterns post-implementation | **ACTIVE** — wired in build, fix, refactor |
+| **code-reviewer** | Agent | Senior reviewer: plan alignment + code quality + architecture + docs | Structured review with severity ratings | **ACTIVE** — used in build spec-gate and review |
+
+**Superpowers summary: 16 capabilities → 6 ACTIVE, 2 INTERNAL, 2 CONDITIONAL, 6 DEAD**
+
+---
+
+### GSD (1.22.4) — Project Orchestration System
+
+| Capability | Type | What It Does | Value Proposition | Status in fhhs |
+|-----------|------|-------------|-------------------|----------------|
+| **gsd-codebase-mapper** | Agent | Explores and documents codebase → STACK/ARCHITECTURE/CONVENTIONS.md | Provides context for planners without token waste | **ACTIVE** — exposed as `/fh:map-codebase` |
+| **gsd-phase-researcher** | Agent | Domain investigation per phase → RESEARCH.md | Verified current knowledge, not stale training data | **DEAD** — fhhs uses simpler research |
+| **gsd-planner** | Agent | Goal-backward planning → structured PLAN.md | Ensures plans achieve outcomes, not just tasks | **DEAD** — fhhs uses own planning format |
+| **gsd-plan-checker** | Agent | Verify plans before execution: coverage, deps, scope, Nyquist | Quality gate preventing bad plans | **DEAD** — fhhs uses `/fh:plan-review` instead |
+| **gsd-executor** | Agent | Atomic execution with deviation rules and checkpoints | Reliable execution with automatic bug-fixing | **DEAD** — fhhs uses own build pipeline |
+| **gsd-debugger** | Agent | Scientific method debugging with persistent sessions | Survives context resets; captures reasoning | **DEAD** — fhhs uses systematic-debugging from Superpowers |
+| **gsd-verifier** | Agent | Goal-backward verification: exists → substantive → wired | Catches stubs, unwired code, incomplete implementations | **DEAD** — not wired |
+| **gsd-nyquist-auditor** | Agent | Generate tests for unverified requirements | Ensures test coverage for all requirements | **DEAD** — not wired |
+| **gsd-integration-checker** | Agent | Cross-phase wiring and E2E flow verification | Catches architectural breaks between phases | **DEAD** — not wired |
+| **gsd-research-synthesizer** | Agent | Combine 4 parallel researcher outputs → SUMMARY.md | Unified research for roadmapping | **DEAD** — not wired |
+| **gsd-roadmapper** | Agent | Requirements → phases → success criteria → roadmap | Foundation for project execution | **DEAD** — fhhs uses own roadmap format |
+| **gsd-project-researcher** | Agent | 4 parallel domain researchers (stack, features, arch, pitfalls) | Deep initial project understanding | **DEAD** — not wired |
+| **new-project** | Workflow | Full project bootstrap: research → roadmap → initial phase | Complete project setup | Used as basis for `/fh:new-project` |
+| **progress** | Workflow | Show current phase status and next steps | Quick status check | Used as basis for `/fh:progress` |
+| **health** | Workflow | Validate .planning/ integrity | Catch corrupted state | Used as basis for `/fh:health` |
+| **38 workflows total** | Workflows | Phase lifecycle, troubleshooting, monitoring, management | Full project orchestration | ~5 actively used, ~33 dead |
+| **16 references** | References | Checkpoints, TDD, verification patterns, git integration | Shared knowledge for agents | Referenced by dead agents |
+| **61 templates** | Templates | Structured output formats for all deliverables | Consistent documentation | Used by gsd-tools.cjs |
+
+**GSD summary: ~80 capabilities → ~5 actively surfaced, ~75 dead (agent/workflow infrastructure largely unused)**
+
+---
+
+### IMPECCABLE (1.2.0) — Design Quality System
+
+| Capability | Type | What It Does | Value Proposition | Status in fhhs |
+|-----------|------|-------------|-------------------|----------------|
+| **frontend-design** | Skill | Core design skill: typography, color, layout, motion, interaction, responsive, UX writing + anti-patterns | Eliminates generic AI aesthetics; teaches design vocabulary | **ACTIVE** — wired in build and fix |
+| **ui-critique** | Command | UX director review: visual hierarchy, information architecture, emotional resonance | Evaluates whether design WORKS, not just looks correct | **CONDITIONAL** — in build design gates |
+| **polish** | Command | Final quality pass: alignment, spacing, typography, states, transitions, copy | Separates good from great; 20-point checklist | **CONDITIONAL** — in build design gates |
+| **normalize** | Command | Align with design system: replace one-offs, apply tokens consistently | Enforces systematic consistency | **CONDITIONAL** — in build design gates |
+| **ui-animate** | Command | Add purposeful motion with choreography and staggering | Polished feel through motion design | **CONDITIONAL** — in build design gates |
+| **audit** | Command | Systematic checks: a11y, performance, theming, responsive, anti-patterns | Documents all issues with severity and remediation | **DEAD** — shipped but never auto-invoked |
+| **harden** | Command | Edge cases: text overflow, i18n, RTL, network errors, large datasets | Production resilience | **DEAD** |
+| **optimize** | Command | Performance: images, bundles, animations, rendering, Core Web Vitals | Speed and smoothness | **DEAD** |
+| **distill** | Command | Strip to essence: remove unnecessary complexity | Design simplicity | **DEAD** |
+| **clarify** | Command | Improve unclear copy, labels, error messages | UX writing quality | **DEAD** |
+| **colorize** | Command | Add strategic color to monochromatic interfaces | Visual interest via OKLCH | **DEAD** |
+| **bolder** | Command | Amplify safe/boring designs with visual impact | Design confidence | **DEAD** |
+| **quieter** | Command | Tone down overly aggressive designs | Design restraint | **DEAD** |
+| **delight** | Command | Add moments of joy, personality, unexpected touches | Emotional engagement | **DEAD** |
+| **extract** | Command | Consolidate reusable patterns into design system | Systematic reuse | **DEAD** |
+| **adapt** | Command | Redesign for different contexts (mobile, tablet, desktop, etc.) | Multi-context support | **DEAD** |
+| **onboard** | Command | Design first-time user experiences and empty states | User activation | **DEAD** |
+| **ui-redesign** | Command | Change look and feel; update design guidelines | Design direction | **DEAD** |
+| **teach-impeccable** | Command | One-time setup: gather design context → save to CLAUDE.md | Persistent design preferences | Exposed as `/fh:ui-branding` |
+
+**Impeccable summary: 19 capabilities → 1 ACTIVE, 4 CONDITIONAL, 14 DEAD**
+
+---
+
+### OTHER UPSTREAMS
+
+| Source | Capabilities | What It Provides | Status in fhhs |
+|--------|-------------|-----------------|----------------|
+| **feature-dev** | 3 agents (explorer, architect, reviewer) | Structured feature dev: explore → design 3 approaches → implement → review | **ACTIVE** — agents used in brainstorming and build |
+| **gstack** (0.3.3) | 8 skills (browse, qa, review, plan-ceo-review, plan-eng-review, ship, retro, setup-browser-cookies) | Browser automation for QA, founder/eng review modes, release management | **PARTIAL** — qa/browse partially wired via `/fh:ui-test`, rest DEAD |
+| **claude-md-management** (1.0.0) | 2 skills (claude-md-improver, revise-claude-md) | CLAUDE.md auditing and session learning capture | **ACTIVE** — both wired |
+| **playwright-best-practices** | 1 skill + 35 references | Comprehensive Playwright testing guidance for all scenarios | **CONDITIONAL** — wired in build/fix/plan-work |
+| **vercel-react-best-practices** | 1 skill + 58 rules | React/Next.js performance optimization | **DEAD** — shipped but not wired in any pipeline |
+
+---
+
+## Part 3: What's Actually Valuable vs Dead Weight
+
+### Tier 1: Actively Earning Their Keep
+These are wired into execution paths and provide clear value:
+
+1. **brainstorming** (Superpowers) — prevents coding without thinking
+2. **test-driven-development** (Superpowers) — prevents untested code
+3. **systematic-debugging** (Superpowers) — prevents symptom-fixing
+4. **simplify** (Superpowers) — catches post-implementation issues
+5. **dispatching-parallel-agents** (Superpowers) — enables parallel work
+6. **frontend-design** (Impeccable) — design quality for frontend
+7. **code-explorer/architect/reviewer** (feature-dev) — structured feature work
+8. **gsd-codebase-mapper** (GSD) — codebase documentation
+9. **gsd-tools.cjs** (GSD) — state management infrastructure
+10. **claude-md-improver/revise-claude-md** (claude-md-management) — project memory
+
+### Tier 2: Conditionally Valuable
+These trigger under specific conditions and add value when they do:
+
+1. **ui-critique/polish/normalize/ui-animate** (Impeccable) — design gates in visual-heavy builds
+2. **playwright-testing** — E2E test guidance when interactive features involved
+3. **finishing-a-development-branch** (Superpowers) — branch completion workflow
+4. **plan-review** (gstack-influenced) — stress-testing plans before build
+
+### Tier 3: Valuable Ideas, Not Wired
+These have real value but aren't connected to any pipeline:
+
+1. **verification-before-completion** (Superpowers) — should be in build/fix pipelines
+2. **GSD verifier** — goal-backward verification is powerful but unused
+3. **GSD integration-checker** — cross-phase wiring checks, valuable for larger projects
+4. **harden** (Impeccable) — production resilience is always valuable
+5. **audit** (Impeccable) — comprehensive quality checks worth auto-triggering
+6. **receiving-code-review** (Superpowers) — technical rigor in processing feedback
+
+### Tier 4: Dead Weight (Consider Removing from Shipped Plugin)
+These add token cost when loaded but provide no automated value:
+
+1. **distill, bolder, quieter, delight, colorize, extract, onboard, adapt** (Impeccable) — niche design commands rarely invoked manually
+2. **ui-redesign** (Impeccable) — too broad, rarely useful
+3. **vercel-react-best-practices** — not wired anywhere
+4. **gstack review/ship/retro/plan-ceo-review/plan-eng-review** — gstack's non-browse skills are unused
+5. **using-superpowers** — meta-skill for Superpowers users, not fhhs users
+6. **writing-skills** — skill authoring skill, only useful for plugin developers (you)
+7. **subagent-driven-development** — pattern absorbed into `/fh:build`
+8. **requesting-code-review** — pattern exists in build but skill itself unused
+
+---
+
+## Part 4: Specific Overlap Analysis
+
+### Research Capabilities (3-way overlap)
+
+```
+GSD Phase Researcher    → Heavy: 4 parallel agents, structured RESEARCH.md, domain-deep
+Superpowers Research    → Light: web search + doc fetch → summary
+fhhs /fh:research      → Light: based on Superpowers pattern
+
+GSD Project Researcher  → Heavy: stack + features + architecture + pitfalls (parallel)
+fhhs /fh:plan-work     → Inline: optional research step before brainstorming
+```
+
+**Verdict:** The light approach is right for fhhs. GSD's research apparatus is designed for greenfield projects where you don't know the stack yet. For a plugin repo, you know the stack.
+
+### Brainstorming/Discussion (2-way overlap)
+
+```
+Superpowers Brainstorming → "What should we build?" → Design doc → Plans
+GSD Discuss-Phase         → "How should we build it?" → CONTEXT.md (locked decisions)
+fhhs /fh:plan-work       → Uses brainstorming, skips discuss-phase
+```
+
+**Verdict:** Both are useful but at different moments. Brainstorming explores the solution space. Discussion locks decisions for execution. fhhs would benefit from a "lock decisions" step for multi-session features.
+
+### Planning (3-way overlap)
+
+```
+GSD Planner         → Goal-backward, agent-verified, phase-aware, TDD-integrated
+Superpowers Plans   → Task-granular (2-5 min), exact paths/code, human-reviewed
+fhhs /fh:plan-work → Hybrid: phase-aware + task-granular
+```
+
+**Verdict:** The fhhs hybrid works. The GSD plan-checker concept (verify plans before execution) is valuable and partially implemented via `/fh:plan-review`.
+
+### Execution (3-way overlap)
+
+```
+GSD Executor              → Atomic commits, deviation rules (1-4), checkpoints
+Superpowers Executing     → Batch (3 tasks), human gates, git worktree
+Superpowers Subagent-Dev  → Fresh agent per task, two-stage review
+fhhs /fh:build            → Subagent per task, spec-gate, design gates
+```
+
+**Verdict:** fhhs build already incorporates the best patterns from all three.
+
+### Code Review (3-way overlap)
+
+```
+Superpowers code-reviewer  → Plan alignment + code quality (agent definition)
+Feature-dev code-reviewer  → Bugs + quality + convention compliance (agent definition)
+GStack review              → Greptile-integrated, paranoid review mode
+fhhs /fh:review            → Combines feature-dev reviewer + spec-gate from build
+```
+
+**Verdict:** fhhs review is well-composed. The Greptile integration from gstack could add value if the user has Greptile access.
+
+### Debugging (2-way overlap)
+
+```
+GSD Debugger             → Scientific method, persistent sessions, parallel UAT
+Superpowers Debugging    → 4-phase root cause methodology, defense-in-depth
+fhhs /fh:fix             → Uses Superpowers systematic-debugging
+```
+
+**Verdict:** GSD debugger has one advantage: persistent debug sessions that survive `/clear`. This is valuable for complex bugs. The Superpowers approach is simpler and sufficient for most cases.
+
+### Verification (2-way overlap)
+
+```
+GSD Verifier             → Goal-backward (exists → substantive → wired), re-verification mode
+GSD Nyquist Auditor      → Generate tests for unverified requirements
+Superpowers Verification → Run command, read output, verify claim matches
+fhhs                     → No explicit verification step in pipeline
+```
+
+**Verdict:** This is a **gap in fhhs**. Neither the simple Superpowers verification nor the heavy GSD verifier is wired. At minimum, verification-before-completion should be injected into build and fix pipelines.
+
+---
+
+## Part 5: Recommendations
+
+### Wire Now (High Value, Low Effort)
+1. **Add verification-before-completion** to `/fh:build` final step and `/fh:fix` final step — prevents false success claims
+2. **Add audit** (Impeccable) as optional step in `/fh:build` for frontend work — catches a11y/performance issues
+3. **Add harden** (Impeccable) to `/fh:build` for frontend features — production resilience
+
+### Consider Wiring (Medium Value)
+4. **GSD discuss-phase pattern** → Add a "lock decisions" step to `/fh:plan-work` for multi-session features
+5. **GSD verifier pattern** → Add goal-backward check to `/fh:build` completion: "did we achieve what the plan said?"
+6. **receiving-code-review** → Inject into `/fh:review` when processing external feedback
+
+### Consider Removing from Shipped Plugin (Reduce Token Cost)
+7. **12 dead Impeccable commands** (distill, bolder, quieter, delight, colorize, extract, onboard, adapt, optimize, clarify, ui-redesign) — keep in upstream, remove from shipped `.claude/skills/` unless you want them available for manual invocation
+8. **vercel-react-best-practices** — not wired; keep in upstream for reference but don't ship
+9. **gstack non-browse skills** — review, ship, retro, plan-ceo-review, plan-eng-review are unused
+
+### Keep as Reference Only
+10. **GSD agent definitions and templates** — valuable as patterns even if not directly wired. The goal-backward thinking and verification patterns inform better skill design.
+11. **writing-skills** (Superpowers) — valuable when YOU are authoring skills, even if not shipped to users

--- a/.planning/upstream/claude-md-management.md
+++ b/.planning/upstream/claude-md-management.md
@@ -24,40 +24,33 @@ upstream/claude-md-management-1.0.0/
             └── update-guidelines.md              ← revision methodology
 ```
 
-## Capability Flow Diagram
+## Deep Capability Description
 
-```
-                CLAUDE-MD-MANAGEMENT WORKFLOW
-
-  ┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
-  │  READ EXISTING   │───▶│  ASSESS QUALITY  │───▶│  APPLY UPDATES  │
-  │  CLAUDE.md       │    │  (quality-       │    │  (update-       │
-  │                  │    │   criteria.md)   │    │   guidelines.md)│
-  └─────────────────┘    └──────────────────┘    └────────┬────────┘
-                                                          │
-                                                 ┌────────▼────────┐
-                                                 │ OUTPUT IMPROVED  │
-                                                 │ CLAUDE.md        │
-                                                 │ (templates.md)   │
-                                                 └─────────────────┘
-```
+| Skill | What It Actually Does | Value Proposition | fhhs Usage |
+|-------|----------------------|-------------------|------------|
+| **claude-md-improver** | Audits CLAUDE.md files against quality criteria: commands/workflows documented?, architecture clarity?, non-obvious patterns captured?, conciseness?, currency?, actionability?. Scores A-F with targeted improvement recommendations. Uses templates by project type (library, app, monorepo, etc.) and structured update guidelines for revision methodology. | Transforms CLAUDE.md maintenance from guesswork into a repeatable, quality-scored process. Prevents knowledge staleness. | **ACTIVE** — forked as internal skill + exposed as `/fh:revise-claude-md`. Quality criteria and templates actively used. |
 
 ## Skills Table
 
-| Skill | SDLC Phase | Quality | Status | fhhs Equivalent | Notes |
-|-------|-----------|---------|--------|-----------------|-------|
-| claude-md-improver | Knowledge | B | ✅ Forked | skills/claude-md-improver/ + /fh:revise-claude-md | Quality-driven CLAUDE.md revision |
+| Skill | SDLC Phase | Quality | Pipeline Status | fhhs Equivalent | Notes |
+|-------|-----------|---------|----------------|-----------------|-------|
+| claude-md-improver | Knowledge | B | ✅ **Active** | skills/claude-md-improver/ + /fh:revise-claude-md | Quality-driven revision |
 
 ## Supporting Assets Table
 
 | Asset | Type | Used by | Status | Notes |
 |-------|------|---------|--------|-------|
-| references/quality-criteria.md | Reference | claude-md-improver | ✅ Forked | Quality assessment rubric |
-| references/templates.md | Reference | claude-md-improver | ✅ Forked | CLAUDE.md structure templates |
-| references/update-guidelines.md | Reference | claude-md-improver | ✅ Forked | Revision methodology |
-| commands/revise-claude-md.md | Command | Entry point | ✅ Forked | /fh:revise-claude-md |
-| *.png (2 screenshots) | Images | Documentation | 🚫 N/A | Usage examples |
+| references/quality-criteria.md | Reference | claude-md-improver | ✅ Active | Quality assessment rubric |
+| references/templates.md | Reference | claude-md-improver | ✅ Active | CLAUDE.md structure templates |
+| references/update-guidelines.md | Reference | claude-md-improver | ✅ Active | Revision methodology |
+| commands/revise-claude-md.md | Command | Entry point | ✅ Active | /fh:revise-claude-md |
 
 ## Assessment
 
-claude-md-management is small but fully integrated. The skill and all three reference documents are forked into fhhs as both an internal skill (skills/claude-md-improver/) and a user-facing command (/fh:revise-claude-md). The quality-criteria and update-guidelines references are the most valuable assets — they provide a structured framework for what is otherwise an unstructured task. No integration gaps exist; this upstream is 100% absorbed.
+Fully integrated, no gaps. The skill and all three reference documents are forked and actively used. The quality-criteria and update-guidelines references are the most valuable assets — they provide structured framework for what is otherwise an unstructured task.
+
+### Recommendations
+
+| Priority | Action | Impact |
+|----------|--------|--------|
+| **None** | No changes needed | 100% integrated |

--- a/.planning/upstream/feature-dev.md
+++ b/.planning/upstream/feature-dev.md
@@ -40,26 +40,48 @@ upstream/feature-dev-55b58ec6/
                                   (Task agent)
 ```
 
+## Deep Capability Descriptions
+
+| Agent | What It Actually Does | Value Proposition | fhhs Usage |
+|-------|----------------------|-------------------|------------|
+| **code-explorer** | Traces execution paths through codebase, identifies key files for a given feature area, maps dependencies and call chains, surfaces hidden complexity. Dispatched as subagent to investigate before planning. | Prevents planning based on assumptions. "What does the code actually do?" before "What should we change?" | **ACTIVE** — dispatched in `/fh:build` brainstorming phase (line 65) and by other skills for codebase understanding. |
+| **code-architect** | Designs 3 implementation approaches (minimal, clean, pragmatic) for a given feature. Evaluates tradeoffs, identifies risks, recommends approach. Dispatched as subagent to propose design before implementation. | Prevents single-approach thinking. Forces consideration of alternatives and tradeoffs. The three-approach model is well-calibrated. | **ACTIVE** — dispatched in brainstorming phase (line 71) for architecture design. |
+| **code-reviewer** | Reviews completed work for: bugs, quality issues, convention compliance, security concerns, performance implications. Structured output with severity ratings. | Systematic review that goes beyond "looks good." Convention compliance catching is especially valuable. | **ACTIVE** — dispatched in `/fh:build` spec-gate and `/fh:review` for quality checks. |
+
 ## Skills Table
 
-| Skill | SDLC Phase | Quality | Status | fhhs Equivalent | Notes |
-|-------|-----------|---------|--------|-----------------|-------|
-| feature-dev (workflow) | Full lifecycle | B | 🔀 Partial | Patterns absorbed into /fh:build | 7-phase feature workflow |
+| Skill | SDLC Phase | Quality | Pipeline Status | fhhs Equivalent | Notes |
+|-------|-----------|---------|----------------|-----------------|-------|
+| feature-dev (workflow) | Full lifecycle | B | 🔀 Pattern absorbed | Patterns in /fh:build | 7-phase workflow replaced by GSD |
 
 ## Subagent Definitions Table
 
 | Agent | Purpose | Dispatched by | Quality | Status | Notes |
 |-------|---------|---------------|---------|--------|-------|
-| code-explorer | Codebase exploration & understanding | feature-dev (phase 1) | B | ✅ Forked | agents/code-explorer.md |
-| code-architect | Architecture & design decisions | feature-dev (phase 2) | B | ✅ Forked | agents/code-architect.md |
-| code-reviewer | Code review & quality checks | feature-dev (phase 5) | B | ✅ Forked | agents/code-reviewer.md |
-
-## Supporting Assets Table
-
-| Asset | Type | Used by | Status | Notes |
-|-------|------|---------|--------|-------|
-| commands/feature-dev.md | Command | Root command | 🔀 Partial | Workflow absorbed into composites |
+| code-explorer | Codebase exploration | /fh:build brainstorming, general use | B | ✅ **Active** | agents/code-explorer.md |
+| code-architect | Architecture design | /fh:build brainstorming | B | ✅ **Active** | agents/code-architect.md |
+| code-reviewer | Code quality review | /fh:build spec-gate, /fh:review | B | ✅ **Active** | agents/code-reviewer.md |
 
 ## Assessment
 
-feature-dev's primary value lies in its three agent personas rather than its workflow command. The code-explorer, code-architect, and code-reviewer agents are all integrated into fhhs's agents/ directory and dispatched by composite skills like /fh:build and /fh:review. The 7-phase workflow itself has been absorbed into fhhs's more sophisticated GSD-backed execution model rather than being exposed as a standalone command. This is the right trade-off: the agents are reusable building blocks while the workflow was too rigid for fhhs's flexible pipeline model.
+feature-dev's primary value lies entirely in its three agent personas. All three are actively used in fhhs's core pipelines.
+
+### What's Working
+
+All three agents are well-integrated:
+- **code-explorer** provides codebase understanding before planning
+- **code-architect** provides multi-approach design exploration
+- **code-reviewer** provides structured quality review
+
+The workflow itself was correctly absorbed into fhhs's more sophisticated GSD-backed execution model rather than being exposed as a standalone command.
+
+### Integration Opportunity for plan-work
+
+The code-explorer agent could be more systematically used in `/fh:plan-work` when the user is working in an unfamiliar codebase. Currently, brainstorming references it but the exploration is optional. For complex plans in unfamiliar codebases, explicit code-explorer dispatch should be suggested to the user.
+
+### Recommendations
+
+| Priority | Action | Impact |
+|----------|--------|--------|
+| **Medium** | Suggest code-explorer dispatch in `/fh:plan-work` for unfamiliar codebases | Better plans from better codebase understanding |
+| **None** | No other changes needed | All agents fully integrated |

--- a/.planning/upstream/playwright-best-practices.md
+++ b/.planning/upstream/playwright-best-practices.md
@@ -51,63 +51,30 @@ upstream/playwright-best-practices-b4b0fd3c/
     └── websockets.md                             ← WebSocket testing
 ```
 
-## Capability Flow Diagram
+## Deep Capability Description
 
-```
-              PLAYWRIGHT-BEST-PRACTICES REFERENCE ARCHITECTURE
-
-  ┌─────────────────────────────────────────────────────────────────┐
-  │                    UPSTREAM-SKILL.md (master)                    │
-  │        Routes to appropriate reference based on context          │
-  └──────────────────────────┬──────────────────────────────────────┘
-                             │
-          ┌──────────────────┼──────────────────────┐
-          │                  │                      │
-  ┌───────┴───────┐  ┌──────┴──────┐  ┌────────────┴──────────────┐
-  │  FOUNDATIONS  │  │  PATTERNS   │  │  ADVANCED SCENARIOS       │
-  ├───────────────┤  ├─────────────┤  ├───────────────────────────┤
-  │ locators      │  │ page-object │  │ multi-user                │
-  │ assertions-   │  │ fixtures-   │  │ multi-context             │
-  │   waiting     │  │   hooks     │  │ iframes                   │
-  │ test-org      │  │ test-data   │  │ browser-extensions        │
-  │ annotations   │  │ global-     │  │ canvas-webgl              │
-  │ debugging     │  │   setup     │  │ electron                  │
-  └───────────────┘  │ component-  │  │ service-workers           │
-                     │   testing   │  │ websockets                │
-  ┌───────────────┐  └─────────────┘  │ clock-mocking             │
-  │  QUALITY      │                   └───────────────────────────┘
-  ├───────────────┤  ┌─────────────┐
-  │ flaky-tests   │  │  OPS/CI     │
-  │ error-testing │  ├─────────────┤
-  │ console-      │  │ ci-cd       │
-  │   errors      │  │ performance │
-  │ accessibility │  │ perf-testing│
-  │ security-     │  │ test-       │
-  │   testing     │  │   coverage  │
-  │ i18n          │  │ network-    │
-  └───────────────┘  │   advanced  │
-                     │ file-ops    │
-                     │ browser-    │
-                     │   apis      │
-                     │ third-party │
-                     │ mobile-     │
-                     │   testing   │
-                     └─────────────┘
-```
+| Skill | What It Actually Does | Value Proposition | fhhs Usage |
+|-------|----------------------|-------------------|------------|
+| **playwright-best-practices** | Activity-based reference guide with decision trees. For any Playwright testing scenario, routes to the appropriate reference guide. Covers foundations (locators, assertions, fixtures), patterns (POM, test data, global setup), quality (flaky tests, error testing, a11y, security), ops (CI/CD, performance, coverage), and advanced scenarios (multi-user, WebSocket, Canvas/WebGL, Electron, browser extensions). 35 individual reference files, each a comprehensive guide for its topic. | Eliminates guessing about test design. Battle-tested patterns for every Playwright scenario. The depth per topic is exceptional — not "how to use locators" but "which locator strategy for which situation, with tradeoffs." | **CONDITIONAL** — wired in `/fh:build` Step 3 (conditional context injection for interactive features), `/fh:fix` Step 2 (when fixing test issues), `/fh:plan-work` Step 6 (E2E test warning for interactive features). Distilled from 35 guides into compact `/fh:playwright-testing`. |
 
 ## Skills Table
 
-| Skill | SDLC Phase | Quality | Status | fhhs Equivalent | Notes |
-|-------|-----------|---------|--------|-----------------|-------|
-| playwright-best-practices | Testing | A | ✅ Forked | /fh:playwright-testing (distilled) | 35 reference guides distilled |
+| Skill | SDLC Phase | Quality | Pipeline Status | fhhs Equivalent | Notes |
+|-------|-----------|---------|----------------|-----------------|-------|
+| playwright-best-practices | Testing | A | ✅ **Conditional** | /fh:playwright-testing (distilled) | 35 guides → compact skill |
 
 ## Supporting Assets Table
 
 | Asset | Type | Used by | Status | Notes |
 |-------|------|---------|--------|-------|
-| references/ (35 files) | Reference | playwright-best-practices | ✅ Forked | Distilled into /fh:playwright-testing |
-| All 35 individual reference files | Reference | Contextual lookup | ✅ Forked | Condensed from full guides |
+| references/ (35 files) | Reference | playwright-best-practices | ✅ Distilled | Condensed into /fh:playwright-testing |
 
 ## Assessment
 
-playwright-best-practices is the deepest single-topic reference in the upstream catalog. Its 35 guides cover Playwright testing with exceptional thoroughness. In fhhs, it is distilled into /fh:playwright-testing — the full 35-file reference set is condensed into a more compact skill that retains the essential patterns while fitting within Claude's context constraints. The distillation is well-executed but means some advanced scenarios (Electron testing, browser extensions, Canvas/WebGL) are less thoroughly covered in the fhhs version. No integration gaps — the upstream is fully leveraged, just compressed.
+Fully integrated via distillation. The 35-file reference set is condensed into a compact skill that retains essential patterns while fitting within Claude's context constraints. Some advanced scenarios (Electron, browser extensions, Canvas/WebGL) are less thoroughly covered in the fhhs version, but these are niche and rarely needed.
+
+### Recommendations
+
+| Priority | Action | Impact |
+|----------|--------|--------|
+| **None** | No changes needed | Fully integrated via distillation |

--- a/.planning/upstream/vercel-react-best-practices.md
+++ b/.planning/upstream/vercel-react-best-practices.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-vercel-react-best-practices is a performance optimization ruleset containing 58 specific rules for React and Next.js applications, organized by concern area (rendering, re-renders, bundling, async, server, client, JS fundamentals). Its philosophy is measurable performance: each rule is a concrete, actionable optimization with clear before/after patterns rather than abstract guidance. What makes it distinctive is its granularity — 58 individual rules that can be applied as a code review checklist or optimization sweep, making it the most rule-dense upstream in the catalog.
+vercel-react-best-practices is a performance optimization ruleset containing 58 specific rules for React and Next.js applications, organized by concern area (rendering, re-renders, bundling, async, server, client, JS fundamentals). Its philosophy is measurable performance: each rule is a concrete, actionable optimization with clear before/after patterns rather than abstract guidance. What makes it distinctive is its granularity — 58 individual rules that can be applied as a code review checklist or optimization sweep.
 
 ## File Tree
 
@@ -14,114 +14,50 @@ upstream/vercel-react-best-practices-64bee5b7/
 ├── README.md                                     ← project documentation
 ├── UPSTREAM-SKILL.md                             ← master skill (references all rules)
 └── rules/
-    ├── rendering-activity.md                     ← React Activity API
-    ├── rendering-animate-svg-wrapper.md          ← SVG animation wrapping
-    ├── rendering-conditional-render.md           ← conditional rendering
-    ├── rendering-content-visibility.md           ← CSS content-visibility
-    ├── rendering-hoist-jsx.md                    ← JSX hoisting
-    ├── rendering-hydration-no-flicker.md         ← hydration flicker prevention
-    ├── rendering-hydration-suppress-warning.md   ← hydration warning suppression
-    ├── rendering-svg-precision.md                ← SVG coordinate precision
-    ├── rendering-usetransition-loading.md        ← useTransition loading states
-    ├── rerender-defer-reads.md                   ← deferred DOM reads
-    ├── rerender-dependencies.md                  ← dependency optimization
-    ├── rerender-derived-state.md                 ← derived state patterns
-    ├── rerender-derived-state-no-effect.md       ← avoid effect for derived state
-    ├── rerender-functional-setstate.md           ← functional setState
-    ├── rerender-lazy-state-init.md               ← lazy state initialization
-    ├── rerender-memo.md                          ← React.memo usage
-    ├── rerender-memo-with-default-value.md       ← memo with defaults
-    ├── rerender-move-effect-to-event.md          ← effect → event handler
-    ├── rerender-simple-expression-in-memo.md     ← simple memo expressions
-    ├── rerender-transitions.md                   ← transition API
-    ├── rerender-use-ref-transient-values.md      ← useRef for transient values
-    ├── bundle-barrel-imports.md                  ← barrel import optimization
-    ├── bundle-conditional.md                     ← conditional bundling
-    ├── bundle-defer-third-party.md               ← third-party deferral
-    ├── bundle-dynamic-imports.md                 ← dynamic import splitting
-    ├── bundle-preload.md                         ← resource preloading
-    ├── async-api-routes.md                       ← async API route patterns
-    ├── async-defer-await.md                      ← defer/await patterns
-    ├── async-dependencies.md                     ← async dependency mgmt
-    ├── async-parallel.md                         ← parallel async ops
-    ├── async-suspense-boundaries.md              ← Suspense boundary placement
-    ├── server-after-nonblocking.md               ← non-blocking server patterns
-    ├── server-auth-actions.md                    ← auth action optimization
-    ├── server-cache-lru.md                       ← LRU cache patterns
-    ├── server-cache-react.md                     ← React cache API
-    ├── server-dedup-props.md                     ← prop deduplication
-    ├── server-hoist-static-io.md                 ← static I/O hoisting
-    ├── server-parallel-fetching.md               ← parallel data fetching
-    ├── server-serialization.md                   ← serialization optimization
-    ├── client-event-listeners.md                 ← event listener optimization
-    ├── client-localstorage-schema.md             ← localStorage schema
-    ├── client-passive-event-listeners.md         ← passive event listeners
-    ├── client-swr-dedup.md                       ← SWR deduplication
-    ├── js-batch-dom-css.md                       ← DOM/CSS batching
-    ├── js-cache-function-results.md              ← function result caching
-    ├── js-cache-property-access.md               ← property access caching
-    ├── js-cache-storage.md                       ← storage caching
-    ├── js-combine-iterations.md                  ← iteration combining
-    ├── js-early-exit.md                          ← early exit patterns
-    ├── js-hoist-regexp.md                        ← RegExp hoisting
-    ├── js-index-maps.md                          ← index map patterns
-    ├── js-length-check-first.md                  ← length check optimization
-    ├── js-min-max-loop.md                        ← min/max loop patterns
-    ├── js-set-map-lookups.md                     ← Set/Map lookup optimization
-    ├── js-tosorted-immutable.md                  ← immutable sorting
-    ├── advanced-event-handler-refs.md            ← event handler ref patterns
-    ├── advanced-init-once.md                     ← one-time initialization
-    └── advanced-use-latest.md                    ← useLatest hook pattern
+    ├── rendering-*       (9 rules)               ← React rendering optimization
+    ├── rerender-*        (12 rules)              ← re-render prevention
+    ├── bundle-*          (5 rules)               ← bundle size reduction
+    ├── async-*           (5 rules)               ← async pattern optimization
+    ├── server-*          (8 rules)               ← server component/action patterns
+    ├── client-*          (4 rules)               ← client-side optimization
+    ├── js-*              (12 rules)              ← vanilla JS performance
+    └── advanced-*        (3 rules)               ← advanced React patterns
 ```
 
-## Capability Flow Diagram
+## Deep Capability Description
 
-```
-             VERCEL-REACT-BEST-PRACTICES RULE CATEGORIES
-
-  ┌────────────────────────────────────────────────────────────────┐
-  │                  UPSTREAM-SKILL.md (master)                     │
-  │         Dispatches rules based on code context                  │
-  └──────────────────────────┬─────────────────────────────────────┘
-                             │
-     ┌───────────┬───────────┼───────────┬───────────┐
-     │           │           │           │           │
-  ┌──┴──┐    ┌──┴──┐    ┌──┴──┐    ┌──┴──┐    ┌──┴──┐
-  │RENDR│    │RERND│    │BUNDL│    │ASYNC│    │SERVR│
-  │(9)  │    │(12) │    │(5)  │    │(5)  │    │(8)  │
-  └─────┘    └─────┘    └─────┘    └─────┘    └─────┘
-
-  ┌───────────┬───────────┬───────────┐
-  │           │           │           │
-  ┌──┴──┐    ┌──┴──┐    ┌──┴──┐    ┌──┴──┐
-  │CLINT│    │JS   │    │ADVNC│    │     │
-  │(4)  │    │(12) │    │(3)  │    │     │
-  └─────┘    └─────┘    └─────┘    └─────┘
-
-  CATEGORY BREAKDOWN (58 rules total):
-  ├── rendering-*      (9)  ── React rendering optimization
-  ├── rerender-*       (12) ── re-render prevention
-  ├── bundle-*         (5)  ── bundle size reduction
-  ├── async-*          (5)  ── async pattern optimization
-  ├── server-*         (8)  ── server component/action patterns
-  ├── client-*         (4)  ── client-side optimization
-  ├── js-*             (12) ── vanilla JS performance
-  └── advanced-*       (3)  ── advanced React patterns
-```
+| Skill | What It Actually Does | Value Proposition | fhhs Usage |
+|-------|----------------------|-------------------|------------|
+| **vercel-react-best-practices** | 58 granular optimization rules organized by priority: (1) Eliminating Waterfalls — CRITICAL (async-* rules), (2) Bundle Size — CRITICAL (bundle-* rules), (3) Server-Side Perf — HIGH (server-* rules), (4) Client Data Fetching — MEDIUM-HIGH (client-* rules), (5) Re-render Prevention — MEDIUM (rerender-* rules), (6) Rendering Perf — MEDIUM (rendering-* rules), (7) JS Performance — LOW-MEDIUM (js-* rules), (8) Advanced Patterns — LOW (advanced-* rules). Each rule has: bad example, good example, explanation, performance impact. | Systematic performance optimization, not arbitrary tips. Priority ordering means you fix the highest-impact issues first. Before/after patterns make rules immediately actionable. | **DEAD** — shipped as `/fh:nextjs-perf` (trimmed to 35 of 58 rules) but **never wired into any pipeline**. Available for manual invocation only. |
 
 ## Skills Table
 
-| Skill | SDLC Phase | Quality | Status | fhhs Equivalent | Notes |
-|-------|-----------|---------|--------|-----------------|-------|
-| vercel-react-best-practices | Performance | B+ | ✅ Forked | /fh:nextjs-perf (trimmed to 35 rules) | 58 rules trimmed to 35 highest-impact |
+| Skill | SDLC Phase | Quality | Pipeline Status | fhhs Equivalent | Notes |
+|-------|-----------|---------|----------------|-----------------|-------|
+| vercel-react-best-practices | Performance | B+ | ⚠️ **Dead** | /fh:nextjs-perf (trimmed to 35 rules) | Not wired into any pipeline |
 
 ## Supporting Assets Table
 
 | Asset | Type | Used by | Status | Notes |
 |-------|------|---------|--------|-------|
-| rules/ (58 files) | Rules | vercel-react-best-practices | 🔀 Partial | 35 of 58 retained in /fh:nextjs-perf |
+| rules/ (58 files) | Rules | vercel-react-best-practices | 🔀 Partial | 35 of 58 retained |
 | AGENTS.md | Config | — | 🚫 N/A | Upstream agent config |
 
 ## Assessment
 
-vercel-react-best-practices provides the most granular performance optimization knowledge in the catalog. Its 58 individual rules are well-structured with clear before/after patterns. In fhhs, it is trimmed to 35 rules as /fh:nextjs-perf — the 23 dropped rules are either too niche (Canvas SVG precision, localStorage schema), overlap with other fhhs capabilities, or target patterns rarely seen in practice. The trimming is a reasonable trade-off between context budget and coverage. The main weakness is narrow applicability — these rules only apply to React/Next.js projects, unlike most other upstreams which are framework-agnostic. The upstream's overall B+ rating (rather than A) reflects this narrow scope.
+Well-structured with clear before/after patterns, but narrow applicability (React/Next.js only) and not wired into any fhhs pipeline. Available for manual invocation but realistically sees little use.
+
+### Honest Assessment
+
+This upstream adds token cost (skill description in session start) without providing automated value. It's only relevant when:
+1. The user is working on a React/Next.js project
+2. The user manually invokes `/fh:nextjs-perf`
+
+The rules themselves are good, but the narrow scope limits integration opportunities. There's no natural trigger in `/fh:build` or `/fh:review` to conditionally load React performance rules.
+
+### Recommendations
+
+| Priority | Action | Impact |
+|----------|--------|--------|
+| **Low** | Consider wiring into `/fh:review` when reviewing React/Next.js code | Automated perf review for React projects |
+| **Low** | Consider conditional loading: only add to skill descriptions when project uses React | Reduce token cost for non-React projects |

--- a/fhhs-skills-workspace/run_all_evals.py
+++ b/fhhs-skills-workspace/run_all_evals.py
@@ -167,9 +167,11 @@ Provide a detailed behavioral trace, not actual tool execution."""
     start_time = time.time()
 
     try:
-        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+        env = {k: v for k, v in os.environ.items()
+               if not k.startswith("CLAUDE") and not k.startswith("CONDUCTOR")
+               and k != "__CFBundleIdentifier"}
         result = subprocess.run(
-            ["claude", "-p", full_prompt, "--output-format", "json"],
+            ["claude", "-p", full_prompt, "--output-format", "stream-json", "--verbose"],
             capture_output=True,
             text=True,
             timeout=TIMEOUT_SECONDS,
@@ -185,16 +187,47 @@ Provide a detailed behavioral trace, not actual tool execution."""
                 "output": "", "assertions": assertions,
             }
         else:
-            try:
-                output_data = json.loads(result.stdout)
-                output_text = output_data.get("result", result.stdout)
-            except json.JSONDecodeError:
-                output_text = result.stdout
+            # Parse NDJSON stream to extract assistant text and result metadata
+            output_text = ""
+            output_data = {}
+            for line in result.stdout.strip().split("\n"):
+                if not line.strip():
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                etype = event.get("type", "")
+                if etype == "assistant":
+                    msg = event.get("message", {})
+                    for block in msg.get("content", []):
+                        if block.get("type") == "text":
+                            output_text += block.get("text", "")
+                elif etype == "result":
+                    output_data = event
+                    # Also grab any result text (may be populated in future CLI versions)
+                    if not output_text and event.get("result"):
+                        output_text = event["result"]
+
+            # Extract token usage from result event
+            usage = output_data.get("usage", {})
+            token_info = {
+                "input_tokens": usage.get("input_tokens", 0),
+                "output_tokens": usage.get("output_tokens", 0),
+                "cache_creation_tokens": usage.get("cache_creation_input_tokens", 0),
+                "cache_read_tokens": usage.get("cache_read_input_tokens", 0),
+                "cost_usd": output_data.get("total_cost_usd", 0),
+            }
+            token_info["total_tokens"] = (
+                token_info["input_tokens"] + token_info["output_tokens"]
+                + token_info["cache_creation_tokens"] + token_info["cache_read_tokens"]
+            )
 
             res = {
                 "eval_id": eval_id, "command": command, "status": "success",
                 "output": output_text[:8000], "duration_ms": duration_ms,
                 "assertions": assertions, "expected": expected,
+                "tokens": token_info,
             }
     except subprocess.TimeoutExpired:
         res = {
@@ -219,9 +252,14 @@ Provide a detailed behavioral trace, not actual tool execution."""
 
         # Append to progress file
         if _progress_file:
+            progress_entry = {
+                "eval_id": eval_id, "command": command,
+                "status": res["status"], "duration_ms": res.get("duration_ms", 0),
+            }
+            if "tokens" in res:
+                progress_entry["tokens"] = res["tokens"]
             with open(_progress_file, "a") as pf:
-                pf.write(json.dumps({"eval_id": eval_id, "command": command,
-                                      "status": res["status"], "duration_ms": res.get("duration_ms", 0)}) + "\n")
+                pf.write(json.dumps(progress_entry) + "\n")
 
     return res
 
@@ -494,6 +532,15 @@ def main():
     total_a = sum(g["total"] for g in graded_evals)
     passed_a = sum(g["passed"] for g in graded_evals)
 
+    # Aggregate token usage from raw results
+    token_results = [r for r in results if r.get("tokens")]
+    total_input = sum(r["tokens"]["input_tokens"] for r in token_results)
+    total_output = sum(r["tokens"]["output_tokens"] for r in token_results)
+    total_cache_create = sum(r["tokens"]["cache_creation_tokens"] for r in token_results)
+    total_cache_read = sum(r["tokens"]["cache_read_tokens"] for r in token_results)
+    total_cost = sum(r["tokens"]["cost_usd"] for r in token_results)
+    total_all_tokens = sum(r["tokens"]["total_tokens"] for r in token_results)
+
     summary = {
         "run_date": datetime.now().isoformat(),
         "total_evals": len(evals),
@@ -503,8 +550,21 @@ def main():
         "total_assertions": total_a,
         "passed_assertions": passed_a,
         "overall_pass_rate": passed_a / total_a if total_a > 0 else 0.0,
+        "token_usage": {
+            "total_tokens": total_all_tokens,
+            "input_tokens": total_input,
+            "output_tokens": total_output,
+            "cache_creation_tokens": total_cache_create,
+            "cache_read_tokens": total_cache_read,
+            "total_cost_usd": round(total_cost, 4),
+            "avg_tokens_per_eval": int(total_all_tokens / max(len(token_results), 1)),
+            "avg_cost_per_eval": round(total_cost / max(len(token_results), 1), 4),
+        },
         "by_command": {},
     }
+
+    # Build a lookup from eval_id -> raw result for token data
+    result_by_id = {r["eval_id"]: r for r in results}
 
     for cmd, cmd_graded in sorted(by_command.items()):
         cmd_g = [g for g in cmd_graded if g["status"] == "graded"]
@@ -512,6 +572,12 @@ def main():
         cmd_passed = sum(g["passed"] for g in cmd_g)
         cmd_errors = sum(1 for g in cmd_graded if g["status"] in ("error", "timeout"))
         avg_dur = sum(g.get("duration_ms", 0) for g in cmd_g) / max(len(cmd_g), 1)
+
+        # Per-command token aggregation
+        cmd_token_results = [result_by_id[g["eval_id"]] for g in cmd_g if result_by_id.get(g["eval_id"], {}).get("tokens")]
+        cmd_tokens = sum(r["tokens"]["total_tokens"] for r in cmd_token_results) if cmd_token_results else 0
+        cmd_cost = sum(r["tokens"]["cost_usd"] for r in cmd_token_results) if cmd_token_results else 0
+
         summary["by_command"][cmd] = {
             "evals": len(cmd_graded),
             "assertions": cmd_total,
@@ -519,6 +585,9 @@ def main():
             "pass_rate": cmd_passed / cmd_total if cmd_total > 0 else 0.0,
             "errors": cmd_errors,
             "avg_duration_ms": int(avg_dur),
+            "total_tokens": cmd_tokens,
+            "avg_tokens": int(cmd_tokens / max(len(cmd_token_results), 1)),
+            "total_cost_usd": round(cmd_cost, 4),
         }
 
     summary_path = workspace_dir / "summary.json"
@@ -526,9 +595,10 @@ def main():
         json.dump(summary, f, indent=2)
 
     # Print report
-    log(f"\n{'='*75}")
+    tu = summary["token_usage"]
+    log(f"\n{'='*90}")
     log(f"EVAL RESULTS SUMMARY")
-    log(f"{'='*75}")
+    log(f"{'='*90}")
     log(f"Total evals:     {summary['total_evals']}")
     log(f"Successful runs: {summary['successful']}")
     log(f"Errors:          {summary['errors']}")
@@ -538,12 +608,24 @@ def main():
     log(f"Passed assertions: {summary['passed_assertions']}")
     log(f"Overall pass rate: {summary['overall_pass_rate']:.1%}")
     log(f"")
-    log(f"{'Command':<20} {'Evals':>6} {'Assert':>7} {'Pass':>5} {'Rate':>7} {'Err':>4} {'Avg(s)':>7}")
-    log(f"{'-'*20} {'-'*6} {'-'*7} {'-'*5} {'-'*7} {'-'*4} {'-'*7}")
+    log(f"TOKEN USAGE:")
+    log(f"  Total tokens:      {tu['total_tokens']:>12,}")
+    log(f"  Input tokens:      {tu['input_tokens']:>12,}")
+    log(f"  Output tokens:     {tu['output_tokens']:>12,}")
+    log(f"  Cache creation:    {tu['cache_creation_tokens']:>12,}")
+    log(f"  Cache read:        {tu['cache_read_tokens']:>12,}")
+    log(f"  Total cost:        ${tu['total_cost_usd']:>11,.4f}")
+    log(f"  Avg tokens/eval:   {tu['avg_tokens_per_eval']:>12,}")
+    log(f"  Avg cost/eval:     ${tu['avg_cost_per_eval']:>11,.4f}")
+    log(f"")
+    log(f"{'Command':<20} {'Evals':>5} {'Assert':>6} {'Pass':>5} {'Rate':>6} {'Err':>3} {'Avg(s)':>6} {'AvgTok':>7} {'Cost$':>7}")
+    log(f"{'-'*20} {'-'*5} {'-'*6} {'-'*5} {'-'*6} {'-'*3} {'-'*6} {'-'*7} {'-'*7}")
     for cmd, stats in sorted(summary["by_command"].items(), key=lambda x: x[1]["pass_rate"]):
         avg_s = stats['avg_duration_ms'] / 1000
-        log(f"{cmd:<20} {stats['evals']:>6} {stats['assertions']:>7} {stats['passed']:>5} {stats['pass_rate']:>6.0%} {stats['errors']:>4} {avg_s:>6.1f}")
-    log(f"{'='*75}")
+        avg_tok = stats.get('avg_tokens', 0)
+        cost = stats.get('total_cost_usd', 0)
+        log(f"{cmd:<20} {stats['evals']:>5} {stats['assertions']:>6} {stats['passed']:>5} {stats['pass_rate']:>5.0%} {stats['errors']:>3} {avg_s:>5.1f} {avg_tok:>7,} {cost:>6.2f}")
+    log(f"{'='*90}")
 
     # Failed assertions detail
     log(f"\n{'='*75}")


### PR DESCRIPTION
## Summary

Completes Phases 2, 3, and 3.5 of the fhhs-skills roadmap. Adds upstream sync validation with pre-checks and regression detection, a full upstream capability audit with gap registry, and pipeline intelligence — complexity-driven research agents, CONTEXT.md contract with 3 canonical sections, engineering review in plan-review, verification gates in build/fix, and 16 new evals (198-213). Includes planning artifacts (PLANs, designs, research), upstream doc updates from deep audit, and skill refinements across audit-upstream, review, simplify, and spec-gate.

## Test plan

- [ ] Run full eval suite (`python3 evals/run_all_evals.py`) — all 213 evals pass
- [ ] Verify no legacy section names in shipped skills: `grep -r "Design Decisions\|Review Decisions\|NOT in scope\|Locked Decisions" .claude/skills/ --include="*.md"`
- [ ] Spot-check `/fh:plan-work` triggers complexity assessment and research agent spawning
- [ ] Spot-check `/fh:plan-review` loads CONTEXT.md and checks RESEARCH.md alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)