### PR TITLE
feat: auto health repair with progress reporting

### DIFF
--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -615,17 +615,36 @@ Check if the user has an existing `.planning/` directory in the current project:
 
 **If HAS_PLANNING:**
 
+Run health repair automatically:
+
+```bash
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" validate health --repair
+```
+
+Parse the JSON output and display results:
+
 ```
 ### .planning/ health check
 
-Your project has a .planning/ directory. If it was created with an
-older version of this plugin (or plain GSD), it may have structural
-issues. Run:
+Status: HEALTHY | DEGRADED | BROKEN
+Errors: N | Warnings: N
+```
 
-  /fh:health --repair
+**If repairs were performed**, list them:
 
-This will detect and auto-fix common problems like missing config,
-invalid state references, or outdated directory layouts.
+```
+Repairs performed:
+  ✓ config.json: Created with defaults
+  ✓ STATE.md: Regenerated from roadmap
+  ✓ workflow.nyquist_validation: Added to config
+```
+
+**If errors remain that couldn't be auto-fixed:**
+
+```
+Remaining issues (manual fix needed):
+  [E002] PROJECT.md not found — run /fh:new-project
+  [W005] Phase directory "setup" doesn't follow NN-name format
 ```
 
 **If NO_PLANNING:** Skip silently.
@@ -811,6 +830,35 @@ Run /fh:update in each project individually to apply the full remediation
 ```
 
 The global reconcile script handles env *detection* but not remediation (tool installs, hook additions need the full SKILL.md logic). The per-project `/fh:update` handles the actual fixes.
+
+**If any projects had health repairs:**
+
+Show what was actually fixed across all projects:
+
+```
+### Health repairs performed
+
+  havana:
+    ✓ config.json: Created with defaults
+    ✓ workflow.nyquist_validation: Added to config
+
+  toronto:
+    ✓ STATE.md: Regenerated from roadmap
+
+  Total: 3 repairs across 2 projects
+```
+
+**If any projects still have health issues after repair:**
+
+```
+### Remaining health issues (manual fix needed)
+
+  chicago-v1: BROKEN
+    [E002] PROJECT.md not found — run /fh:new-project
+
+  dallas: BROKEN
+    [E003] ROADMAP.md not found — run /fh:new-project
+```
 
 **If any projects have stale git-tracked files:**
 

--- a/bin/global-reconcile.cjs
+++ b/bin/global-reconcile.cjs
@@ -209,6 +209,8 @@ function reconcileProject(project) {
           errors: (parsed.errors || []).length,
           warnings: (parsed.warnings || []).length,
           repairsPerformed: parsed.repairs_performed || [],
+          errorDetails: (parsed.errors || []).map(e => ({ code: e.code, message: e.message })),
+          warningDetails: (parsed.warnings || []).map(w => ({ code: w.code, message: w.message })),
         };
       } catch (e) {
         // Health check may output non-JSON on some errors
@@ -360,8 +362,16 @@ function main() {
   }
 
   const results = [];
-  for (const project of projects) {
-    results.push(reconcileProject(project));
+  for (let i = 0; i < projects.length; i++) {
+    const project = projects[i];
+    // Progress to stderr (not captured in JSON stdout)
+    process.stderr.write(`[${i + 1}/${projects.length}] ${project.name}...`);
+    const result = reconcileProject(project);
+    const healthStatus = result.steps.healthRepair?.status || 'skip';
+    const repairs = result.steps.healthRepair?.repairsPerformed?.length || 0;
+    const stale = result.steps.staleFileCheck?.files?.length || 0;
+    process.stderr.write(` ${result.status === 'ok' ? 'ok' : 'partial'} (health: ${healthStatus}${repairs > 0 ? `, ${repairs} repaired` : ''}${stale > 0 ? `, ${stale} stale` : ''})\n`);
+    results.push(result);
   }
 
   // Build summary


### PR DESCRIPTION
## Summary

- Regular `/fh:update` now runs `health --repair` automatically (was only suggesting it)
- Global update shows progress as each project completes: `[1/13] kyoto... ok (health: degraded, 1 repaired)`
- Detailed repair report shows what was fixed and what still needs manual attention per-project
- Error/warning details included in JSON output

## Test plan
- [x] Progress output to stderr verified (13 projects)
- [x] Repair details surfaced in JSON (repairsPerformed + errorDetails + warningDetails)
- [x] Regular update path runs health --repair inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)