### PR TITLE
feat: suggest --global tip after regular update

### DIFF
--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -260,7 +260,9 @@ Then run Steps 5a, 5a½, 5a¾, 5a⅞, and 5b with `PREV_VERSION="0.0.0"` and `LA
 - If ALL items were already OK (nothing missing): `You're on the latest version — environment is fully synced.`
 - If gaps were found and fixed: show the reconciliation table, then `Environment synced. Restart Claude Code to pick up any hook or plugin changes.`
 
-Then check Step 5c (`.planning/` health suggestion) and exit.
+Then check Step 5c (`.planning/` health suggestion).
+
+After Step 5c, also check how many other projects exist (same logic as the post-reconciliation tip in the main flow) and show the `--global` tip if applicable. Then exit.
 
 ---
 
@@ -633,6 +635,32 @@ invalid state references, or outdated directory layouts.
 **After reconciliation is complete (current project):**
 
 If `--global` flag is NOT set:
+
+Check how many other projects exist in the tracker registry:
+
+```bash
+python3 -c "
+import json, pathlib, os
+registry = pathlib.Path(os.path.expanduser('~/.claude/tracker/projects.json'))
+if registry.exists():
+    projects = json.loads(registry.read_text())
+    other = [p for p in projects if os.path.exists(p['path']) and p['path'] != os.getcwd()]
+    print(len(other))
+else:
+    print('0')
+" 2>/dev/null
+```
+
+If the count is greater than 0, show:
+
+```
+Restart Claude Code to use the new version.
+
+Tip: You have N other projects using fhhs-skills. Run /fh:update --global
+to reconcile all of them at once (env sync, health repair, tracker registration).
+```
+
+If 0 or check fails:
 
 ```
 Restart Claude Code to use the new version.

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -9884,6 +9884,78 @@
           "scan"
         ]
       }
+    },
+    {
+      "id": 298,
+      "command": "update",
+      "prompt": "update the plugin to the latest version",
+      "expected_output": "After completing the update and reconciliation for the current project, should check how many other projects exist in the tracker registry. If other projects exist, should suggest running /fh:update --global to reconcile all projects at once. The tip should mention the count of other projects and explain that --global handles env sync, health repair, and tracker registration for all of them.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Checks tracker registry for other projects after current-project reconciliation",
+          "type": "behavioral"
+        },
+        {
+          "text": "Suggests /fh:update --global when other projects exist",
+          "type": "output"
+        },
+        {
+          "text": "Mentions the count of other projects in the tip",
+          "type": "output"
+        },
+        {
+          "text": "Does NOT show the --global tip when no other projects exist",
+          "type": "guard"
+        }
+      ],
+      "tier": "smoke",
+      "tags": [
+        "happy-path",
+        "global-update"
+      ],
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "--global",
+          "projects",
+          "reconcil"
+        ]
+      }
+    },
+    {
+      "id": 299,
+      "command": "update",
+      "prompt": "I just ran /fh:update and it said I have 5 other projects. What does --global actually do to each project?",
+      "expected_output": "The --global flag runs three reconciliation steps on each discovered project: (1) post-update-reconcile.sh for claude-mem patch, CLAUDE_MEM_PROJECT env var, and tracker registration, (2) changelog reconcile to detect env gaps (missing tools, hooks, env vars) using the fhhs-skills plugin changelog, and (3) health --repair to fix .planning/ directory issues. Projects without .planning/ skip the health step. The script discovers projects from two sources: the tracker registry and Conductor workspace scan.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Explains the three reconciliation steps per project",
+          "type": "output"
+        },
+        {
+          "text": "Mentions both discovery sources (tracker registry and Conductor scan)",
+          "type": "output"
+        },
+        {
+          "text": "Notes that health is skipped for projects without .planning/",
+          "type": "output"
+        }
+      ],
+      "tier": "full",
+      "tags": [
+        "happy-path",
+        "global-update"
+      ],
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "reconcil",
+          "tracker",
+          "health"
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

- After `/fh:update` completes, checks tracker registry for other projects
- If other projects exist, shows tip: "You have N other projects. Run /fh:update --global to reconcile all at once"
- Shows on both fresh-update and already-current paths
- 2 new evals (IDs 298-299) covering the suggestion behavior

## Test plan
- [x] Tip shown when other projects exist in registry
- [x] Tip NOT shown when no other projects (guard eval)
- [x] Works on both update paths (fresh update + already current)

🤖 Generated with [Claude Code](https://claude.com/claude-code)