### PR TITLE
release: v1.52.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "fh",
       "description": "fhhs-skills: Composite workflow skills unifying engineering discipline, design quality, and project tracking. Includes /fh:plan-work, /fh:build, /fh:fix, /fh:review, /fh:ui-critique, /fh:polish, and 30+ more commands.",
-      "version": "1.52.1",
+      "version": "1.52.2",
       "author": {
         "name": "Konstantin"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fh",
   "description": "fhhs-skills: All-in-one workflow plugin — engineering discipline (TDD, verification, code review), design quality (critique, polish, normalize), and project tracking (phases, milestones, roadmaps). No other plugins required.",
-  "version": "1.52.1",
+  "version": "1.52.2",
   "author": {
     "name": "Konstantin"
   },

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -205,6 +205,7 @@ non-interactive environments. Open a separate terminal and run:
   claude plugin update fh@fhhs-skills
 
 Then come back and run /fh:update again to complete reconciliation.
+(If you used --global, re-add it: /fh:update --global)
 
 ──────────────────────────────────────────────────────────────
 → Run the command above in your terminal, then type "done"
@@ -262,7 +263,10 @@ Then run Steps 5a, 5a½, 5a¾, 5a⅞, and 5b with `PREV_VERSION="0.0.0"` and `LA
 
 Then check Step 5c (`.planning/` health suggestion).
 
-After Step 5c, also check how many other projects exist (same logic as the post-reconciliation tip in the main flow) and show the `--global` tip if applicable. Then exit.
+After Step 5c, check for the `--global` flag:
+
+- **If `--global` IS set:** Proceed to Step 6 (global project reconciliation). The current project was just reconciled; now reconcile all others.
+- **If `--global` is NOT set:** Check how many other projects exist (same logic as the post-reconciliation tip in the main flow) and show the `--global` tip if applicable. Then exit.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Entries affecting `/fh:setup` or `/fh:new-project` environment carry reconciliation tags
 (`[setup:TYPE:ID]`, `[project:TYPE:ID]`) used by `/fh:update` for post-update checks.
 
+## [1.52.2] - 2026-03-29
+
+### Fixed
+- **Global update on already-current plugin** — `--global` flag was silently ignored when the plugin version already matched latest (Step 5½ exited before reaching Step 6), now correctly proceeds to global reconciliation
+- **Conductor CHECKPOINT reminder** — update failure message now reminds users to re-add `--global` when re-running after manual CLI update
+
+### Added
+- **Global update evals** — 3 new evals covering `--global` flag behavior including the already-up-to-date edge case
+
 ## [1.52.1] - 2026-03-28
 
 ### Fixed

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -10698,6 +10698,128 @@
           "pattern": "log|classif|next|action"
         }
       ]
+    },
+    {
+      "id": 322,
+      "command": "update",
+      "prompt": "update --global",
+      "expected_output": "Should update plugin then discover ALL projects using fhhs-skills (from tracker registry and Conductor workspaces) and reconcile each one. Should show project status map before reconciling, then aggregate results table after.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Discovers projects from tracker registry and Conductor workspace scan",
+          "type": "behavioral"
+        },
+        {
+          "text": "Runs reconciliation on multiple projects, not just current one",
+          "type": "behavioral"
+        },
+        {
+          "text": "Shows aggregate results with per-project status",
+          "type": "output"
+        },
+        {
+          "text": "Runs global-reconcile.cjs script for cross-project reconciliation",
+          "type": "behavioral"
+        }
+      ],
+      "scenario_requires": [
+        "gsd_project"
+      ],
+      "tier": "full",
+      "tags": [
+        "happy-path",
+        "global"
+      ],
+      "checks": [
+        {
+          "type": "required_terms",
+          "terms": [
+            "global",
+            "reconcil"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 323,
+      "command": "update",
+      "prompt": "update --global",
+      "expected_output": "When plugin is already at latest version but --global is passed, should still run environment reconciliation on current project AND then proceed to global reconciliation across all discovered projects. Must NOT exit after current-project reconciliation.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Recognizes plugin is already up to date",
+          "type": "behavioral"
+        },
+        {
+          "text": "Runs environment reconciliation on current project first",
+          "type": "behavioral"
+        },
+        {
+          "text": "Proceeds to global project reconciliation (Step 6) despite already being up to date",
+          "type": "behavioral"
+        },
+        {
+          "text": "Does NOT exit after current-project reconciliation when --global is set",
+          "type": "guard"
+        }
+      ],
+      "scenario_requires": [
+        "gsd_project"
+      ],
+      "tier": "full",
+      "tags": [
+        "edge-case",
+        "guard",
+        "global"
+      ],
+      "checks": [
+        {
+          "type": "required_terms",
+          "terms": [
+            "global",
+            "reconcil"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 324,
+      "command": "update",
+      "prompt": "I just updated the plugin from a different terminal. Now I want to update all my other projects too",
+      "expected_output": "Should detect plugin is already current, run local reconciliation, then recognize this is a --global use case and either suggest --global or if --global was passed, proceed to Step 6 global reconciliation.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Detects plugin is already at latest version",
+          "type": "behavioral"
+        },
+        {
+          "text": "Mentions --global flag for cross-project reconciliation",
+          "type": "output"
+        },
+        {
+          "text": "Does NOT attempt to reinstall an already-current plugin",
+          "type": "guard"
+        }
+      ],
+      "scenario_requires": [
+        "gsd_project"
+      ],
+      "tier": "full",
+      "tags": [
+        "edge-case",
+        "global"
+      ],
+      "checks": [
+        {
+          "type": "required_terms",
+          "terms": [
+            "global"
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Version bump and changelog for v1.52.2

### Fixed
- **Global update on already-current plugin** — `--global` flag was silently ignored when the plugin version already matched latest
- **Conductor CHECKPOINT reminder** — update failure message now reminds users to re-add `--global`

### Added
- 3 new evals covering `--global` flag behavior