### PR TITLE
fix: repair broken skill registration and update cache invalidation

### DIFF
--- a/.claude/skills/audit-upstream/SKILL.md
+++ b/.claude/skills/audit-upstream/SKILL.md
@@ -1,6 +1,7 @@
 ---
-name: audit-upstream
+name: fh:audit-upstream
 description: "Use when evaluating upstream skill changes after sync, assessing integration opportunities, or maintaining the upstream capability index. Triggers on 'audit upstream', 'evaluate upstream', 'what changed upstream', 'integration opportunities', or after /fh:sync-upstream."
+user-invokable: true
 ---
 
 # Audit Upstream

--- a/.claude/skills/ui-branding/SKILL.md
+++ b/.claude/skills/ui-branding/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: fh:ui-branding
 description: One-time setup that gathers design context for your project and saves it to your AI config file. Run once to establish persistent design guidelines.
-user-invocable: true
+user-invokable: true
 ---
 
 Gather design context for this project, then persist it for all future sessions.

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -137,9 +137,44 @@ AskUserQuestion:
 **If "Yes, update now":**
 
 ```bash
-# Refresh marketplace to ensure update pulls the latest version
+# Get current installed version before updating
+PREV_VERSION=$(python3 -c "
+import json, pathlib
+data = json.loads(pathlib.Path(pathlib.Path.home() / '.claude/plugins/installed_plugins.json').read_text())
+entry = data.get('plugins', {}).get('fh@fhhs-skills')
+print(entry[0].get('version', 'unknown') if entry else 'unknown')
+" 2>/dev/null)
+```
+
+```bash
+# Uninstall then reinstall to fully clear cached skill registrations.
+# A plain `claude plugin update` can leave stale metadata (gitCommitSha,
+# cached skill names) that prevents renamed or restructured skills from
+# appearing under the /fh: prefix.
+claude plugin uninstall fh@fhhs-skills --keep-data
 claude plugin marketplace update fhhs-skills 2>/dev/null
-claude plugin update fh@fhhs-skills
+claude plugin install fh@fhhs-skills
+```
+
+```bash
+# Remove old version caches that accumulate across updates
+INSTALL_PATH=$(python3 -c "
+import json, pathlib
+data = json.loads(pathlib.Path(pathlib.Path.home() / '.claude/plugins/installed_plugins.json').read_text())
+entry = data.get('plugins', {}).get('fh@fhhs-skills')
+print(entry[0].get('installPath', '') if entry else '')
+" 2>/dev/null)
+
+if [ -n "$INSTALL_PATH" ]; then
+  CACHE_DIR=$(dirname "$INSTALL_PATH")
+  CURRENT_VER=$(basename "$INSTALL_PATH")
+  for old_dir in "$CACHE_DIR"/*/; do
+    old_ver=$(basename "$old_dir")
+    if [ "$old_ver" != "$CURRENT_VER" ]; then
+      rm -rf "$old_dir"
+    fi
+  done
+fi
 ```
 
 Clear the update indicator from the statusline:
@@ -153,7 +188,7 @@ rm -f "$HOME/.claude/cache/fhhs-update-check.json"
 ```
 ## Updated
 
-**fhhs-skills** X.Y.Z → A.B.C
+**fhhs-skills** PREV_VERSION → A.B.C
 
 Restart Claude Code to use the new version.
 ```


### PR DESCRIPTION
## Summary
- **audit-upstream/SKILL.md**: Added missing `fh:` name prefix and `user-invokable: true` field
- **ui-branding/SKILL.md**: Fixed typo `user-invocable` → `user-invokable`
- **update/SKILL.md**: Replaced `claude plugin update` with uninstall+reinstall cycle to clear stale `gitCommitSha` and cached skill names; added old version cache cleanup

## Root cause
`claude plugin update` preserves `gitCommitSha` from the original install, causing Claude Code to serve cached skill metadata from older versions where names lacked the `fh:` prefix. Skills added after the original install worked fine, but pre-existing skills (build, fix, plan-work, etc.) were invisible under `/fh:`.

## Test plan
- [ ] Run `/fh:update` after release — verify uninstall+reinstall cycle completes
- [ ] Restart Claude Code — verify all skills appear under `/fh:` prefix
- [ ] Verify old version cache directories are cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)