### PR TITLE
feat: ASCII pre-scan and no-git-merge messaging for global update

### DIFF
--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -674,23 +674,77 @@ If `--global` flag IS set, proceed to Step 6.
 
 Discover and reconcile ALL projects using fhhs-skills across the filesystem. This step runs the same reconciliation logic (Steps 5a through 5c) on every discovered project, not just the current one.
 
-### 6a: Run global reconcile
+### 6a: Pre-update scan
 
-The global reconcile uses the **fhhs-skills plugin changelog** (not each project's own changelog) to check environment requirements. The plugin changelog contains reconciliation tags like `[setup:tool:fallow]` and `[setup:hook:fhhs-statusline]` that verify whether each project's environment has the required tools, hooks, and env vars installed. User projects don't need their own changelogs — this is purely about plugin environment sync.
+Before making any changes, scan all projects to show their current state:
 
 ```bash
 # Fetch the fhhs-skills plugin changelog (used for env gap detection across all projects)
-# This was likely already fetched in Step 2, but re-fetch if missing
 if [ ! -f /tmp/fhhs-changelog.md ] || [ ! -s /tmp/fhhs-changelog.md ]; then
   curl -sL "https://raw.githubusercontent.com/cinjoff/fhhs-skills/main/CHANGELOG.md" > /tmp/fhhs-changelog.md 2>/dev/null
 fi
 
-# Build the changelog flag — omit entirely if fetch failed (reconcile still works without it)
 CHANGELOG_FLAG=""
 if [ -s /tmp/fhhs-changelog.md ]; then
   CHANGELOG_FLAG="--changelog-file /tmp/fhhs-changelog.md"
 fi
 
+# Scan without making changes
+node "$HOME/.claude/get-shit-done/bin/global-reconcile.cjs" \
+  --scan-only --from "$PREV_VERSION" --to "$LATEST_VERSION" \
+  $CHANGELOG_FLAG
+```
+
+Parse the JSON and display an ASCII project status map. Group projects by Conductor workspace:
+
+```
+## Projects to reconcile
+
+  fh-starter-project
+  ├─ havana         ■■■■■■■□□□  health: degraded  4 env gaps
+  └─ kyoto          □□□□□□□□□□  no .planning      4 env gaps  ⚠ no settings.json
+
+  nerve-os
+  ├─ toronto        ■■■■■■□□□□  health: degraded  4 env gaps
+  └─ quito          □□□□□□□□□□  no .planning      4 env gaps  ⚠ no settings.json
+
+  fhhs-skills
+  ├─ san-francisco  ■■■■■■□□□□  health: degraded  2 env gaps
+  ├─ casablanca     ■■■■■■□□□□  health: degraded  2 env gaps
+  └─ dallas         ■■■□□□□□□□  health: broken    4 env gaps  ⚠ no settings.json
+
+  (standalone)
+  └─ san-juan       ■■■■■■■■■■  health: healthy   0 env gaps
+
+  Legend: ■ = ok  □ = needs attention  ⚠ = missing .claude/settings.json
+```
+
+**Build the progress bar** from the scan data:
+- `health: healthy` + 0 env gaps + has settings.json = full bar (10 filled)
+- `health: degraded` = 6 filled
+- `health: broken` = 3 filled
+- No `.planning/` = 0 filled
+- Each env gap subtracts 1 from the bar
+- Missing settings.json gets a `⚠` flag
+
+After showing the scan, display:
+
+```
+These changes are applied directly in each project directory — no git
+merge or branch changes are involved. Plugin skills come from the global
+plugin cache, and environment files (.claude/settings.json, .planning/
+config) are updated in-place.
+
+If you use Conductor: existing workspaces will pick up the new plugin
+skills automatically (they read from the cache). No need to merge main
+or start new workspaces for plugin updates.
+```
+
+### 6b: Run global reconcile
+
+The global reconcile uses the **fhhs-skills plugin changelog** (not each project's own changelog) to check environment requirements. The plugin changelog contains reconciliation tags like `[setup:tool:fallow]` and `[setup:hook:fhhs-statusline]` that verify whether each project's environment has the required tools, hooks, and env vars installed. User projects don't need their own changelogs — this is purely about plugin environment sync.
+
+```bash
 # Run global reconcile — discovers projects from tracker registry + Conductor scan
 node "$HOME/.claude/get-shit-done/bin/global-reconcile.cjs" \
   --from "$PREV_VERSION" --to "$LATEST_VERSION" \
@@ -706,7 +760,7 @@ For each project, it runs:
 - `changelog reconcile` (env gap detection using the fhhs-skills plugin changelog — skipped if changelog unavailable)
 - `validate health --repair` (planning directory health)
 
-### 6b: Display aggregate results
+### 6c: Display aggregate results
 
 Format the JSON report into a human-readable summary:
 
@@ -742,7 +796,7 @@ Run /fh:update in each project individually to apply the full remediation
 
 The global reconcile script handles env *detection* but not remediation (tool installs, hook additions need the full SKILL.md logic). The per-project `/fh:update` handles the actual fixes.
 
-### 6c: Stale project cleanup
+### 6d: Stale project cleanup
 
 If any projects from the tracker registry no longer exist on disk (paths that 404'd during discovery), offer to clean them up:
 
@@ -788,7 +842,7 @@ print(f'Removed {removed} stale entries')
 "
 ```
 
-### 6d: Final summary
+### 6e: Final summary
 
 ```
 ## Summary

--- a/bin/global-reconcile.cjs
+++ b/bin/global-reconcile.cjs
@@ -31,16 +31,19 @@ const args = process.argv.slice(2);
 let fromVersion = '0.0.0';
 let toVersion = '';
 let changelogFile = '';
+let scanOnly = false;
 for (let i = 0; i < args.length; i++) {
   switch (args[i]) {
     case '--from': fromVersion = args[++i]; break;
     case '--to': toVersion = args[++i]; break;
     case '--changelog-file': changelogFile = args[++i]; break;
+    case '--scan-only': scanOnly = true; break;
   }
 }
 
-if (!toVersion) {
+if (!scanOnly && !toVersion) {
   console.error('Usage: global-reconcile.cjs --from <ver> --to <ver> --changelog-file <path>');
+  console.error('       global-reconcile.cjs --scan-only');
   process.exit(1);
 }
 
@@ -228,6 +231,66 @@ function reconcileProject(project) {
   return result;
 }
 
+// ─── Scan (pre-update preview) ───────────────────────────────────────────────
+
+function scanProject(project) {
+  const scan = {
+    path: project.path,
+    name: project.name,
+    isConductor: project.isConductor,
+    conductorWorkspace: project.conductorWorkspace,
+    hasPlanning: project.hasPlanning,
+    hasClaudeSettings: project.hasClaudeSettings,
+    health: null,
+    envGaps: 0,
+  };
+
+  // Check health status (read-only, no --repair)
+  if (project.hasPlanning) {
+    const gsdTools = path.join(os.homedir(), '.claude', 'get-shit-done', 'bin', 'gsd-tools.cjs');
+    if (fs.existsSync(gsdTools)) {
+      try {
+        const out = execFileSync('node', [gsdTools, 'validate', 'health'], {
+          cwd: project.path, timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        const parsed = JSON.parse(out.toString().trim());
+        scan.health = {
+          status: parsed.status || 'unknown',
+          errors: (parsed.errors || []).length,
+          warnings: (parsed.warnings || []).length,
+          repairable: parsed.repairable_count || 0,
+        };
+      } catch {
+        scan.health = { status: 'error', errors: 0, warnings: 0, repairable: 0 };
+      }
+    }
+  }
+
+  // Check env gaps (read-only)
+  if (changelogFile && fs.existsSync(changelogFile)) {
+    const gsdTools = path.join(os.homedir(), '.claude', 'get-shit-done', 'bin', 'gsd-tools.cjs');
+    if (fs.existsSync(gsdTools)) {
+      try {
+        const out = execFileSync('node', [
+          gsdTools, 'changelog', 'reconcile',
+          '--from', fromVersion, '--to', toVersion || '99.99.99',
+          '--changelog-file', changelogFile,
+          '--project-root', project.path,
+        ], { cwd: project.path, timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] });
+        const parsed = JSON.parse(out.toString().trim());
+        scan.envGaps = parsed.missing ? parsed.missing.length : 0;
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  // Check if .claude/settings.json is missing
+  scan.missingSettings = !project.hasClaudeSettings;
+
+  return scan;
+}
+
 // ─── Main ────────────────────────────────────────────────────────────────────
 
 function main() {
@@ -235,6 +298,23 @@ function main() {
 
   if (projects.length === 0) {
     const report = { projects: [], summary: 'No projects found' };
+    console.log(JSON.stringify(report, null, 2));
+    process.exit(0);
+  }
+
+  // Scan-only mode: preview without changes
+  if (scanOnly) {
+    const scans = projects.map(p => scanProject(p));
+    const report = {
+      mode: 'scan',
+      discovery: {
+        total: projects.length,
+        fromTracker: projects.filter(p => p.source === 'tracker').length,
+        fromScan: projects.filter(p => p.source === 'conductor-scan').length,
+        withPlanning: projects.filter(p => p.hasPlanning).length,
+      },
+      projects: scans,
+    };
     console.log(JSON.stringify(report, null, 2));
     process.exit(0);
   }


### PR DESCRIPTION
## Summary

- Pre-scan step (6a) shows ASCII tree visualization of all projects grouped by workspace before making changes
- Progress bars show health status, env gaps, missing settings.json flags
- Explicit messaging that no git merge happens — files are updated in-place, plugin skills come from global cache
- `--scan-only` mode added to `global-reconcile.cjs` for preview without changes

## Test plan
- [x] `--scan-only` discovers 13 projects, returns health + gap data without modifying anything
- [x] Non-git directories handled gracefully in scan mode
- [x] Messaging clarifies no branch/merge impact for Conductor users

🤖 Generated with [Claude Code](https://claude.com/claude-code)