### PR TITLE
fix(auto): correct claude -p invocation for headless sessions

### DIFF
--- a/.claude/skills/auto/SKILL.md
+++ b/.claude/skills/auto/SKILL.md
@@ -75,10 +75,20 @@ Confirm the config was set successfully before proceeding.
 
 ## Step 5: Shell Out to Orchestrator
 
-Invoke the Node.js orchestrator for process-isolated phase execution:
+**Find the orchestrator path first** — it lives in the plugin cache, not in the project:
 
 ```bash
-node .claude/skills/auto/auto-orchestrator.cjs \
+ORCHESTRATOR=$(find "$HOME/.claude/plugins/cache/fhhs-skills" -name "auto-orchestrator.cjs" 2>/dev/null | sort -V | tail -1)
+if [ -z "$ORCHESTRATOR" ]; then
+  echo "ERROR: auto-orchestrator.cjs not found in plugin cache"
+  exit 1
+fi
+```
+
+Then invoke it:
+
+```bash
+node "$ORCHESTRATOR" \
   --project-dir "$(pwd)" \
   --start-phase "${START_PHASE}" \
   --end-phase "${END_PHASE}" \
@@ -87,18 +97,29 @@ node .claude/skills/auto/auto-orchestrator.cjs \
   ${RESUME:+--resume}
 ```
 
-The orchestrator runs each phase through a sequential loop using `claude -p` for fresh-context sessions:
+The orchestrator runs each phase through a sequential loop using `claude -p` for fresh-context sessions. Each session receives:
+- `--plugin-dir` pointing to the fh plugin root (so `/fh:` skills are available)
+- `--permission-mode bypassPermissions` (non-interactive, no prompts)
+- `--append-system-prompt` with CLAUDE.md content (project context)
+- A rich prompt with the phase goal and explicit autonomous instructions
 
 ```
 Per-phase loop:
-1. claude -p "/fh:plan-work plan N for phase X"     → produces PLAN.md
-2. claude -p "/fh:plan-review .planning/phases/..."  → HOLD SCOPE review
-3. claude -p "/fh:build .planning/phases/..."        → executes plan
-4. claude -p "/fh:review --quick"                    → final code review
-5. Update STATE.md via gsd-tools
+1. claude -p [rich prompt] --plugin-dir [...] --permission-mode bypassPermissions  → PLAN.md
+2. claude -p [rich prompt] --plugin-dir [...] --permission-mode bypassPermissions  → HOLD review
+3. claude -p [rich prompt] --plugin-dir [...] --permission-mode bypassPermissions  → build
+4. claude -p [rich prompt] --plugin-dir [...] --permission-mode bypassPermissions  → quick review
+5. Update STATE.md via gsd-tools (from projectDir/.claude/get-shit-done/bin/)
 ```
 
 Each step is a separate `claude -p` session with fresh context. The orchestrator handles crash recovery, state persistence to `.planning/`, and budget tracking.
+
+**Known pitfalls:**
+- `claude -p` does NOT support `--cwd` — use spawn `cwd` option only
+- `gsd-tools.cjs` must resolve from `projectDir/.claude/get-shit-done/bin/`, not `__dirname`
+- Without `--plugin-dir`, `/fh:` skill commands are unavailable in `-p` sessions
+- Without `--permission-mode bypassPermissions`, interactive prompts hang the process
+- Bare skill invocations (e.g. `/fh:plan-work`) alone are insufficient — include phase goal and autonomy instructions
 
 Monitor the orchestrator's stdout for progress updates. If the orchestrator exits with a non-zero code, read its error output and report the failure point.
 

--- a/.claude/skills/auto/auto-orchestrator.cjs
+++ b/.claude/skills/auto/auto-orchestrator.cjs
@@ -292,8 +292,21 @@ function appendDecision(projectDir, { id, title, status, confidence, context, de
 
 function runClaudeSession(prompt, opts) {
   return new Promise((resolve, reject) => {
-    const args = ['-p', prompt, '--cwd', opts.cwd];
-    log(`  Running: claude -p "${prompt}"`);
+    // Resolve plugin dir: auto-orchestrator lives at <plugin-root>/.claude/skills/auto/
+    // so __dirname/../../../ = plugin root where skills/SKILL.md etc. live
+    const pluginDir = path.resolve(__dirname, '..', '..', '..');
+    const args = [
+      '-p', prompt,
+      '--permission-mode', 'bypassPermissions',
+      '--plugin-dir', pluginDir,
+    ];
+    // Inject project conventions so the session has full context
+    const claudeMdPath = path.join(opts.cwd, 'CLAUDE.md');
+    if (fs.existsSync(claudeMdPath)) {
+      const claudeMd = fs.readFileSync(claudeMdPath, 'utf-8').slice(0, 4000);
+      args.push('--append-system-prompt', `Project conventions:\n${claudeMd}`);
+    }
+    log(`  Running: claude -p "${prompt}" (plugin-dir=${pluginDir})`);
 
     const child = spawn('claude', args, {
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -357,7 +370,8 @@ function runClaudeSession(prompt, opts) {
 // ─── State Update via gsd-tools ──────────────────────────────────────────────
 
 function updateStateViaGsd(projectDir, phaseId) {
-  const gsdPath = path.join(__dirname, 'gsd-tools.cjs');
+  // gsd-tools lives in the project, not next to this orchestrator
+  const gsdPath = path.join(projectDir, '.claude/get-shit-done/bin/gsd-tools.cjs');
   const { execSync } = require('child_process');
   try {
     execSync(`node "${gsdPath}" phase complete ${phaseId} --cwd "${projectDir}"`, {
@@ -375,10 +389,21 @@ function updateStateViaGsd(projectDir, phaseId) {
 const PHASE_STEPS = ['plan-work', 'plan-review', 'build', 'review'];
 
 async function executeStep(projectDir, phaseId, step, planPath) {
+  // Read phase goal from ROADMAP.md for richer autonomous prompts
+  let phaseGoal = '';
+  try {
+    const roadmap = fs.readFileSync(path.join(projectDir, '.planning/ROADMAP.md'), 'utf-8');
+    const phaseMatch = roadmap.match(new RegExp(`## Phase ${phaseId}[^\\n]*\\n\\*\\*Goal:\\*\\*\\s*([^\\n]+)`));
+    if (phaseMatch) phaseGoal = phaseMatch[1].trim();
+  } catch { /* ignore */ }
+
   switch (step) {
     case 'plan-work':
       return await runClaudeSession(
-        `/fh:plan-work plan next for phase ${phaseId}`,
+        `You are in auto mode (workflow.auto_advance=true). Read .planning/STATE.md and .planning/ROADMAP.md for context. ` +
+        `Plan phase ${phaseId}. Phase goal: "${phaseGoal}". ` +
+        `Use /fh:plan-work to create the plan. Auto-decide all gray areas using best judgment. ` +
+        `Write the plan to .planning/phases/ directory. Do not ask questions — make decisions autonomously.`,
         { cwd: projectDir }
       );
 
@@ -389,7 +414,8 @@ async function executeStep(projectDir, phaseId, step, planPath) {
       }
       const relPlan = path.relative(projectDir, latestPlan);
       return await runClaudeSession(
-        `/fh:plan-review ${relPlan} --mode hold`,
+        `You are in auto mode. Review the plan at ${relPlan} using /fh:plan-review with --mode hold. ` +
+        `Phase goal: "${phaseGoal}". Apply feedback directly to the plan. Do not ask questions.`,
         { cwd: projectDir }
       );
     }
@@ -401,14 +427,16 @@ async function executeStep(projectDir, phaseId, step, planPath) {
       }
       const relPlan = path.relative(projectDir, latestPlan);
       return await runClaudeSession(
-        `/fh:build ${relPlan}`,
+        `You are in auto mode. Execute the plan at ${relPlan} using /fh:build. ` +
+        `Phase goal: "${phaseGoal}". Build all tasks, run tests, commit changes. Do not ask questions.`,
         { cwd: projectDir }
       );
     }
 
     case 'review':
       return await runClaudeSession(
-        `/fh:review --quick`,
+        `You are in auto mode. Run /fh:review --quick on the recent changes. ` +
+        `Phase goal: "${phaseGoal}". Fix any issues found. Do not ask questions.`,
         { cwd: projectDir }
       );
 


### PR DESCRIPTION
## Problem

\`/fh:auto\` was completely broken in non-interactive mode. Three bugs:

1. **\`--cwd\` flag doesn't exist** — \`claude -p\` was called with \`--cwd <path>\` but the CLI doesn't support this flag, causing immediate exit with code 1.

2. **No plugin access** — \`claude -p\` sessions started without \`--plugin-dir\`, so \`/fh:\` skills were unavailable and commands like \`/fh:plan-work\` were unrecognized.

3. **Hung on permission prompts** — Without \`--permission-mode bypassPermissions\`, headless sessions blocked waiting for interactive approval.

Also:
- \`gsd-tools.cjs\` was resolved from \`__dirname\` (the orchestrator's directory) where it doesn't exist — correct path is \`projectDir/.claude/get-shit-done/bin/gsd-tools.cjs\`
- Step prompts were too minimal (just \`/fh:plan-work\`) — needed phase goal + autonomy context to make decisions without asking questions

## Fix

- Remove \`--cwd\` from claude args (spawn \`cwd\` option handles working dir)
- Add \`--plugin-dir\` pointing to fh plugin root (\`__dirname/../../../\`)
- Add \`--permission-mode bypassPermissions\`
- Add \`--append-system-prompt\` with CLAUDE.md for project context
- Fix \`gsd-tools.cjs\` path to \`projectDir/.claude/get-shit-done/bin/gsd-tools.cjs\`
- Enrich step prompts with phase goal + explicit "do not ask questions" instructions

## Test

Verified against a real project: phases 8–13 executed successfully end-to-end after these fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)