### PR TITLE
release: v1.32.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "fh",
       "description": "fhhs-skills: Composite workflow skills unifying engineering discipline, design quality, and project tracking. Includes /fh:plan-work, /fh:build, /fh:fix, /fh:review, /fh:ui-critique, /fh:polish, and 30+ more commands.",
-      "version": "1.32.1",
+      "version": "1.32.2",
       "author": {
         "name": "Konstantin"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fh",
   "description": "fhhs-skills: All-in-one workflow plugin — engineering discipline (TDD, verification, code review), design quality (critique, polish, normalize), and project tracking (phases, milestones, roadmaps). No other plugins required.",
-  "version": "1.32.1",
+  "version": "1.32.2",
   "author": {
     "name": "Konstantin"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Entries affecting `/fh:setup` or `/fh:new-project` environment carry reconciliation tags
 (`[setup:TYPE:ID]`, `[project:TYPE:ID]`) used by `/fh:update` for post-update checks.
 
+## [1.32.2] - 2026-03-27
+
+### Fixed
+- **`/fh:auto` headless sessions** — corrects `claude -p` invocation: removes unsupported `--cwd` flag, adds `--plugin-dir` for skill access, enables `bypassPermissions` mode to prevent interactive hangs, fixes `gsd-tools.cjs` path resolution, and enriches step prompts with phase goal and system context
+
 ## [1.32.1] - 2026-03-27
 
 ### Fixed


### PR DESCRIPTION
Version bump and changelog for v1.32.2

### Fixed
- **`/fh:auto` headless sessions** — corrects `claude -p` invocation for non-interactive mode