### PR TITLE
feat: Fallow setup/fix, Supabase DATABASE_URL, worktree symlinks

### DIFF
--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -39,6 +39,25 @@ This step should consume <2% context. Don't deep-dive the errors yet — just su
 
 ---
 
+## Step 0½: Fallow Static Analysis (if available)
+
+Before triaging, gather deterministic findings from Fallow to augment investigation.
+
+```bash
+if command -v fallow &>/dev/null; then
+  FALLOW_CHECK=$(fallow check --format json --quiet 2>/dev/null) || FALLOW_CHECK=""
+  FALLOW_HEALTH=$(fallow health --format json --quiet 2>/dev/null) || FALLOW_HEALTH=""
+fi
+```
+
+If Fallow ran and produced output:
+- **`fallow check`** — unused exports, circular dependencies. If the bug involves an import or wiring issue, these findings are definitive ground truth.
+- **`fallow health`** — complexity metrics. High-complexity functions near the bug site are more likely to harbor subtle issues.
+
+**Cap:** Keep under 1% context. Filter to files mentioned in the bug report or error trace. Skip if Fallow is not installed — no mention in output.
+
+---
+
 ## Step 1: Triage
 
 Quickly assess bug depth before choosing strategy. Spend <5% context.

--- a/.claude/skills/new-project/SKILL.md
+++ b/.claude/skills/new-project/SKILL.md
@@ -694,6 +694,47 @@ supabase link --project-ref "$PROJECT_REF" --password "$DB_PASSWORD"
 
 This creates the `supabase/` directory with `config.toml` and links it to the cloud project.
 
+#### Reset database password and configure DATABASE_URL
+
+The initial password generated during project creation is ephemeral. Reset it to a known password and configure the pooler connection string for direct database access (used by ORMs like Prisma/Drizzle):
+
+```bash
+# Generate a new strong password
+NEW_DB_PASSWORD="$(openssl rand -base64 32 | tr -d '/+=' | head -c 32)"
+
+# Reset the database password
+supabase db reset-password --project-ref "$PROJECT_REF" --password "$NEW_DB_PASSWORD"
+```
+
+Determine the pooler host from the chosen region. Map the region to the Supabase pooler hostname:
+
+| Region | Pooler Host |
+|--------|-------------|
+| `us-east-1` | `aws-0-us-east-1.pooler.supabase.com` |
+| `us-west-1` | `aws-0-us-west-1.pooler.supabase.com` |
+| `eu-west-1` | `aws-0-eu-west-1.pooler.supabase.com` |
+| `eu-central-1` | `aws-0-eu-central-1.pooler.supabase.com` |
+| `ap-southeast-1` | `aws-0-ap-southeast-1.pooler.supabase.com` |
+| `ap-northeast-1` | `aws-0-ap-northeast-1.pooler.supabase.com` |
+
+Construct and append the pooler `DATABASE_URL` to `.env.local`:
+
+```bash
+POOLER_HOST="aws-0-${REGION}.pooler.supabase.com"
+DATABASE_URL="postgresql://postgres.${PROJECT_REF}:${NEW_DB_PASSWORD}@${POOLER_HOST}:6543/postgres"
+
+cat >> .env.local <<EOF
+
+# Supabase Database (pooler — use for ORMs like Prisma/Drizzle)
+DATABASE_URL=${DATABASE_URL}
+EOF
+```
+
+**Security rules:**
+- `DATABASE_URL` contains the database password — must NEVER be prefixed with `NEXT_PUBLIC_`
+- Never echo the `DATABASE_URL` value in user-facing output
+- The pooler connection (port 6543) uses transaction mode by default, which is compatible with serverless environments
+
 #### Sync environment variables to Vercel
 
 Push the Supabase env vars to Vercel so deployments work out of the box:
@@ -702,6 +743,7 @@ Push the Supabase env vars to Vercel so deployments work out of the box:
 echo "$SUPABASE_URL" | vercel env add NEXT_PUBLIC_SUPABASE_URL production
 echo "$ANON_KEY" | vercel env add NEXT_PUBLIC_SUPABASE_ANON_KEY production
 echo "$SERVICE_ROLE_KEY" | vercel env add SUPABASE_SERVICE_ROLE_KEY production
+echo "$DATABASE_URL" | vercel env add DATABASE_URL production
 ```
 
 If the `vercel` CLI is unavailable (Step 8c was skipped), show a checkpoint:
@@ -716,8 +758,9 @@ Add these environment variables in Vercel Dashboard → Settings → Environment
   NEXT_PUBLIC_SUPABASE_URL       = https://<ref>.supabase.co
   NEXT_PUBLIC_SUPABASE_ANON_KEY  = <your anon key>
   SUPABASE_SERVICE_ROLE_KEY      = <your service_role key>
+  DATABASE_URL                   = <your pooler connection string>
 
-Mark SUPABASE_SERVICE_ROLE_KEY as "Sensitive" in Vercel.
+Mark SUPABASE_SERVICE_ROLE_KEY and DATABASE_URL as "Sensitive" in Vercel.
 ```
 
 ### 8f: Observability Setup
@@ -789,7 +832,7 @@ If Conductor is detected, create `conductor.json` in the project root with scrip
 ```json
 {
   "scripts": {
-    "setup": "npm install && [ -f \"$CONDUCTOR_ROOT_PATH/.env.local\" ] && cp \"$CONDUCTOR_ROOT_PATH/.env.local\" .env.local || true; node -e \"var fs=require('fs'),f='.claude/settings.json',s={};try{s=JSON.parse(fs.readFileSync(f,'utf8'))}catch{}s.env=Object.assign(s.env||{},{CLAUDE_CODE_TASK_LIST_ID:process.env.CONDUCTOR_WORKSPACE_NAME||'default'});fs.writeFileSync(f,JSON.stringify(s,null,2)+'\\n')\"",
+    "setup": "npm install && [ -f \"$CONDUCTOR_ROOT_PATH/.env.local\" ] && ln -sf \"$CONDUCTOR_ROOT_PATH/.env.local\" .env.local || true; [ -d \"$CONDUCTOR_ROOT_PATH/.vercel\" ] && ln -sf \"$CONDUCTOR_ROOT_PATH/.vercel\" .vercel || true; node -e \"var fs=require('fs'),f='.claude/settings.json',s={};try{s=JSON.parse(fs.readFileSync(f,'utf8'))}catch{}s.env=Object.assign(s.env||{},{CLAUDE_CODE_TASK_LIST_ID:process.env.CONDUCTOR_WORKSPACE_NAME||'default'});fs.writeFileSync(f,JSON.stringify(s,null,2)+'\\n')\"",
     "run": "npm run dev -- --port $CONDUCTOR_PORT",
     "archive": "rm -rf \"$HOME/.claude/tasks/${CONDUCTOR_WORKSPACE_NAME}\" 2>/dev/null; true"
   },
@@ -807,17 +850,17 @@ If Conductor is detected, create `conductor.json` in the project root with scrip
 >
 > **Why `archive` cleans up?** Task lists persist at `~/.claude/tasks/{ID}/`. Without cleanup, old workspace task lists accumulate indefinitely. The archive script removes the directory when the workspace is torn down.
 
-> **Why `cp` instead of `ln -s`?** Conductor workspaces are git worktrees. Symlinks into `$CONDUCTOR_ROOT_PATH` can break when the root's working tree changes. Copying is safer — the setup script runs each time a workspace starts, so the copy stays fresh.
+> **Why `ln -sf` for `.env.local` and `.vercel/`?** These are gitignored files, so git operations never touch them — symlinks are safe and keep all worktrees in sync bidirectionally. When the user updates `.env.local` in any worktree, all others see the change immediately. This is different from git-tracked files, where symlinks into `$CONDUCTOR_ROOT_PATH` could break during checkout.
 
 **For other common stacks** — adapt the scripts:
 
 | Stack | Setup script | Run script |
 |-------|-------------|------------|
-| Next.js | `npm install && cp "$CONDUCTOR_ROOT_PATH/.env.local" .env.local 2>/dev/null; true` | `npm run dev -- --port $CONDUCTOR_PORT` |
-| Rails | `bundle install && cp "$CONDUCTOR_ROOT_PATH/.env" .env 2>/dev/null; true` | `bin/rails server -p $CONDUCTOR_PORT` |
-| Django | `pip install -r requirements.txt && cp "$CONDUCTOR_ROOT_PATH/.env" .env 2>/dev/null; true` | `python manage.py runserver $CONDUCTOR_PORT` |
-| Phoenix | `mix deps.get && cp "$CONDUCTOR_ROOT_PATH/.env" .env 2>/dev/null; true` | `mix phx.server` (uses `PORT=$CONDUCTOR_PORT`) |
-| Vite | `npm install && cp "$CONDUCTOR_ROOT_PATH/.env" .env 2>/dev/null; true` | `npm run dev -- --port $CONDUCTOR_PORT` |
+| Next.js | `npm install && ln -sf "$CONDUCTOR_ROOT_PATH/.env.local" .env.local 2>/dev/null; true` | `npm run dev -- --port $CONDUCTOR_PORT` |
+| Rails | `bundle install && ln -sf "$CONDUCTOR_ROOT_PATH/.env" .env 2>/dev/null; true` | `bin/rails server -p $CONDUCTOR_PORT` |
+| Django | `pip install -r requirements.txt && ln -sf "$CONDUCTOR_ROOT_PATH/.env" .env 2>/dev/null; true` | `python manage.py runserver $CONDUCTOR_PORT` |
+| Phoenix | `mix deps.get && ln -sf "$CONDUCTOR_ROOT_PATH/.env" .env 2>/dev/null; true` | `mix phx.server` (uses `PORT=$CONDUCTOR_PORT`) |
+| Vite | `npm install && ln -sf "$CONDUCTOR_ROOT_PATH/.env" .env 2>/dev/null; true` | `npm run dev -- --port $CONDUCTOR_PORT` |
 
 The setup script should:
 1. Install dependencies (`npm install` handles per-worktree `node_modules` correctly)
@@ -862,7 +905,7 @@ Project initialized:
 - Starter template          — cinjoff/fh-starter-project (if default stack)
 - Vercel project            — linked (auto-deploys on push to main)
 - Supabase project          — <project-url> (if set up)
-- .env.local                — API keys configured (if Supabase)
+- .env.local                — API keys + DATABASE_URL configured (if Supabase)
 - lib/sentry-local.ts       — local error tracking (Sentry SDK → SQLite)
 - lib/sentry-local-query.mjs — error query CLI for agents
 - .sentry-local/             — error store (gitignored, per-worktree)

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -632,7 +632,73 @@ If the install fails (e.g. network issue, npx not available), show a warning but
 
 ---
 
-## Step 8: Conductor Configuration
+## Step 8: Fallow (Static Analysis)
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ FHHS ► FALLOW
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+[Fallow](https://docs.fallow.tools/) provides deterministic static analysis — dead-code detection, circular dependency analysis, code duplication, and complexity metrics. Used by `/fh:simplify`, `/fh:review`, `/fh:fix`, and `/fh:build` (spec gate) to inject ground truth findings into review agents.
+
+### Check and install
+
+```bash
+command -v fallow >/dev/null 2>&1 && echo "INSTALLED $(fallow --version 2>/dev/null)" || echo "NOT_INSTALLED"
+```
+
+If `INSTALLED`:
+
+```
+✓ Fallow installed
+```
+
+If `NOT_INSTALLED`:
+
+Detect the project's package manager to install with the right tool:
+
+```bash
+if [ -f pnpm-lock.yaml ]; then
+  PKG_MGR="pnpm"
+elif [ -f yarn.lock ]; then
+  PKG_MGR="yarn"
+else
+  PKG_MGR="npm"
+fi
+echo "PKG_MGR=$PKG_MGR"
+```
+
+```
+◆ Installing Fallow via $PKG_MGR...
+```
+
+```bash
+$PKG_MGR install -g fallow
+```
+
+Verify:
+
+```bash
+fallow --version && echo "✓ Fallow ready"
+```
+
+If the install fails, show a warning but don't block setup:
+
+```
+⚠ Could not install Fallow automatically.
+  You can install it manually later:
+
+    pnpm install -g fallow   # or: npm install -g fallow
+
+  Without Fallow, /fh:simplify, /fh:review, /fh:fix, and /fh:build
+  still work but use LLM-only analysis instead of deterministic
+  static analysis.
+```
+
+---
+
+## Step 9: Conductor Configuration
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -643,7 +709,7 @@ If the install fails (e.g. network issue, npx not available), show a warning but
 
 [Conductor](https://conductor.build) lets you run multiple Claude Code agents in parallel workspaces. Each workspace gets a copy of your git files plus isolated setup/run scripts. This step checks whether Conductor is installed and reminds the user to configure it per-project.
 
-### 8a: Detect Conductor
+### 9a: Detect Conductor
 
 ```bash
 # Check if the Conductor app exists
@@ -658,9 +724,9 @@ If `NOT_INSTALLED`:
   Download from https://conductor.build if interested.
 ```
 
-Skip to Step 9.
+Skip to Step 10.
 
-### 8b: Conductor awareness
+### 9b: Conductor awareness
 
 If installed, display:
 
@@ -689,7 +755,7 @@ If installed, display:
 
     {
       "scripts": {
-        "setup": "npm install && cp \"$CONDUCTOR_ROOT_PATH/.env.local\" .env.local 2>/dev/null; true; node -e \"var fs=require('fs'),f='.claude/settings.json',s={};try{s=JSON.parse(fs.readFileSync(f,'utf8'))}catch{}s.env=Object.assign(s.env||{},{CLAUDE_CODE_TASK_LIST_ID:process.env.CONDUCTOR_WORKSPACE_NAME||'default'});fs.writeFileSync(f,JSON.stringify(s,null,2)+'\\n')\"",
+        "setup": "npm install && ln -sf \"$CONDUCTOR_ROOT_PATH/.env.local\" .env.local 2>/dev/null; true; ln -sf \"$CONDUCTOR_ROOT_PATH/.vercel\" .vercel 2>/dev/null; true; node -e \"var fs=require('fs'),f='.claude/settings.json',s={};try{s=JSON.parse(fs.readFileSync(f,'utf8'))}catch{}s.env=Object.assign(s.env||{},{CLAUDE_CODE_TASK_LIST_ID:process.env.CONDUCTOR_WORKSPACE_NAME||'default'});fs.writeFileSync(f,JSON.stringify(s,null,2)+'\\n')\"",
         "run": "npm run dev -- --port $CONDUCTOR_PORT",
         "archive": "rm -rf \"$HOME/.claude/tasks/${CONDUCTOR_WORKSPACE_NAME}\" 2>/dev/null; true"
       },
@@ -706,7 +772,7 @@ If installed, display:
 
 ---
 
-## Step 9: Summary
+## Step 10: Summary
 
 Display the summary banner as **direct text output** (not via Bash — Bash output gets collapsed by Claude Code and users won't see it). Output this exactly:
 
@@ -747,6 +813,7 @@ Then present the status table and next steps as regular markdown text:
 | CLI Tools                  | ✓ linked                 |
 | Hooks                      | ✓ statusline + update check + context monitor |
 | claude-mem                 | ✓ installed / ○ skipped (optional)       |
+| Fallow                     | ✓ installed / ⚠ manual install needed    |
 | shadcn skills              | ✓ installed / ⚠ manual install needed    |
 | Conductor                  | ✓ detected / ○ not installed (optional) |
 


### PR DESCRIPTION
## Summary
- `/fh:setup` now installs Fallow (static analysis) with pnpm/yarn/npm detection
- `/fh:fix` runs `fallow check` + `fallow health` before triage for ground truth findings
- `/fh:new-project` resets Supabase DB password and writes `DATABASE_URL` with pooler connection string to `.env.local` and Vercel
- Conductor setup scripts use `ln -sf` instead of `cp` for `.env.local` and `.vercel/`, keeping worktrees in bidirectional sync

## Test plan
- [ ] Run `/fh:setup` on a project with pnpm — verify Fallow installs via pnpm
- [ ] Run `/fh:fix` with Fallow installed — verify Step 0½ runs before triage
- [ ] Run `/fh:new-project` with Supabase — verify DATABASE_URL in `.env.local`
- [ ] Create Conductor workspace — verify `.env.local` is symlinked, not copied

🤖 Generated with [Claude Code](https://claude.com/claude-code)