### PR TITLE
release: v1.41.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "fh",
       "description": "fhhs-skills: Composite workflow skills unifying engineering discipline, design quality, and project tracking. Includes /fh:plan-work, /fh:build, /fh:fix, /fh:review, /fh:ui-critique, /fh:polish, and 30+ more commands.",
-      "version": "1.41.0",
+      "version": "1.41.1",
       "author": {
         "name": "Konstantin"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fh",
   "description": "fhhs-skills: All-in-one workflow plugin — engineering discipline (TDD, verification, code review), design quality (critique, polish, normalize), and project tracking (phases, milestones, roadmaps). No other plugins required.",
-  "version": "1.41.0",
+  "version": "1.41.1",
   "author": {
     "name": "Konstantin"
   },

--- a/.claude/skills/tracker/SKILL.md
+++ b/.claude/skills/tracker/SKILL.md
@@ -38,15 +38,9 @@ $ARGUMENTS
 3. Check if `.project-tracker/.version` exists and read it.
 4. **If `.project-tracker/.version` exists and its content matches the plugin version**, skip to Step 3 — files are already up to date.
 5. **Otherwise**, refresh the template files:
-   a. Read all 6 template files from `templates/project-tracker/` in the plugin directory:
-      - `server.cjs`
-      - `parser.cjs`
-      - `index.html`
-      - `README.md`
-      - `ProjectCard.jsx`
-      - `DailyMetrics.jsx`
+   a. List all non-directory files in `templates/project-tracker/` in the plugin directory.
    b. Create `.project-tracker/` if it doesn't exist.
-   c. Write all 6 files into `.project-tracker/`, overwriting any existing versions.
+   c. Copy all listed files into `.project-tracker/`, overwriting any existing versions.
    d. Write the plugin version string into `.project-tracker/.version`.
    e. Check if `.gitignore` exists and contains `.project-tracker/`:
       - If `.gitignore` doesn't exist, create it with `.project-tracker/` as its content.

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -246,7 +246,7 @@ CHANGELOG_CONTENT=$(curl -sL "https://raw.githubusercontent.com/cinjoff/fhhs-ski
 echo "$CHANGELOG_CONTENT" > /tmp/fhhs-changelog.md
 ```
 
-Then run Steps 5a, 5a½, and 5b with `PREV_VERSION="0.0.0"` and `LATEST_VERSION` set to the installed version.
+Then run Steps 5a, 5a½, 5a¾, 5a⅞, and 5b with `PREV_VERSION="0.0.0"` and `LATEST_VERSION` set to the installed version.
 
 **After reconciliation completes:**
 
@@ -297,6 +297,80 @@ fi
 ```
 
 If the patch outputs "WARNING: gp() signature changed", claude-mem changed its internals and the patch needs updating — note this in the reconciliation table but don't fail the update.
+
+### 5a¾: Set CLAUDE_MEM_PROJECT env var
+
+For Conductor workspaces and git worktrees, the cwd basename often differs from the actual project name (e.g., "cairo" vs "fhhs-skills"). Set `CLAUDE_MEM_PROJECT` in the project-local `.claude/settings.json` so interactive sessions attribute observations correctly — not just auto-orchestrator spawned sessions.
+
+```bash
+# Derive project name from git toplevel basename
+PROJECT_NAME=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null)
+if [ -n "$PROJECT_NAME" ]; then
+  # Check if .claude/settings.json exists and already has CLAUDE_MEM_PROJECT
+  if [ -f ".claude/settings.json" ]; then
+    CURRENT=$(python3 -c "
+import json, sys
+try:
+    s = json.load(open('.claude/settings.json'))
+    print(s.get('env', {}).get('CLAUDE_MEM_PROJECT', ''))
+except: pass
+" 2>/dev/null)
+    if [ "$CURRENT" = "$PROJECT_NAME" ]; then
+      echo "✓ CLAUDE_MEM_PROJECT already set to $PROJECT_NAME"
+    else
+      python3 -c "
+import json
+f = '.claude/settings.json'
+try:
+    s = json.load(open(f))
+except: s = {}
+s.setdefault('env', {})['CLAUDE_MEM_PROJECT'] = '$PROJECT_NAME'
+with open(f, 'w') as fh: json.dump(s, fh, indent=2); fh.write('\n')
+print('✓ CLAUDE_MEM_PROJECT set to $PROJECT_NAME')
+" 2>/dev/null
+    fi
+  else
+    echo "⚠ No .claude/settings.json — skipping CLAUDE_MEM_PROJECT (run /fh:new-project first)"
+  fi
+else
+  echo "⚠ Not a git repo — skipping CLAUDE_MEM_PROJECT"
+fi
+```
+
+### 5a⅞: Refresh tracker template files
+
+If `.project-tracker/` exists, refresh template files from the updated plugin cache. This ensures tracker dashboard changes (UI redesigns, new components, server fixes) are picked up without requiring a manual `/fh:tracker` re-run.
+
+```bash
+if [ -d ".project-tracker" ]; then
+  PLUGIN_ROOT=""
+  LATEST="$(ls -d "$HOME/.claude/plugins/cache/fhhs-skills/fh"/*/ 2>/dev/null | sort | tail -1)"
+  LATEST="${LATEST%/}"
+  if [ -n "$LATEST" ] && [ -d "$LATEST/templates/project-tracker" ]; then
+    PLUGIN_ROOT="$LATEST"
+  fi
+
+  if [ -n "$PLUGIN_ROOT" ]; then
+    PLUGIN_VER=$(python3 -c "import json; print(json.load(open('$PLUGIN_ROOT/.claude-plugin/plugin.json'))['version'])" 2>/dev/null)
+    CURRENT_VER=$(cat .project-tracker/.version 2>/dev/null)
+
+    if [ "$PLUGIN_VER" = "$CURRENT_VER" ]; then
+      echo "✓ Tracker templates already at v$PLUGIN_VER"
+    else
+      # Copy all non-directory files from the template
+      for f in "$PLUGIN_ROOT/templates/project-tracker"/*; do
+        [ -f "$f" ] && cp "$f" ".project-tracker/$(basename "$f")"
+      done
+      echo "$PLUGIN_VER" > .project-tracker/.version
+      echo "✓ Tracker templates refreshed to v$PLUGIN_VER (was: ${CURRENT_VER:-none})"
+    fi
+  else
+    echo "⚠ Could not find plugin templates for tracker refresh"
+  fi
+else
+  echo "· No .project-tracker/ — skipping tracker refresh"
+fi
+```
 
 ### 5b: Changelog-driven reconciliation — auto-fix gaps
 
@@ -362,6 +436,7 @@ Use the **Read tool** to load `~/.claude/settings.json`, then use the **Edit too
 | `CLAUDE_CODE_ENABLE_LSP` | `"1"` |
 | `CLAUDE_CODE_ENABLE_TASKS` | `"true"` |
 | `CLAUDE_CWD` | `"true"` |
+| `CLAUDE_MEM_PROJECT` | Derive from `basename $(git rev-parse --show-toplevel)` — NOT a static value |
 | Any other env | `"true"` (safe default) |
 
 Do NOT overwrite existing keys. Merge carefully.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Entries affecting `/fh:setup` or `/fh:new-project` environment carry reconciliation tags
 (`[setup:TYPE:ID]`, `[project:TYPE:ID]`) used by `/fh:update` for post-update checks.
 
+## [1.41.1] - 2026-03-28
+
+### Fixed
+- **`/fh:update` tracker refresh** — post-update reconciliation now refreshes `.project-tracker/` template files when the plugin version changes, so tracker dashboard redesigns are picked up without manually re-running `/fh:tracker`
+- **`/fh:update` CLAUDE_MEM_PROJECT** — post-update reconciliation now sets `CLAUDE_MEM_PROJECT` in project-local `.claude/settings.json` derived from `git rev-parse --show-toplevel`, fixing observation misattribution in interactive Conductor sessions [setup:env:CLAUDE_MEM_PROJECT]
+- **Tracker template list** — `/fh:tracker` now copies all template files dynamically instead of a hardcoded list that became stale after the dashboard redesign
+
 ## [1.41.0] - 2026-03-28
 
 ### Changed


### PR DESCRIPTION
Version bump and changelog for v1.41.1

### Fixed
- `/fh:update` tracker refresh — post-update reconciliation now refreshes `.project-tracker/` template files
- `/fh:update` CLAUDE_MEM_PROJECT — sets env var in project-local settings.json for Conductor workspaces
- Tracker template list — dynamic file copying instead of stale hardcoded list