### PR TITLE
chore: add conductor.json for worktree setup

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -54,7 +54,7 @@ created: "2026-03-25"
 - **REQ-25:** /fh:audit-upstream evaluates upstream changes and maintains the capability index
 - **REQ-26:** Gap Registry tracks unused upstream capabilities with prioritized integration recommendations
 
-## Startup Validation Skills
+## Startup Validation Skills (Complete — shipped v1.39.0)
 
 - **REQ-27:** Pre-building skills help founders validate ideas, research markets, and shape startups before writing code
 - **REQ-28:** Each startup skill works standalone but produces richer output when prior skill artifacts exist (progressive enrichment)
@@ -65,9 +65,35 @@ created: "2026-03-25"
 - **REQ-33:** Reference files required at runtime are co-located in `.claude/skills/{name}/` (shipping boundary)
 - **REQ-34:** `/fh:startup-advisor` provides three-tier knowledge retrieval: claude-mem indexed YC library → shipped curated frameworks → firecrawl/web search
 - **REQ-35:** ~~DROPPED~~ — composite orchestrator removed; startup-design IS the journey, others are optional depth/follow-up
-- **REQ-39:** All startup skills use `startup-` prefix for discoverability (startup-design, startup-competitors, startup-positioning, startup-pitch, startup-advisor)
-- **REQ-40:** `/fh:plan-work` reads `.planning/startup/` as domain context — market data, competitors, and positioning inform planning decisions
-- **REQ-41:** `/fh:auto` pre-indexes `.planning/startup/` alongside other `.planning/` files for each phase session
 - **REQ-36:** `/fh:new-project` Step 0.5 detects `.planning/startup/` and auto-populates project vision from startup artifacts
-- **REQ-37:** `/fh:startup-design` supports `--refresh` to update existing artifacts (other skills get `--refresh` in later milestone)
+- **REQ-37:** `/fh:startup-design` supports `--refresh` to update existing artifacts
 - **REQ-38:** `/fh:auto` detects missing `.planning/` and suggests running startup skills first
+- **REQ-39:** All startup skills use `startup-` prefix for discoverability
+- **REQ-40:** `/fh:plan-work` reads `.planning/startup/` as domain context
+- **REQ-41:** `/fh:auto` pre-indexes `.planning/startup/` alongside other `.planning/` files
+
+## Auto Skill Optimization & Observability
+
+- **REQ-42:** Auto orchestrator validates .auto-state.json on resume — corrupted state is detected, renamed to .corrupt, and fresh run starts
+- **REQ-43:** Milestone completion awareness — orchestrator detects all-phases-done and suggests archive
+- **REQ-44:** Walk-away narrative documented in SKILL.md — from project description to working codebase
+- **REQ-45:** Auto pipeline lifecycle evals cover corrupt state, milestone complete, walk-away scenarios
+- **REQ-46:** Observability dashboard shows live auto progress (activity feed, step tokens, cost)
+- **REQ-47:** Cost optimization measured — per-phase agent cost tracked, context waste identified
+- **REQ-48:** Auto agents use context-mode (ctx_search) for large files instead of Read
+
+## Serena & Context Workflow
+
+- **REQ-49:** Serena is primary symbol navigator when installed — not "enhanced alternative"
+- **REQ-50:** map-codebase uses Serena `get_symbols_overview` on entry points before agent dispatch
+- **REQ-51:** Workflow decision matrix documented: when to use context-mode vs Serena vs claude-mem vs Read
+- **REQ-52:** Serena runs in `--mode no-memories` — symbol tools only, claude-mem handles cross-session memory
+- **REQ-53:** Evals updated for Serena-primary behavior in fix, refactor, extract skills
+
+## Eval Framework & Continuous Improvement
+
+- **REQ-54:** /auto-improve command runs iterative eval analysis, proposes fixes, re-runs to verify
+- **REQ-55:** Eval pass rates baselined and tracked — regressions detected automatically
+- **REQ-56:** Before/after metrics required for every skill change
+- **REQ-57:** Deterministic checks alongside keyword heuristics in eval grading
+- **REQ-58:** Context-mode token savings and Serena impact measurable via eval infrastructure

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,196 +1,193 @@
 ---
 type: roadmap
 project: fhhs-skills
-version: v1
+version: v2
 created: "2026-03-25"
-phases: 11
+revised: "2026-03-29"
+phases: 12
 ---
 
 # Roadmap
 
-## Phase 1: Skill Quality & Eval Coverage
-**Goal:** Every shipped skill works correctly and has eval coverage proving it.
-**Status:** Mostly complete (130+ evals, all skills covered)
-
-- All composite skills orchestrate correctly (build, plan-work, fix, refactor, review, simplify)
-- All design skills produce quality output (23 design commands)
-- Eval suite covers happy paths, edge cases, misrouting, failure recovery, state corruption
-- Fixture-backed evals validate against real project structures
-
-## Phase 2: Upstream Sync & Patch Stability
-**Goal:** Upstream updates can be incorporated without breaking patched skills.
-**Status:** Complete
-
-- Upstream sync workflow documented and repeatable
-- PATCHES.md and COMPATIBILITY.md stay accurate after syncs
-- Eval suite catches regressions introduced by upstream changes
-- `/fh:sync-upstream` skill guides the process
-- Pre-sync validation (Step 0.5) checks forked paths, snapshots, PATCHES.md
-- Git checkpoint (Step 3.5) with --include-untracked before modifications
-- Post-sync regression detection (Step 4.5) with targeted eval runs
-- Registry has explicit eval_commands per upstream
-- Eval runner supports --commands filter for targeted runs
-- 6 sync-upstream evals covering validation and regression flows
-
-## Phase 3: Upstream Capability Audit & Integration Planning
-**Goal:** All upstream capabilities are cataloged, quality-assessed, and gaps identified with integration recommendations.
-**Status:** Complete
-
-- UPSTREAM-INDEX.md documents all 8 upstream sources with skill-level detail
-- Every upstream skill has quality rating (A-D) and integration status
-- Gap Registry identifies unused high-value capabilities with recommended approaches (G1-G11)
-- /fh:audit-upstream skill maintains the index after upstream syncs
-- SDLC coverage matrix shows where gaps exist across the development lifecycle
-- 8 per-source upstream catalog files in `.planning/upstream/`
-- 13 audit-upstream evals (IDs 181-193)
-
-## Phase 3.5: Pipeline Depth & Intelligence
-**Goal:** Plan-work and new-project pipelines intelligently assess task complexity and suggest appropriate depth — deeper research, decision-locking, and engineering review when warranted.
-**Status:** Planning
-
-- `/fh:plan-work` evaluates complexity and suggests deep research for unfamiliar domains
-- Decision-locking (CONTEXT.md locked/discretion/deferred) prevents cross-session drift
-- Engineering review mode complements existing CEO-style plan-review
-- `/fh:build` wires verification-before-completion into final steps
-- Upstream gap registry items G1-G5 addressed
-
-## Phase 4: User Experience & Onboarding
-**Goal:** Non-technical users can install and use the plugin without assistance.
-
-- `/fh:setup` handles all platform-specific tooling installation
-- Documentation is clear, non-verbose, and action-oriented
-- Error messages always suggest next steps
-- `/fh:progress` and `/fh:tracker` provide clear status at any point
-
-## Phase 5: Advanced Integrations
-**Goal:** Skills leverage external tooling for deterministic analysis where available.
-
-- Fallow CLI integration for static analysis (unused exports, circular deps, complexity)
-- TypeScript LSP integration for type-aware code analysis
-- Graceful degradation when external tools aren't available
-
-## Phase 6: Ecosystem & Distribution
-**Goal:** Plugin is discoverable, installable, and maintainable at scale.
-
-- Marketplace listing is accurate and compelling
-- Release process is automated (version bump, changelog, tag, GitHub release)
-- Plugin update mechanism works reliably (`/fh:update`)
-- Community feedback loop established
-
-## Phase 7: Autonomous Execution & Harness Engineering
-**Goal:** Users can invoke `/fh:auto` with a project description and walk away — the system produces a working codebase with multi-milestone roadmap, executed phases, and a DECISIONS.md audit trail, without human intervention.
-
-- DECISIONS.md as append-only autonomous decision journal with confidence flagging and correction cascade
-- `/fh:new-project --auto` with deep research, scope-expansion roadmap, elaborate multi-milestone output
-- Autonomous loop: plan-work → plan-review (HOLD SCOPE) → build → review per phase
-- Headless orchestrator using `claude -p` for process-isolated agent sessions with crash recovery
-- Stuck detection, timeout supervision, and cost tracking
-- Decision correction cascade: human corrects a decision, system identifies downstream impact
-
-## Phase 9: Learning Persistence & Feedback Loop
-**Goal:** Workflow issues and skill improvement opportunities are automatically extracted from claude-mem observations and filed as GitHub issues.
-
-- `/fh:learnings` analyzes cross-project observations from claude-mem
-- Surfaces positive insights and productive patterns alongside problems
-- Clusters similar issues and deduplicates against existing GitHub issues
-- Auto-files structured issues with problem/evidence/suggestion format
-- Supports --dry-run and configurable time windows
-- Suggests claude-mem dashboard for deeper exploration
+> **v2 revision (2026-03-29):** Reconciled phase statuses with implementation reality. Absorbed orphan Phase 08 (pipeline optimization). Reprioritized remaining work around three goals: (1) auto skill optimization with observability, (2) Serena-driven context/memory workflow rework, (3) eval framework strengthening via /auto-improve and /skill-creator.
 
 ---
 
-# Milestone: Startup Validation Skills
+## Completed Phases
 
-Pre-building skills that help founders validate ideas, research markets, and shape their startup before writing code. Artifacts produced become the starting point for `/fh:new-project`.
+### Phase 1: Skill Quality & Eval Coverage
+**Goal:** Every shipped skill works correctly and has eval coverage proving it.
+**Status:** Complete
 
-**Research:** `.planning/research/startup-skills-research.md`
-**Upstream candidate:** [ferdinandobons/startup-skill](https://github.com/ferdinandobons/startup-skill) (MIT, 4 skills, 52 commits)
+- 210+ evals covering all shipped skills
+- Happy paths, edge cases, misrouting, failure recovery, state corruption
+- Fixture-backed evals with real project structures
 
-## Phase 10: Deep Skill Analysis & Architecture Design
-**Goal:** Save upstream snapshot, analyze skill internals, and design the 5-skill startup suite — boundaries, artifacts, chains, and advisor knowledge system.
+### Phase 2: Upstream Sync & Patch Stability
+**Goal:** Upstream updates can be incorporated without breaking patched skills.
+**Status:** Complete
 
-### Upstream & Analysis
-- Save `ferdinandobons/startup-skill` verbatim in `upstream/startup-skill/` (all 4 skills + references + output-guidelines)
-- Clone full repo (not just raw files) to capture all reference files and inter-skill dependencies
-- Analyze each SKILL.md: prompt structure, phase flow, parallel agent dispatch, fallback chains
-- Document artifact chain: which files each skill reads from prior skills, exact paths and formats
-- Catalog all reference files and their role (agent templates, research prompts, output guidelines)
-- Document startup-design's Fast Track mode and checkpoint/resume mechanism
-- Assess shipping boundary: what must co-locate in `.claude/skills/`, what's too large to ship
+- `/fh:sync-upstream` workflow with pre-sync validation, git checkpoints, post-sync regression detection
+- PATCHES.md and COMPATIBILITY.md stay accurate after syncs
+- 6 sync-upstream evals
 
-### Architecture Design (5 skills)
-- **4 forked workflow skills:** `/fh:startup-design` (monolithic 8-phase, the comprehensive journey), `/fh:startup-competitors` (optional deeper dive), `/fh:startup-positioning` (optional deeper dive), `/fh:startup-pitch` (natural follow-up)
-- **1 new skill:** `/fh:startup-advisor` (claude-mem + frameworks + firecrawl)
-- Per-skill spec: name, trigger phrases, explicit exclusions, YAML description draft
-- Artifact directory: `.planning/startup/` with per-skill output files
-- Artifact chain map: which skill produces what, which reads what, fallback when prior data missing
-- `/fh:startup-design --refresh` design: update existing artifacts (v1 for this skill only, others deferred)
-- Artifact flow design: `.planning/startup/` feeds `/fh:new-project` (Step 0.5), `/fh:plan-work` (domain context), `/fh:auto` (pre-indexed), `/fh:plan-review` (business reality checks)
-- Territory conflict analysis: no overlap with `/fh:plan-work`, `/fh:review`, `/fh:research`, `/fh:plan-review`
+### Phase 3: Upstream Capability Audit & Integration Planning
+**Goal:** All upstream capabilities are cataloged, quality-assessed, and gaps identified.
+**Status:** Complete
 
-### Advisor Knowledge Architecture
-- Three-tier retrieval: claude-mem (indexed YC library) → shipped frameworks → firecrawl + WebSearch fallback
-- `/fh:startup-advisor --setup`: downloads YC resources from pinned release, indexes into claude-mem with proper tagging
-- Shipped `references/frameworks/*.md` (~20-30KB): distilled decision frameworks as fallback
-- Firecrawl with targeted arguments (scrape mode for specific URLs, search mode for market data)
-- Context grounding: advisor reads `.planning/startup/` artifacts to personalize advice
+- UPSTREAM-INDEX.md with 8 upstream sources, per-skill quality ratings
+- Gap Registry (G1-G11), SDLC coverage matrix
+- 13 audit-upstream evals
 
-### Integration Points
-- `/fh:new-project` bridge: Step 0.5 reads `.planning/startup/` to auto-populate vision, scope, constraints
-- `/fh:auto` detection: when no `.planning/` exists, suggest running `/fh:startup-design` first
-- Startup artifacts drive `/fh:plan-work` — scorecard, market analysis, positioning inform planning decisions
+### Phase 3.5: Pipeline Depth & Intelligence
+**Goal:** Pipelines intelligently assess task complexity and suggest appropriate depth.
+**Status:** Complete
 
-### Delight Features (design only)
-- Visual ASCII scorecard from `/fh:startup-design` (screenshot-worthy format)
-- 2-sentence description generator with clarity scoring (grandmother test)
-- `/fh:startup-pitch --practice` investor roleplay mode (adapt from upstream)
-- Shareable battle card format (self-contained, Notion/Docs-ready)
+- Decision-locking (CONTEXT.md locked/discretion/deferred) prevents cross-session drift
+- Engineering review mode in plan-review
+- Verification-before-completion in build
+- 3 plans executed with SUMMARYs
 
-### Deliverable
-- `.planning/research/startup-skill-deep-analysis.md` — per-skill upstream breakdown
-- `.planning/research/startup-skill-architecture.md` — skill specs, artifact map, territory rules, advisor design, delight specs
+### Phase 4: User Experience & Onboarding
+**Goal:** Non-technical users can install and use the plugin without assistance.
+**Status:** Complete (core)
 
-## Phase 11: Integration Planning & Readiness
-**Goal:** Plan exact implementation changes, validate the architecture is buildable, and produce a go/no-go assessment with implementation wave plan.
+- `/fh:setup` with platform detection, first-run detection, Getting Started flow
+- Standardized error messages with next-step suggestions
+- `/fh:progress` routes new users to setup
+- Onboarding evals added
+- _Note: tracker UI redesign (plan 01/03) partially done, continued in Phase 8_
 
-### Upstream Integration
-- Plan PATCHES.md entries for each forked skill
-- Plan COMPATIBILITY.md updates (startup-skill as source #9)
-- Plan UPSTREAM-INDEX.md update: add startup-skill with per-skill quality ratings
-- Plan sync-upstream registry addition for future upstream syncs
+### Phase 6: Ecosystem & Distribution
+**Goal:** Plugin is discoverable, installable, and maintainable at scale.
+**Status:** Complete
 
-### Per-Skill Adaptation Plan
-- List all changes needed per forked SKILL.md: path changes (upstream dirs → `.planning/startup/`), naming (`/fh:` prefix), reference co-location
-- New skill not in upstream: `/fh:startup-advisor` (knowledge + search)
-- `/fh:startup-design --refresh` implementation approach: diff existing artifacts, update sections, preserve user edits
-- Reference files: which must ship vs generated at runtime (web research results)
-- Size assessment: estimate total shipped file size, check plugin cache constraints
+- Marketplace listing, automated release process
+- `/fh:update` and `/fh:release` working
+- Community docs and contributor guide
+- Health check integrated into release flow
 
-### New-Project & Auto Bridge
-- Plan `/fh:new-project` Step 0.5: detect `.planning/startup/`, read artifacts, auto-populate PROJECT.md
-- Map which startup artifacts feed which new-project questions
-- Plan `/fh:auto` detection: suggest startup skills when no `.planning/` exists
-- Design how `.planning/startup/` artifacts flow into `/fh:plan-work` (domain context), `/fh:auto` (pre-indexed per phase), and `/fh:plan-review` (business reality checks)
-- Plan modifications to plan-work and auto to read `.planning/startup/` as context source
+### Phase 8: Pipeline Optimization
+**Goal:** Build and review pipelines are fast, cheap, and well-structured.
+**Status:** Complete
 
-### Eval Strategy
-- Minimum 3 evals per skill: standalone mode, chained mode (with prior artifacts), fast-track mode (startup-design)
-- Advisor skill: eval for framework retrieval, eval for claude-mem search, eval for web fallback
-- Territory conflict evals: ensure startup skills don't trigger on development tasks
+- Build pipeline slimmed (9 to 7 steps): removed spec gate, Fallow gates, self-check
+- Model tiering: Sonnet for implementers, Haiku for GSD state
+- 1-agent simplify (was 3), inlined checkpoint protocol
+- Conditional context injection in implementer prompt
+- Plan-work brainstorm fast-track for Simple tasks
+- Configurable plan limits via config.json
+- 3 plans executed with SUMMARYs
 
-### Implementation Wave Plan
-- Wave 1: Upstream snapshot + base skill forks (startup-design, startup-competitors, startup-positioning, startup-pitch)
-- Wave 2: New skill (startup-advisor with framework references + claude-mem --setup)
-- Wave 3: New-project bridge (Step 0.5) + auto detection + downstream integration (plan-work + auto + plan-review read .planning/startup/)
-- Wave 4: Delight features + evals + startup-design --refresh
-- Risk assessment + mitigation strategies per wave
+### Phase 9: Learning Persistence & Feedback Loop
+**Goal:** Workflow issues extracted from claude-mem and filed as GitHub issues.
+**Status:** Complete (skill shipped)
 
-### Go/No-Go Checklist
-- All architectural decisions recorded and consistent
-- No unresolved questions or dependencies
-- Size budget confirmed within plugin cache limits
-- Eval strategy covers all skill modes
-- Implementation waves have clear execution order
+- `/fh:learnings` analyzes cross-project observations
+- Positive insights, clustering, dedup, auto-filing, dry-run, configurable windows
+- 8 evals (4 core + 4 edge-case)
+- _Note: plan 01 SUMMARY pending — skill was verified complete, just needs doc_
 
-### Deliverable
-- `.planning/research/startup-skill-integration-plan.md` — task breakdown, wave plan, go/no-go checklist
+### Phase 10-11: Startup Validation Skills
+**Goal:** Pre-building skills for founders to validate ideas before coding.
+**Status:** Complete (shipped in v1.39.0)
+
+- 5 skills shipped: startup-design, startup-competitors, startup-positioning, startup-pitch, startup-advisor
+- Upstream snapshot saved, PATCHES.md updated
+- new-project bridge (Step 0.5), auto detection
+- 15+ startup skill evals
+
+---
+
+## Active Work
+
+### Phase 5: Advanced Integrations — Serena & Context Workflow
+**Goal:** Skills leverage Serena for symbol navigation and context-mode for token efficiency. Workflow rework to identify what Serena should replace vs complement.
+**Status:** In progress — Plans 01-03 (context-mode) complete, Plans 04-06 (Fallow+Serena) partially executed
+
+**Completed:**
+- Context-mode integration across 18+ skills (ctx_search, ctx_batch_execute patterns)
+- Fallow CLI wired into map-codebase, review, simplify, fix, extract, refactor
+- Serena setup with `--mode no-memories` (symbol tools only, claude-mem handles memory)
+- Serena references in fix, refactor, extract skills
+
+**Remaining (Serena workflow rework):**
+- [ ] **Serena as primary symbol navigator** — currently "enhanced alternative", needs to become primary when installed (D-AUTO-06)
+- [ ] **map-codebase Serena integration** — pre-agent `get_symbols_overview` on entry points (D-AUTO-07)
+- [ ] **Evaluate Serena vs claude-mem memory overlap** — research spike concluded: no-memories is correct, but need to verify workflow handoffs
+- [ ] **Context-mode + Serena synergy** — define when to use ctx_search vs Serena symbol tools vs direct Read
+- [ ] **Workflow decision matrix** — document which tool to use when (context-mode for large output, Serena for symbols, claude-mem for cross-session, Read for editing)
+- [ ] **Eval coverage** — update existing evals for Serena-primary behavior, add map-codebase symbol eval
+
+**Key decisions locked:**
+- D-AUTO-06: Serena as primary, not enhanced alternative
+- Decision 1 (Plan 06): Memory architecture Option C (no-memories) — symbol tools only
+- D-AUTO-01: Fallow in map-codebase via pre-agent injection
+
+### Phase 7: Autonomous Execution & Harness Engineering
+**Goal:** Users invoke `/fh:auto` and walk away — system produces working codebase with decision audit trail.
+**Status:** In progress — core pipeline working, optimization and observability needed
+
+**Completed:**
+- DECISIONS.md as append-only autonomous decision journal
+- `/fh:new-project --auto` with scope-expansion roadmap
+- Autonomous loop: plan-work → plan-review (HOLD SCOPE) → build → review
+- Headless orchestrator via `claude -p` with crash recovery
+- Stuck detection, timeout supervision, cost tracking
+- Decision correction cascade
+- Parallel pipeline architecture (3-wave: concurrent plan → concurrent review → dependency-ordered build)
+- Activity events and kill sentinel support (uncommitted, 72 lines)
+- Per-step stuck thresholds (build: 15min, plan/review: 8min)
+
+**Remaining (optimization + observability):**
+- [ ] **Commit orchestrator improvements** — 72 lines of uncommitted changes (activity events, kill sentinel, per-step thresholds)
+- [ ] **Resume state validation** — validate .auto-state.json on resume, handle corruption gracefully (Plan 07-10 Task 1)
+- [ ] **Milestone completion awareness** — detect all-phases-done and suggest `gsd-tools milestone complete` (Plan 07-10 Task 2)
+- [ ] **Walk-away documentation** — document full narrative in SKILL.md (Plan 07-10 Task 3)
+- [ ] **Auto pipeline lifecycle evals** — corrupt state, milestone complete, walk-away from description (Plan 07-10 Task 4)
+- [ ] **Observability dashboard** — tracker UI shows live auto progress (activity feed, step tokens, cost chart)
+- [ ] **Cost optimization** — measure and reduce per-phase agent cost, identify context waste
+- [ ] **Context-mode integration in auto** — agents use ctx_search instead of Read for large files (CONTEXT-SHARING.md improvements)
+
+---
+
+## New Phases
+
+### Phase 12: Eval Framework & Continuous Improvement
+**Goal:** Eval-driven development loop where skill changes are measured, not guessed. /auto-improve runs iteratively to find and fix skill issues. /skill-creator provides structured skill development with built-in eval measurement.
+**Status:** Planning
+
+**Workstreams:**
+
+1. **Auto-improve loop hardening**
+   - [ ] Verify `/auto-improve` command works end-to-end (currently at `.claude/commands/auto-improve.md`)
+   - [ ] Run /auto-improve against current eval suite, baseline pass rates
+   - [ ] Add tier support (micro for fast iteration, smoke for core skills)
+   - [ ] Track improvement deltas across runs
+
+2. **Skill-creator integration**
+   - [ ] Assess skill-creator availability (not found locally — check if upstream or installable)
+   - [ ] Use skill-creator for new skill development with eval-first methodology
+   - [ ] Integrate eval benchmarking into skill development workflow
+
+3. **Eval infrastructure improvements**
+   - [ ] Fixture-backed evals for auto skill (mock .auto-state.json scenarios)
+   - [ ] Deterministic checks alongside keyword heuristics
+   - [ ] LLM grader for nuanced eval assessment
+   - [ ] Eval coverage dashboard (which skills have gaps)
+   - [ ] Baseline tracking: save pass rates, detect regressions
+
+4. **Measurement-driven decisions**
+   - [ ] Before/after metrics for every skill change
+   - [ ] Cost-per-phase tracking in auto runs
+   - [ ] Context-mode savings measurement (token reduction)
+   - [ ] Serena impact measurement (symbol resolution accuracy)
+
+---
+
+## Deferred
+
+- **Fallow MCP server integration** — use MCP instead of CLI shelling (revisit when Fallow MCP adoption grows)
+- **Fallow baseline/regression tracking** — nice-to-have across builds
+- **Multi-milestone auto execution** — archive → create → execute loop (D-070: roadmap creation scope only for now)
+- **Tracker UI redesign** — Linear-inspired dashboard (design docs exist at `.planning/designs/DESIGN.md`, partially implemented components exist)

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "setup": "sh -c '[ -d /Users/konstantin/conductor/fhhs-planning/.planning ] && { [ -L .planning ] || rm -rf .planning; ln -sf /Users/konstantin/conductor/fhhs-planning/.planning .planning; echo \"Symlinked .planning → private repo\"; } || echo \"WARN: fhhs-planning repo not found — .planning not symlinked\"; node -e \"var fs=require(\\\"fs\\\"),p=require(\\\"path\\\"),f=\\\".claude/settings.json\\\",s={};try{s=JSON.parse(fs.readFileSync(f,\\\"utf8\\\"))}catch{}s.env=Object.assign(s.env||{},{CLAUDE_CODE_TASK_LIST_ID:process.env.CONDUCTOR_WORKSPACE_NAME||\\\"default\\\",CLAUDE_MEM_PROJECT:p.basename(process.env.CONDUCTOR_ROOT_PATH||process.cwd())});fs.writeFileSync(f,JSON.stringify(s,null,2)+\\\"\\\\n\\\")\"'"
+  },
+  "env": {
+    "CLAUDE_CODE_ENABLE_TASKS": "true"
+  }
+}

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -103,7 +103,10 @@
         },
         {
           "type": "forbidden_terms",
-          "terms": []
+          "terms": [
+            "wave",
+            "SUMMARY.md"
+          ]
         }
       ]
     },
@@ -1665,7 +1668,7 @@
         {
           "type": "required_terms",
           "terms": [
-            "suggest"
+            "recommendation"
           ]
         },
         {
@@ -1715,7 +1718,10 @@
         },
         {
           "type": "forbidden_terms",
-          "terms": []
+          "terms": [
+            "wave",
+            "SUMMARY.md"
+          ]
         }
       ]
     },
@@ -2491,7 +2497,7 @@
         {
           "type": "required_terms",
           "terms": [
-            "suggest"
+            "recommendation"
           ]
         }
       ]
@@ -2709,7 +2715,8 @@
           "type": "forbidden_terms",
           "terms": [
             "BLOCK",
-            "WARN"
+            "WARN",
+            "finding"
           ]
         }
       ]
@@ -2836,6 +2843,7 @@
         {
           "type": "forbidden_terms",
           "terms": [
+            "triage",
             "TDD fix"
           ]
         }
@@ -4921,6 +4929,8 @@
         {
           "type": "forbidden_terms",
           "terms": [
+            "error",
+            "crash",
             "failed"
           ]
         }
@@ -5648,7 +5658,10 @@
         },
         {
           "type": "forbidden_terms",
-          "terms": []
+          "terms": [
+            "Design Decisions",
+            "NOT in scope"
+          ]
         }
       ]
     },
@@ -6084,7 +6097,7 @@
           "type": "required_terms",
           "terms": [
             "wave",
-            "wave"
+            "task"
           ]
         },
         {
@@ -7009,15 +7022,15 @@
           "type": "behavioral"
         },
         {
-          "text": "The dependency graph shows a chain where each phase depends on the previous one",
+          "text": "The dependency graph shows a chain \u2014 each phase depends on the previous",
           "type": "behavioral"
         },
         {
-          "text": "Mentions that shared files force sequential ordering despite concurrency setting",
+          "text": "Speculative plan validation checks file overlap before each build",
           "type": "behavioral"
         },
         {
-          "text": "Effective parallelism is reduced when all phases overlap on the same files",
+          "text": "Effective concurrency is 1 despite higher concurrency setting",
           "type": "behavioral"
         }
       ],
@@ -7218,7 +7231,9 @@
         },
         {
           "type": "forbidden_terms",
-          "terms": []
+          "terms": [
+            "test-spec"
+          ]
         }
       ]
     },
@@ -7349,7 +7364,7 @@
         },
         {
           "type": "regex",
-          "pattern": "test|metric|coverage"
+          "pattern": "test_metrics|tests_passed|tests_total"
         }
       ]
     },
@@ -7423,12 +7438,18 @@
       ],
       "checks": [
         {
-          "type": "regex",
-          "pattern": "git.?common.?dir|CLAUDE_MEM_PROJECT|project.?name"
+          "type": "required_terms",
+          "terms": [
+            "CLAUDE_MEM_PROJECT"
+          ]
         },
         {
           "type": "regex",
-          "pattern": "environment|env|spawn"
+          "pattern": "git.*common.dir|git-common-dir|common.dir"
+        },
+        {
+          "type": "regex",
+          "pattern": "fallback|basename"
         }
       ]
     },
@@ -7470,7 +7491,7 @@
         },
         {
           "type": "regex",
-          "pattern": "Read|ctx_search|context.?mode|Edit"
+          "pattern": "Read.*edit|only.*Read|Read.*modif"
         }
       ]
     },
@@ -7547,12 +7568,18 @@
       ],
       "checks": [
         {
-          "type": "regex",
-          "pattern": "metric|token|cost|usage"
+          "type": "required_terms",
+          "terms": [
+            "token"
+          ]
         },
         {
           "type": "regex",
-          "pattern": "session|track|log"
+          "pattern": "auto-state|stepHistory|metrics"
+        },
+        {
+          "type": "regex",
+          "pattern": "PHASE_METRICS|log.*metric|observ"
         }
       ]
     },
@@ -7625,12 +7652,22 @@
       ],
       "checks": [
         {
-          "type": "regex",
-          "pattern": "concurrent|parallel|simultaneous|same.?wave"
+          "type": "required_terms",
+          "terms": [
+            "concurrent",
+            "parallel"
+          ]
         },
         {
           "type": "regex",
-          "pattern": "depend|overlap|independent"
+          "pattern": "phase.*6.*wait|phase.*6.*after|phase.*6.*depend"
+        },
+        {
+          "type": "forbidden_terms",
+          "terms": [
+            "worktree",
+            "git worktree"
+          ]
         }
       ]
     },
@@ -7699,12 +7736,18 @@
       ],
       "checks": [
         {
-          "type": "regex",
-          "pattern": "ctx_search|context.?mode|pre.?index|index.*once|shared.*index"
+          "type": "required_terms",
+          "terms": [
+            "ctx_search"
+          ]
         },
         {
           "type": "regex",
-          "pattern": "token|cache|efficien"
+          "pattern": "pre.?index|index.*once|shared.*index"
+        },
+        {
+          "type": "regex",
+          "pattern": "Read.*edit|only.*Read|reduc.*[Rr]ead|fewer.*[Rr]ead|avoid.*redundant"
         }
       ]
     },
@@ -7773,11 +7816,19 @@
       "checks": [
         {
           "type": "regex",
-          "pattern": "database|index|shared|ctx_search"
+          "pattern": "SESSION_ID|session.?id|shared.*session"
         },
         {
           "type": "regex",
-          "pattern": "read.?only|sequential|parallel|contention"
+          "pattern": "shar|reuse|persist|same.*session|same.*db|same.*index"
+        },
+        {
+          "type": "forbidden_terms",
+          "terms": [
+            "re-read all",
+            "re-index all stable",
+            "bootstrap every step"
+          ]
         }
       ]
     },
@@ -8639,7 +8690,9 @@
         },
         {
           "type": "forbidden_terms",
-          "terms": []
+          "terms": [
+            "show-toplevel"
+          ]
         }
       ]
     },
@@ -8688,7 +8741,10 @@
         },
         {
           "type": "forbidden_terms",
-          "terms": []
+          "terms": [
+            "API error",
+            "health check backoff"
+          ]
         }
       ]
     },
@@ -8755,8 +8811,12 @@
       ],
       "checks": [
         {
-          "type": "regex",
-          "pattern": "warn|proceed|graceful|degrad"
+          "type": "required_terms",
+          "terms": [
+            "claude-mem",
+            "warning",
+            "not found"
+          ]
         }
       ]
     },
@@ -8791,8 +8851,13 @@
       ],
       "checks": [
         {
-          "type": "regex",
-          "pattern": "log|capture|error|classif|differ"
+          "type": "required_terms",
+          "terms": [
+            "stderr",
+            "stdout",
+            "error",
+            "retry"
+          ]
         }
       ]
     },
@@ -9271,9 +9336,8 @@
         {
           "type": "required_terms",
           "terms": [
-            "phase",
-            "directory",
-            "resolve"
+            "findPhaseDir",
+            "decisions-pending"
           ]
         }
       ]
@@ -9286,16 +9350,16 @@
       "files": [],
       "assertions": [
         {
-          "text": "Matches both Current Phase and Active Phase field names in STATE.md",
+          "text": "Matches both 'Current Phase' and 'Active Phase' field names in STATE.md body",
           "type": "behavioral"
         },
         {
-          "text": "Extracts the phase number even when format varies",
+          "text": "Extracts the phase number even without 'Phase' prefix (e.g., '3' from 'Active Phase: 3')",
           "type": "behavioral"
         },
         {
-          "text": "Handles non-standard STATE.md formatting gracefully",
-          "type": "behavioral"
+          "text": "Does NOT return null when STATE.md uses Active Phase instead of Current Phase",
+          "type": "guard"
         }
       ],
       "tier": "micro",
@@ -9304,16 +9368,14 @@
         "guard",
         "state-parsing"
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "Active Phase",
-            "Current Phase",
-            "parseCurrentPhase"
-          ]
-        }
-      ]
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "Active Phase",
+          "Current Phase",
+          "parseCurrentPhase"
+        ]
+      }
     },
     {
       "id": 285,
@@ -9345,16 +9407,14 @@
         "guard",
         "completion-detection"
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "SUMMARY.md",
-            "summaryExists",
-            "findLatestPlan"
-          ]
-        }
-      ]
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "SUMMARY.md",
+          "summaryExists",
+          "findLatestPlan"
+        ]
+      }
     },
     {
       "id": 286,
@@ -9364,20 +9424,20 @@
       "files": [],
       "assertions": [
         {
-          "text": "writeAutoStatus uses atomic write with temporary file and rename",
+          "text": "writeAutoStatus uses tmp file + renameSync for atomic writes",
           "type": "behavioral"
         },
         {
-          "text": "saveAutoState uses atomic write with temporary file and rename",
+          "text": "saveAutoState uses tmp file + renameSync for atomic writes",
           "type": "behavioral"
         },
         {
-          "text": "Atomic writes prevent partial reads by the tracker dashboard",
+          "text": "log() debounced updater also uses tmp file + renameSync",
           "type": "behavioral"
         },
         {
-          "text": "Uses renameSync or rename for atomic file replacement",
-          "type": "behavioral"
+          "text": "Does NOT write directly to .auto-state.json without atomicity",
+          "type": "guard"
         }
       ],
       "tier": "micro",
@@ -9386,15 +9446,14 @@
         "atomicity",
         "tracker"
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "atomic",
-            "rename"
-          ]
-        }
-      ]
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "renameSync",
+          ".tmp",
+          "atomic"
+        ]
+      }
     },
     {
       "id": 287,
@@ -9426,17 +9485,15 @@
         "crash-recovery",
         "state-persistence"
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "saveAutoState",
-            "planning-wave-complete",
-            "review-wave-complete",
-            "phase_plan_paths"
-          ]
-        }
-      ]
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "saveAutoState",
+          "planning-wave-complete",
+          "review-wave-complete",
+          "phase_plan_paths"
+        ]
+      }
     },
     {
       "id": 288,
@@ -9464,16 +9521,14 @@
         "sequential-mode",
         "state-persistence"
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "saveAutoState",
-            "sequential",
-            "steps_completed"
-          ]
-        }
-      ]
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "saveAutoState",
+          "sequential",
+          "steps_completed"
+        ]
+      }
     },
     {
       "id": 289,
@@ -9501,12 +9556,15 @@
         "tracker",
         "completion"
       ],
-      "checks": [
-        {
-          "type": "regex",
-          "pattern": "false|inactive|completed|not.?running|finished"
-        }
-      ]
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "auto-state.json",
+          "active",
+          "false",
+          "clearAutoState"
+        ]
+      }
     },
     {
       "id": 290,
@@ -9542,16 +9600,14 @@
         "tracker",
         "frontend"
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "stepAliases",
-            "plan-work",
-            "plan-review"
-          ]
-        }
-      ]
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "stepAliases",
+          "plan-work",
+          "plan-review"
+        ]
+      }
     },
     {
       "id": 291,
@@ -9587,22 +9643,20 @@
         "tracker",
         "server"
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "buildProjectSummary",
-            "autoState",
-            ".auto-state.json"
-          ]
-        }
-      ]
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "buildProjectSummary",
+          "autoState",
+          ".auto-state.json"
+        ]
+      }
     },
     {
       "id": 292,
       "command": "update",
       "prompt": "update --global",
-      "expected_output": "Should update the plugin globally (once), then discover all ACTIVE projects using fhhs-skills. Discovery uses Conductor DB (only state='ready' workspaces) and tracker registry (non-Conductor projects only). Projects are grouped by GitHub repo. For each worktree, runs post-update-reconcile.sh, changelog reconcile with auto-remediation (installs tools, sets env vars, adds hooks), and health --repair. Displays results grouped by repo. Cleans up stale and archived entries from registry.",
+      "expected_output": "Should update the plugin globally (once), then discover ALL projects using fhhs-skills across the filesystem. Discovery uses two sources: tracker registry (~/.claude/tracker/projects.json) and Conductor workspace scan (~/conductor/workspaces/*/*). For each discovered project, should run post-update-reconcile.sh, changelog reconcile, and health --repair. Should display an aggregate table showing per-project status. Should clean up stale registry entries (paths that no longer exist).",
       "files": [],
       "assertions": [
         {
@@ -9610,7 +9664,7 @@
           "type": "behavioral"
         },
         {
-          "text": "Discovers active projects from Conductor DB and tracker registry, grouped by repo",
+          "text": "Discovers projects from tracker registry and Conductor workspace scan",
           "type": "behavioral"
         },
         {
@@ -9631,21 +9685,19 @@
         "happy-path",
         "global-update"
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "global",
-            "projects.json",
-            "reconcil"
-          ]
-        }
-      ]
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "global",
+          "projects.json",
+          "reconcil"
+        ]
+      }
     },
     {
       "id": 293,
       "command": "update",
-      "prompt": "update --global \u2014 I have 5 projects across 3 Conductor workspaces, but 2 of the projects were deleted from disk last week. What happens to those stale entries?",
+      "prompt": "update --global — I have 5 projects across 3 Conductor workspaces, but 2 of the projects were deleted from disk last week. What happens to those stale entries?",
       "expected_output": "Should discover all 5 registered projects, detect that 2 paths no longer exist on disk (fs.existsSync returns false), skip reconciliation for those 2, auto-remove the stale entries from ~/.claude/tracker/projects.json, and report the cleanup in the summary. Should NOT error out or stop processing because of missing paths.",
       "files": [],
       "assertions": [
@@ -9675,22 +9727,20 @@
         "edge-case",
         "global-update"
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "stale",
-            "removed",
-            "registry"
-          ]
-        }
-      ]
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "stale",
+          "removed",
+          "registry"
+        ]
+      }
     },
     {
       "id": 294,
       "command": "update",
-      "prompt": "update --global \u2014 some of my projects don't have a .planning/ directory yet (they're just regular repos with .claude/settings.json). How does global update handle those?",
-      "expected_output": "Projects without .planning/ should still receive environment reconciliation (post-update-reconcile.sh for claude-mem patch and env vars, changelog reconcile for tool/hook/env gap checks). Health --repair should be skipped since there's no .planning/ to validate. The results table should show health as 'skipped' or '\u2014' for those projects.",
+      "prompt": "update --global — some of my projects don't have a .planning/ directory yet (they're just regular repos with .claude/settings.json). How does global update handle those?",
+      "expected_output": "Projects without .planning/ should still receive environment reconciliation (post-update-reconcile.sh for claude-mem patch and env vars, changelog reconcile for tool/hook/env gap checks). Health --repair should be skipped since there's no .planning/ to validate. The results table should show health as 'skipped' or '—' for those projects.",
       "files": [],
       "assertions": [
         {
@@ -9715,22 +9765,20 @@
         "edge-case",
         "global-update"
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "planning",
-            "skip",
-            "reconcil"
-          ]
-        }
-      ]
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "planning",
+          "skip",
+          "reconcil"
+        ]
+      }
     },
     {
       "id": 295,
       "command": "update",
-      "prompt": "update --global \u2014 I use Conductor with worktrees. I have 3 worktrees for the same repo (fh-starter-project/havana, fh-starter-project/kyoto, fh-starter-project/tokyo). Will each worktree get its own reconciliation pass?",
-      "expected_output": "Yes \u2014 each worktree gets its own reconciliation pass because each has its own .claude/settings.json and potentially different .planning/ state. However, worktrees are grouped by repo in the display (e.g., fh-starter-project shows havana, kyoto, tokyo as instances). Discovery uses Conductor DB (only state='ready') so archived worktrees are excluded. The CLAUDE_MEM_PROJECT env var is set correctly per-worktree using git rev-parse --git-common-dir to resolve the actual repo name.",
+      "prompt": "update --global — I use Conductor with worktrees. I have 3 worktrees for the same repo (fh-starter-project/havana, fh-starter-project/kyoto, fh-starter-project/tokyo). Will each worktree get its own reconciliation pass?",
+      "expected_output": "Yes — each Conductor worktree is treated as a separate project because each has its own .claude/settings.json and potentially different .planning/ state. The global reconcile discovers them individually (from tracker registry or Conductor scan) and runs reconciliation on each. The CLAUDE_MEM_PROJECT env var is set correctly per-worktree using git rev-parse --git-common-dir to resolve the actual repo name. Results table should show each worktree with its Conductor workspace group.",
       "files": [],
       "assertions": [
         {
@@ -9756,22 +9804,20 @@
         "global-update",
         "conductor"
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "worktree",
-            "git-common-dir",
-            "workspace"
-          ]
-        }
-      ]
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "worktree",
+          "git-common-dir",
+          "workspace"
+        ]
+      }
     },
     {
       "id": 296,
       "command": "update",
-      "prompt": "update --global \u2014 what if a project has env gaps like missing tools or hooks? Does the global update fix those or just report them?",
-      "expected_output": "The global reconcile now auto-remediates env gaps. It installs missing tools (pnpm/npm install -g), sets env vars in .claude/settings.json, adds hooks to global settings, and creates missing directories. Only items that genuinely can't be auto-fixed (like plugin installs in non-interactive environments) are reported as failures. The summary shows total remediated count and any remaining failures. It does NOT tell the user to run /fh:update individually.",
+      "prompt": "update --global — what if a project has env gaps that the global reconcile detects but can't auto-fix (like missing tool installs or hooks)? How does it report that?",
+      "expected_output": "The global reconcile script runs changelog reconcile which detects env gaps but does NOT auto-remediate them (tool installs, hook additions require the full SKILL.md remediation logic). It reports the gap count per project in the results table. For projects with remaining gaps, suggests running /fh:update individually in each project to apply the full remediation. The summary shows total env gaps across all projects.",
       "files": [],
       "assertions": [
         {
@@ -9796,22 +9842,20 @@
         "edge-case",
         "global-update"
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "gap",
-            "reconcil",
-            "/fh:update"
-          ]
-        }
-      ]
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "gap",
+          "reconcil",
+          "/fh:update"
+        ]
+      }
     },
     {
       "id": 297,
       "command": "update",
-      "prompt": "update --global \u2014 what if the tracker registry doesn't exist yet (fresh install, no projects tracked)?",
-      "expected_output": "Primary discovery uses Conductor DB (only active workspaces). If the DB is unavailable, falls back to filesystem scan of ~/conductor/workspaces/. Tracker registry is only used for non-Conductor projects. If no projects found from any source, report 'No projects found'. Should NOT error out or crash when projects.json is missing or Conductor DB is unavailable.",
+      "prompt": "update --global — what if the tracker registry doesn't exist yet (fresh install, no projects tracked)?",
+      "expected_output": "Should fall back to Conductor workspace scan as the secondary discovery source. If ~/conductor/workspaces/ exists, scan all subdirectories for .planning/ or .claude/settings.json. If neither source finds any projects, report 'No projects found' and suggest running /fh:new-project. Should NOT error out or crash when projects.json is missing.",
       "files": [],
       "assertions": [
         {
@@ -9832,16 +9876,14 @@
         "edge-case",
         "global-update"
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "projects.json",
-            "conductor",
-            "scan"
-          ]
-        }
-      ]
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "projects.json",
+          "conductor",
+          "scan"
+        ]
+      }
     },
     {
       "id": 298,
@@ -9872,22 +9914,20 @@
         "happy-path",
         "global-update"
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "--global",
-            "projects",
-            "reconcil"
-          ]
-        }
-      ]
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "--global",
+          "projects",
+          "reconcil"
+        ]
+      }
     },
     {
       "id": 299,
       "command": "update",
       "prompt": "I just ran /fh:update and it said I have 5 other projects. What does --global actually do to each project?",
-      "expected_output": "The --global flag discovers all active projects (from Conductor DB for active workspaces, tracker registry for non-Conductor projects), groups them by repo, and runs full reconciliation on each worktree: (1) post-update-reconcile.sh for claude-mem patch, CLAUDE_MEM_PROJECT env var, and tracker registration, (2) changelog reconcile to detect AND auto-fix env gaps (installs missing tools, sets env vars, adds hooks), and (3) health --repair to fix .planning/ directory issues. Archived Conductor workspaces are excluded. Projects without .planning/ skip the health step.",
+      "expected_output": "The --global flag runs three reconciliation steps on each discovered project: (1) post-update-reconcile.sh for claude-mem patch, CLAUDE_MEM_PROJECT env var, and tracker registration, (2) changelog reconcile to detect env gaps (missing tools, hooks, env vars) using the fhhs-skills plugin changelog, and (3) health --repair to fix .planning/ directory issues. Projects without .planning/ skip the health step. The script discovers projects from two sources: the tracker registry and Conductor workspace scan.",
       "files": [],
       "assertions": [
         {
@@ -9895,7 +9935,7 @@
           "type": "output"
         },
         {
-          "text": "Mentions discovery from Conductor DB (active only) and tracker registry",
+          "text": "Mentions both discovery sources (tracker registry and Conductor scan)",
           "type": "output"
         },
         {
@@ -9908,916 +9948,461 @@
         "happy-path",
         "global-update"
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "reconcil",
-            "tracker",
-            "health"
-          ]
-        }
-      ]
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "reconcil",
+          "tracker",
+          "health"
+        ]
+      }
     },
     {
       "id": 300,
-      "command": "auto",
-      "tier": "micro",
-      "tags": [
-        "workshop",
-        "research"
-      ],
-      "prompt": "User says 'auto, build this project' with no prior discussion. PROJECT.md has a vague one-line vision. No DESIGN.md. How should auto handle this?",
-      "expected_output": "Should recognize gaps in project definition, do domain research before engaging user, ask informed strategic questions grounded in research findings.",
+      "command": "progress",
+      "prompt": "/fh:progress",
+      "expected_output": "When run in a project with no .planning/ directory and no gsd-tools symlink (new install with no tracked project), /fh:progress should detect the uninitialized state and direct the user to run /fh:setup. The output must include a clear routing message pointing to /fh:setup as the required next step before any project work can begin.",
       "files": [],
       "assertions": [
         {
-          "text": "Identifies gaps in PROJECT.md vision",
+          "text": "Detects missing .planning/ directory (new install state)",
           "type": "behavioral"
         },
         {
-          "text": "Does domain research before asking questions",
-          "type": "behavioral"
+          "text": "Outputs routing message directing user to /fh:setup",
+          "type": "output"
         },
         {
-          "text": "Grounds the conversation in research findings not generic questions",
-          "type": "behavioral"
+          "text": "Does NOT attempt to show project status or phase info",
+          "type": "guard"
+        },
+        {
+          "text": "Does NOT crash or show a stack trace",
+          "type": "guard"
         }
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "research",
-            "gap"
-          ]
-        },
-        {
-          "type": "regex",
-          "pattern": "search|firecrawl|web"
-        }
-      ]
+      "tier": "smoke",
+      "tags": [
+        "onboarding",
+        "phase-04"
+      ],
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "/fh:setup"
+        ]
+      }
     },
     {
       "id": 301,
-      "command": "auto",
-      "tier": "micro",
-      "tags": [
-        "workshop",
-        "skip"
-      ],
-      "prompt": "User says 'just go, skip the workshop, build everything'. PROJECT.md exists with clear vision and REQUIREMENTS.md is detailed. Should auto skip workshop?",
-      "expected_output": "Should skip workshop when all three conditions met: clear vision with north star, exhaustive requirements, well-formed phases. User explicitly asking to skip also triggers skip.",
+      "command": "setup",
+      "prompt": "/fh:setup --check",
+      "expected_output": "When invoked with --check, /fh:setup should validate the current environment and display a status table showing each component (node, npm, gh, TypeScript LSP, GSD symlink, etc.) with pass/fail indicators. It must NOT run any installation steps — no brew install, no npm install -g, no plugin install, no symlink creation. The output must include a SETUP STATUS section or equivalent component table. The check-only mode is purely diagnostic.",
       "files": [],
       "assertions": [
         {
-          "text": "Respects user intent to skip workshop",
-          "type": "behavioral"
+          "text": "Outputs SETUP STATUS section or component status table",
+          "type": "output"
         },
         {
-          "text": "Runs quick sanity check on planning artifacts even when skipping",
-          "type": "behavioral"
+          "text": "Lists individual components with pass/fail or present/missing status",
+          "type": "output"
         },
         {
-          "text": "Proceeds to execution after sanity check",
-          "type": "behavioral"
+          "text": "Does NOT run brew install or any package installation",
+          "type": "guard"
+        },
+        {
+          "text": "Does NOT run npm install -g or TypeScript LSP installation",
+          "type": "guard"
+        },
+        {
+          "text": "Does NOT create GSD symlink or modify filesystem",
+          "type": "guard"
         }
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "skip"
-          ]
-        },
-        {
-          "type": "regex",
-          "pattern": "vision|north.?star|requirements"
-        }
-      ]
+      "tier": "smoke",
+      "tags": [
+        "onboarding",
+        "phase-04"
+      ],
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "SETUP STATUS",
+          "check"
+        ]
+      }
     },
     {
       "id": 302,
-      "command": "auto",
-      "tier": "micro",
-      "tags": [
-        "recovery",
-        "reporting"
-      ],
-      "prompt": "Auto-orchestrator phase 4 build failed with exit code 1. The error log shows a missing dependency. What should auto report to the user and what recovery action should it take?",
-      "expected_output": "Should report the failure with clear context (phase, step, error), show the error log content, and either retry or skip depending on dependency graph.",
+      "command": "map-codebase",
+      "prompt": "When fallow is installed, /fh:map-codebase should run fallow check and fallow health before spawning the mapper agent and inject results into the agent prompt under 'Static Analysis Data'",
+      "expected_output": "Should detect fallow availability via `command -v fallow`, run `fallow check` and `fallow health`, collect their output, and inject the results into the mapper agent prompt under a 'Static Analysis Data' section. The static analysis data should be available to the agent before it begins mapping the codebase.",
       "files": [],
       "assertions": [
         {
-          "text": "Reports which phase and step failed with the error details",
+          "text": "Checks for fallow availability with `command -v fallow`",
           "type": "behavioral"
         },
         {
-          "text": "Reads and surfaces the error log content to user",
+          "text": "Runs `fallow check` to collect static analysis data",
           "type": "behavioral"
         },
         {
-          "text": "Classifies error type and decides retry vs skip vs abort",
+          "text": "Runs `fallow health` to collect health data",
+          "type": "behavioral"
+        },
+        {
+          "text": "Injects fallow results into agent prompt under 'Static Analysis Data'",
           "type": "behavioral"
         }
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "error",
-            "log"
-          ]
-        },
-        {
-          "type": "regex",
-          "pattern": "retry|skip|abort|recover"
-        }
-      ]
+      "tier": "smoke",
+      "tags": [
+        "fallow",
+        "integration"
+      ],
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "fallow check",
+          "fallow health",
+          "Static Analysis Data",
+          "command -v fallow"
+        ]
+      }
     },
     {
       "id": 303,
-      "command": "auto",
-      "tier": "micro",
-      "tags": [
-        "stale",
-        "stuck"
-      ],
-      "prompt": "The auto pipeline has been running for 45 minutes. 3 phases planned, 0 built. The build wave has 2 sessions running but neither has produced output in 10 minutes. What should happen?",
-      "expected_output": "Stuck detector should kill sessions after 8min silence. Writes PARTIAL-SUMMARY.md. Reports to user what happened and next steps.",
+      "command": "map-codebase",
+      "prompt": "When fallow is NOT installed, /fh:map-codebase should skip static analysis silently and produce the same CODEBASE.md output without mentioning Fallow",
+      "expected_output": "Should detect that fallow is not available, skip static analysis without error, and proceed to map the codebase normally. The resulting CODEBASE.md output should be identical in structure to a run without Fallow — no error messages about missing fallow, no 'fallow not found' warnings in the output.",
       "files": [],
       "assertions": [
         {
-          "text": "Stuck detection triggers and kills sessions after extended silence",
+          "text": "Skips fallow static analysis when fallow is not installed",
           "type": "behavioral"
         },
         {
-          "text": "Writes partial summary with diagnostic context from the killed session",
-          "type": "behavioral"
+          "text": "Does NOT produce an error when fallow is unavailable",
+          "type": "guard"
         },
         {
-          "text": "User can resume or retry the failed phase afterward",
-          "type": "behavioral"
+          "text": "Produces CODEBASE.md output regardless of fallow availability",
+          "type": "output"
+        },
+        {
+          "text": "Does NOT mention Fallow in the output when fallow is not installed",
+          "type": "guard"
         }
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "stuck",
-            "kill"
-          ]
-        },
-        {
-          "type": "regex",
-          "pattern": "PARTIAL|resume|next.?step"
-        }
-      ]
+      "tier": "smoke",
+      "tags": [
+        "fallow",
+        "degradation"
+      ],
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "graceful",
+          "skip"
+        ]
+      }
     },
     {
       "id": 304,
-      "command": "auto",
-      "tier": "micro",
-      "tags": [
-        "cache",
-        "context-mode"
-      ],
-      "prompt": "Auto pipeline starts with 8 phases. How does it handle context-mode pre-indexing to avoid SQLite contention between parallel sessions?",
-      "expected_output": "Pre-indexes shared docs once before any wave. Parallel sessions use ctx_search read-only. No concurrent writes to context-mode database.",
+      "command": "refactor",
+      "prompt": "When fallow is installed, /fh:refactor Step 1 should use fallow check output to detect circular dependencies and unused exports in the refactoring target",
+      "expected_output": "Should augment the refactoring scope analysis in Step 1 using fallow check output. The skill should identify circular dependencies and unused exports in the target module/file using Fallow Scope Augmentation. This data should inform the refactoring plan before implementation begins.",
       "files": [],
       "assertions": [
         {
-          "text": "Pre-indexes stable documents (PROJECT.md, ROADMAP.md, research) before waves start",
+          "text": "Uses fallow check output to augment refactoring scope in Step 1",
           "type": "behavioral"
         },
         {
-          "text": "Parallel sessions use read-only ctx_search, not ctx_index",
+          "text": "Detects circular dependencies in the refactoring target",
           "type": "behavioral"
         },
         {
-          "text": "Prevents SQLite write contention by sequential indexing then parallel reads",
+          "text": "Detects unused exports in the refactoring target",
+          "type": "behavioral"
+        },
+        {
+          "text": "References 'Fallow Scope Augmentation' or equivalent fallow integration label",
           "type": "behavioral"
         }
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "pre-index",
-            "ctx_search"
-          ]
-        },
-        {
-          "type": "regex",
-          "pattern": "SQLite|contention|read.?only|sequential.*index"
-        }
-      ]
+      "tier": "smoke",
+      "tags": [
+        "fallow",
+        "integration"
+      ],
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "Fallow Scope Augmentation",
+          "circular dependency",
+          "unused exports"
+        ]
+      }
     },
     {
       "id": 305,
-      "command": "auto",
-      "tier": "micro",
-      "tags": [
-        "reporting",
-        "completion"
-      ],
-      "prompt": "Auto finishes all 6 phases. What exactly should the completion report include?",
-      "expected_output": "Should report: phases completed count, decisions logged count, any LOW confidence decisions needing review, reset AUTO_MODE, read final STATE.md.",
+      "command": "fix",
+      "prompt": "/fh:fix, /fh:refactor, and /fh:extract should reference Serena MCP tools (find_symbol, find_referencing_symbols, rename_symbol) as enhanced alternatives but explicitly fall back to built-in LSP when Serena is not connected",
+      "expected_output": "Skills /fh:fix, /fh:refactor, and /fh:extract should mention Serena MCP tools (find_symbol, find_referencing_symbols, rename_symbol) as enhanced alternatives for symbol navigation and renaming. Each skill must also include an explicit fallback pattern that uses built-in LSP tools when Serena is not connected, ensuring the skill works correctly without Serena.",
       "files": [],
       "assertions": [
         {
-          "text": "Reports count of phases completed",
+          "text": "References Serena MCP tool find_symbol",
           "type": "behavioral"
         },
         {
-          "text": "Lists decisions made and flags LOW confidence ones for human review",
+          "text": "References Serena MCP tool find_referencing_symbols",
           "type": "behavioral"
         },
         {
-          "text": "Resets auto_advance to false",
+          "text": "References Serena MCP tool rename_symbol",
           "type": "behavioral"
         },
         {
-          "text": "Reads and confirms STATE.md reflects final position",
+          "text": "Includes explicit fallback to built-in LSP when Serena is not connected",
           "type": "behavioral"
         }
       ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "auto_advance",
-            "STATE.md",
-            "decision"
-          ]
-        },
-        {
-          "type": "regex",
-          "pattern": "confidence|review|complete"
-        }
-      ]
+      "tier": "smoke",
+      "tags": [
+        "serena",
+        "degradation"
+      ],
+      "checks": {
+        "type": "required_terms",
+        "terms": [
+          "find_symbol",
+          "find_referencing_symbols",
+          "rename_symbol",
+          "fallback"
+        ]
+      }
     },
     {
       "id": 306,
       "command": "auto",
-      "tier": "micro",
-      "tags": [
-        "resilience",
-        "api-health"
-      ],
-      "prompt": "During auto execution, a claude -p session fails with connection refused. How does the orchestrator handle API failures vs logic failures?",
-      "expected_output": "API/infra errors (connection refused, 502/503, rate limit) trigger health check with exponential backoff. Logic errors (exit code 1) do NOT trigger health check.",
+      "prompt": "Verify that auto-orchestrator.cjs writes activity_events and last_activity_at into the auto-state JSON file after each step completes",
+      "expected_output": "auto-orchestrator.cjs should build an _activityEvents array and track _autoStatus.lastActivityAt, then write both activity_events and last_activity_at fields into the auto-state JSON via writeAutoState or equivalent.",
       "files": [],
       "assertions": [
         {
-          "text": "Distinguishes API/infra errors from logic errors",
-          "type": "behavioral"
+          "text": "Orchestrator accumulates activity events in _activityEvents array",
+          "type": "output"
         },
         {
-          "text": "API errors trigger health check with exponential backoff (10s \u2192 20s \u2192 40s \u2192 80s \u2192 120s)",
-          "type": "behavioral"
+          "text": "Orchestrator writes activity_events to auto-state JSON",
+          "type": "output"
         },
         {
-          "text": "Logic errors skip health check backoff",
-          "type": "behavioral"
+          "text": "Orchestrator writes last_activity_at timestamp to auto-state JSON",
+          "type": "output"
         }
       ],
-      "checks": [
+      "tier": "micro",
+      "tags": [
+        "auto",
+        "observability",
+        "04-03"
+      ],
+      "deterministic_checks": [
         {
-          "type": "required_terms",
-          "terms": [
-            "backoff",
-            "health"
-          ]
+          "type": "file_contains",
+          "path": ".claude/skills/auto/auto-orchestrator.cjs",
+          "pattern": "pushActivityEvent"
         },
         {
-          "type": "regex",
-          "pattern": "API|infra|connection|logic"
+          "type": "file_contains",
+          "path": ".claude/skills/auto/auto-orchestrator.cjs",
+          "pattern": "lastActivityAt"
         }
       ]
     },
     {
       "id": 307,
       "command": "auto",
-      "tier": "micro",
-      "tags": [
-        "workshop",
-        "design-context"
-      ],
-      "prompt": "User runs /fh:auto. PROJECT.md exists but no DESIGN.md. The project is a SaaS dashboard. What should the workshop do about design context?",
-      "expected_output": "Should suggest running /fh:ui-branding first or capture basic brand direction during workshop. UX patterns for SaaS dashboards should be researched.",
+      "prompt": "Verify that STUCK_KILL_BY_STEP in auto-orchestrator.cjs assigns build steps a longer stuck threshold (15 minutes) compared to the default",
+      "expected_output": "auto-orchestrator.cjs should define a STUCK_KILL_BY_STEP map that gives build-related steps a 15-minute (900000ms) threshold, and the stuck-detection logic should look up the current step name in this map before falling back to the default STUCK_KILL_MS.",
       "files": [],
       "assertions": [
         {
-          "text": "Notices missing DESIGN.md and suggests /fh:ui-branding or captures brand direction",
-          "type": "behavioral"
+          "text": "STUCK_KILL_BY_STEP map exists with per-step thresholds",
+          "type": "output"
         },
         {
-          "text": "Researches UX patterns appropriate for the product type (SaaS dashboard)",
+          "text": "Build step has a 15-minute (900000ms) threshold",
+          "type": "output"
+        },
+        {
+          "text": "Stuck detection falls back to default STUCK_KILL_MS when step not in map",
           "type": "behavioral"
         }
       ],
-      "checks": [
+      "tier": "micro",
+      "tags": [
+        "auto",
+        "observability",
+        "04-03"
+      ],
+      "deterministic_checks": [
         {
-          "type": "required_terms",
-          "terms": [
-            "DESIGN.md"
-          ]
-        },
-        {
-          "type": "regex",
-          "pattern": "ui-branding|brand|UX|design"
+          "type": "file_contains",
+          "path": ".claude/skills/auto/auto-orchestrator.cjs",
+          "pattern": "'build': 15 * 60"
         }
       ]
     },
     {
       "id": 308,
-      "command": "build",
-      "tier": "micro",
-      "tags": [
-        "happy-path"
-      ],
-      "prompt": "User runs /fh:build for phase 03. PLAN.md exists in .planning/phases/03/. What's the first thing build does?",
-      "expected_output": "Reads PLAN.md, validates it has required structure, checks dependencies, then begins executing tasks.",
+      "command": "auto",
+      "prompt": "Verify that auto-orchestrator.cjs checks for a .auto-kill sentinel file to allow external kill requests, and that server.cjs exposes a /api/kill endpoint to create it",
+      "expected_output": "auto-orchestrator.cjs should check for existence of a .auto-kill file in its main loop and exit gracefully when found. server.cjs should expose a /api/kill POST endpoint that creates the .auto-kill sentinel file.",
       "files": [],
       "assertions": [
         {
-          "text": "Reads PLAN.md from the phase directory",
-          "type": "behavioral"
+          "text": "Orchestrator checks for .auto-kill sentinel file",
+          "type": "output"
         },
         {
-          "text": "Checks prerequisites like PROJECT.md and STATE.md before building",
+          "text": "Server exposes /api/kill endpoint",
+          "type": "output"
+        },
+        {
+          "text": "Kill sentinel triggers graceful shutdown, not abrupt process.exit",
           "type": "behavioral"
         }
       ],
-      "checks": [
+      "tier": "micro",
+      "tags": [
+        "auto",
+        "observability",
+        "04-03"
+      ],
+      "deterministic_checks": [
         {
-          "type": "required_terms",
-          "terms": [
-            "PLAN.md"
-          ]
+          "type": "file_contains",
+          "path": ".claude/skills/auto/auto-orchestrator.cjs",
+          "pattern": "auto-kill"
         },
         {
-          "type": "regex",
-          "pattern": "read|validate|structure"
+          "type": "file_contains",
+          "path": ".claude/skills/auto/auto-orchestrator.cjs",
+          "pattern": "fs.existsSync(killFile)"
+        },
+        {
+          "type": "file_contains",
+          "path": "templates/project-tracker/server.cjs",
+          "pattern": "/api/kill"
         }
       ]
     },
     {
       "id": 309,
-      "command": "build",
-      "tier": "micro",
-      "tags": [
-        "artifact-wiring"
-      ],
-      "prompt": "Build is executing phase 05. The plan references decisions from CONTEXT.md. Where does build read CONTEXT.md from and how does it ensure it has the right context?",
-      "expected_output": "Reads CONTEXT.md from the phase directory (.planning/phases/05/CONTEXT.md) for phase-specific decisions, and .planning/CONTEXT.md for project-level decisions.",
+      "command": "tracker",
+      "prompt": "Verify that server.cjs merges auto-state activity_events into the recentActivity array returned to the dashboard",
+      "expected_output": "server.cjs should read the auto-state JSON, extract activity_events, and merge them into the recentActivity response so the dashboard can display both manual and auto-generated activity events.",
       "files": [],
       "assertions": [
         {
-          "text": "Reads CONTEXT.md from the phase directory for locked decisions and constraints",
-          "type": "behavioral"
+          "text": "Server reads activity_events from auto-state JSON",
+          "type": "output"
         },
         {
-          "text": "CONTEXT.md decisions guide what the build implements and how",
-          "type": "behavioral"
+          "text": "Server merges auto events into recentActivity response",
+          "type": "output"
+        },
+        {
+          "text": "Does NOT overwrite manual activity events when merging",
+          "type": "guard"
         }
       ],
-      "checks": [
+      "tier": "micro",
+      "tags": [
+        "auto",
+        "observability",
+        "04-03"
+      ],
+      "deterministic_checks": [
         {
-          "type": "required_terms",
-          "terms": [
-            "CONTEXT.md"
-          ]
-        },
-        {
-          "type": "regex",
-          "pattern": "phase|directory|decision"
+          "type": "file_contains",
+          "path": "templates/project-tracker/server.cjs",
+          "pattern": "autoState.activity_events"
         }
       ]
     },
     {
       "id": 310,
-      "command": "build",
-      "tier": "micro",
-      "tags": [
-        "test-enforcement"
-      ],
-      "prompt": "Build finishes implementing all tasks in the plan. What test-related steps must it complete before writing SUMMARY.md?",
-      "expected_output": "Must generate test specs from plan must_haves, run tests, track coverage metrics, ensure business logic has test coverage.",
+      "command": "tracker",
+      "prompt": "Verify that AutoPipeline.jsx includes a FreshnessIndicator component that shows color-coded staleness based on last_activity_at timestamp",
+      "expected_output": "AutoPipeline.jsx should render a FreshnessIndicator (or equivalent) that compares last_activity_at against current time and applies color coding (green for recent, yellow for stale, red for very stale) to indicate pipeline freshness.",
       "files": [],
       "assertions": [
         {
-          "text": "Runs the project test suite to check for failures",
-          "type": "behavioral"
+          "text": "FreshnessIndicator component exists in AutoPipeline",
+          "type": "output"
         },
         {
-          "text": "Records test results and coverage in SUMMARY.md",
-          "type": "behavioral"
+          "text": "Shows color-coded staleness (green/yellow/red or equivalent)",
+          "type": "output"
         },
         {
-          "text": "Runs build or type check command to verify code compiles",
+          "text": "Uses last_activity_at or equivalent timestamp for freshness calculation",
           "type": "behavioral"
         }
       ],
-      "checks": [
+      "tier": "micro",
+      "tags": [
+        "auto",
+        "observability",
+        "04-03"
+      ],
+      "deterministic_checks": [
         {
-          "type": "required_terms",
-          "terms": [
-            "test"
-          ]
-        },
-        {
-          "type": "regex",
-          "pattern": "coverage|spec|SUMMARY"
+          "type": "file_contains",
+          "path": "templates/project-tracker/src/components/AutoPipeline.jsx",
+          "pattern": "FreshnessIndicator"
         }
       ]
     },
     {
       "id": 311,
-      "command": "build",
-      "tier": "micro",
-      "tags": [
-        "error-recovery"
-      ],
-      "prompt": "During build step 3 (implement task), the code fails to compile. What should build do?",
-      "expected_output": "Should diagnose the error, attempt to fix, re-run verification. If repeated failure, log the issue and move to next task or escalate.",
+      "command": "tracker",
+      "prompt": "Verify that app.jsx merges autoState.activity_events into the ActivityFeed component so auto-generated events appear in the activity timeline",
+      "expected_output": "app.jsx should read activity_events from autoState and pass them (merged with other activity sources) to the ActivityFeed component for rendering in the unified activity timeline.",
       "files": [],
       "assertions": [
         {
-          "text": "Diagnoses the compilation error before attempting fix",
-          "type": "behavioral"
-        },
-        {
-          "text": "Attempts to fix the error and re-verify",
-          "type": "behavioral"
-        }
-      ],
-      "checks": [
-        {
-          "type": "regex",
-          "pattern": "diagnos|fix|error|retry|verif"
-        }
-      ]
-    },
-    {
-      "id": 312,
-      "command": "build",
-      "tier": "micro",
-      "tags": [
-        "summary"
-      ],
-      "prompt": "Build completes phase 03 successfully. What must SUMMARY.md contain?",
-      "expected_output": "SUMMARY.md must include: what was built, files modified, test results, any deviations from plan, test metrics.",
-      "files": [],
-      "assertions": [
-        {
-          "text": "SUMMARY.md records what was implemented and which files were changed",
-          "type": "behavioral"
-        },
-        {
-          "text": "Includes test results and build verification status",
-          "type": "behavioral"
-        },
-        {
-          "text": "Notes any issues encountered during implementation",
-          "type": "behavioral"
-        }
-      ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "SUMMARY.md"
-          ]
-        },
-        {
-          "type": "regex",
-          "pattern": "test|metric|deviation|file"
-        }
-      ]
-    },
-    {
-      "id": 313,
-      "command": "review",
-      "tier": "micro",
-      "tags": [
-        "happy-path"
-      ],
-      "prompt": "User runs /fh:review on a freshly built phase. What does review check?",
-      "expected_output": "Reviews code quality, architecture alignment, tests, whether the implementation achieves the plan's goal.",
-      "files": [],
-      "assertions": [
-        {
-          "text": "Checks code quality including patterns and best practices",
-          "type": "behavioral"
-        },
-        {
-          "text": "Examines architecture and design decisions",
-          "type": "behavioral"
-        },
-        {
-          "text": "Assesses test coverage and test quality",
-          "type": "behavioral"
-        }
-      ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "quality"
-          ]
-        },
-        {
-          "type": "regex",
-          "pattern": "test|goal|plan|architect"
-        }
-      ]
-    },
-    {
-      "id": 314,
-      "command": "review",
-      "tier": "micro",
-      "tags": [
-        "actionability"
-      ],
-      "prompt": "Review finds 3 issues: an unused import, a missing error handler, and an N+1 query. How should it report these?",
-      "expected_output": "Each finding should include: severity, file location, what's wrong, and a specific fix suggestion. Not generic advice.",
-      "files": [],
-      "assertions": [
-        {
-          "text": "Classifies findings by severity like important or nitpick",
-          "type": "behavioral"
-        },
-        {
-          "text": "Groups findings by category with next action routing",
-          "type": "behavioral"
-        },
-        {
-          "text": "Does not auto-fix but presents findings for user decision",
-          "type": "behavioral"
-        }
-      ],
-      "checks": [
-        {
-          "type": "regex",
-          "pattern": "sever|file|line|fix|specific"
-        }
-      ]
-    },
-    {
-      "id": 315,
-      "command": "review",
-      "tier": "micro",
-      "tags": [
-        "quick-mode"
-      ],
-      "prompt": "User runs /fh:review --quick. How does quick mode differ from full review?",
-      "expected_output": "Quick mode is faster, focuses on critical issues only, skips deep architecture analysis. Good for post-build sanity checks.",
-      "files": [],
-      "assertions": [
-        {
-          "text": "Quick mode runs faster with fewer subagents than full review",
-          "type": "behavioral"
-        },
-        {
-          "text": "Prioritizes important issues over nitpicks in quick mode",
-          "type": "behavioral"
-        }
-      ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "quick"
-          ]
-        },
-        {
-          "type": "regex",
-          "pattern": "fast|focus|critical"
-        }
-      ]
-    },
-    {
-      "id": 316,
-      "command": "review",
-      "tier": "micro",
-      "tags": [
-        "architecture"
-      ],
-      "prompt": "Review detects that a new module duplicates logic already present in an existing utility. What should it recommend?",
-      "expected_output": "Should flag duplication, point to existing utility, and recommend refactoring to use the existing code instead of the duplicate.",
-      "files": [],
-      "assertions": [
-        {
-          "text": "Detects that new code duplicates existing utility logic",
-          "type": "behavioral"
-        },
-        {
-          "text": "Points to the existing utility that should be reused",
-          "type": "behavioral"
-        },
-        {
-          "text": "Suggests removing the duplication by importing the existing code",
-          "type": "behavioral"
-        }
-      ],
-      "checks": [
-        {
-          "type": "regex",
-          "pattern": "duplic|exist|refactor|reuse"
-        }
-      ]
-    },
-    {
-      "id": 317,
-      "command": "fix",
-      "tier": "micro",
-      "tags": [
-        "happy-path"
-      ],
-      "prompt": "User reports a bug: 'the login page crashes when I submit empty credentials'. What does /fh:fix do first?",
-      "expected_output": "Should reproduce the bug, find the root cause (not just the symptom), then write a failing test before applying the fix.",
-      "files": [],
-      "assertions": [
-        {
-          "text": "Searches for the bug location by reading error messages and relevant code",
-          "type": "behavioral"
-        },
-        {
-          "text": "Identifies the root cause of the crash not just the surface symptom",
-          "type": "behavioral"
-        },
-        {
-          "text": "Writes a test that captures the bug before applying the fix",
-          "type": "behavioral"
-        }
-      ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "root cause",
-            "test"
-          ]
-        },
-        {
-          "type": "regex",
-          "pattern": "reproduc|fail.*test|before.*fix"
-        }
-      ]
-    },
-    {
-      "id": 318,
-      "command": "fix",
-      "tier": "micro",
-      "tags": [
-        "regression"
-      ],
-      "prompt": "Fix finds the bug is caused by a missing null check. After fixing, what should it do to prevent regression?",
-      "expected_output": "Should verify test passes, check for similar patterns elsewhere in the codebase, add guard for related edge cases.",
-      "files": [],
-      "assertions": [
-        {
-          "text": "Verifies the fix resolves the bug and tests pass",
-          "type": "behavioral"
-        },
-        {
-          "text": "Checks if similar code patterns elsewhere have the same problem",
-          "type": "behavioral"
-        }
-      ],
-      "checks": [
-        {
-          "type": "regex",
-          "pattern": "test.*pass|similar|pattern|regress"
-        }
-      ]
-    },
-    {
-      "id": 319,
-      "command": "fix",
-      "tier": "micro",
-      "tags": [
-        "edge-case"
-      ],
-      "prompt": "User says 'fix the auth bug' but doesn't specify which one. Multiple auth-related files exist. How does /fh:fix triage?",
-      "expected_output": "Should search for recent auth-related errors, check git log for recent auth changes, look at error logs or test failures to narrow down the specific bug.",
-      "files": [],
-      "assertions": [
-        {
-          "text": "Searches for auth-related errors or test failures to narrow down",
-          "type": "behavioral"
-        },
-        {
-          "text": "Does not guess \u2014 investigates to find the specific bug",
-          "type": "behavioral"
-        }
-      ],
-      "checks": [
-        {
-          "type": "regex",
-          "pattern": "search|investigat|error|log|narrow"
-        }
-      ]
-    },
-    {
-      "id": 320,
-      "command": "auto",
-      "tier": "micro",
-      "tags": [
-        "workshop",
-        "sanity-check"
-      ],
-      "prompt": "User says 'just go, build it' for a project where PROJECT.md has only one vague line: 'Build a task manager'. REQUIREMENTS.md is empty. Should auto skip the workshop entirely?",
-      "expected_output": "Should skip the full workshop per user request but run the Quick Sanity Check (Step 2.1b). Should warn about gaps in PROJECT.md and empty REQUIREMENTS.md without blocking.",
-      "files": [],
-      "assertions": [
-        {
-          "text": "Skips full workshop because user said just go",
-          "type": "behavioral"
-        },
-        {
-          "text": "Runs quick sanity check and warns about vague PROJECT.md and empty REQUIREMENTS.md",
-          "type": "behavioral"
-        },
-        {
-          "text": "Does not block execution despite gaps \u2014 only warns",
-          "type": "behavioral"
-        }
-      ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "sanity",
-            "warn"
-          ]
-        },
-        {
-          "type": "regex",
-          "pattern": "skip|gap|vague|empty"
-        }
-      ]
-    },
-    {
-      "id": 321,
-      "command": "auto",
-      "tier": "micro",
-      "tags": [
-        "error-reporting",
-        "failure"
-      ],
-      "prompt": "The auto orchestrator exits with code 1 after phase 4 build failed. An error log exists at .planning/phases/04/build-error.log. What should auto report to the user?",
-      "expected_output": "Should read the error log, classify the failure, and provide actionable next steps including --resume command.",
-      "files": [],
-      "assertions": [
-        {
-          "text": "Reads error log from the failed phase directory",
-          "type": "behavioral"
-        },
-        {
-          "text": "Classifies whether this is API error or logic error",
-          "type": "behavioral"
-        },
-        {
-          "text": "Suggests running auto with --resume to continue",
-          "type": "behavioral"
-        }
-      ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "error",
-            "resume"
-          ]
-        },
-        {
-          "type": "regex",
-          "pattern": "log|classif|next|action"
-        }
-      ]
-    },
-    {
-      "id": 322,
-      "command": "update",
-      "prompt": "update --global",
-      "expected_output": "Should update plugin then discover ALL projects using fhhs-skills (from tracker registry and Conductor workspaces) and reconcile each one. Should show project status map before reconciling, then aggregate results table after.",
-      "files": [],
-      "assertions": [
-        {
-          "text": "Discovers projects from tracker registry and Conductor workspace scan",
-          "type": "behavioral"
-        },
-        {
-          "text": "Runs reconciliation on multiple projects, not just current one",
-          "type": "behavioral"
-        },
-        {
-          "text": "Shows aggregate results with per-project status",
+          "text": "app.jsx reads activity_events from autoState",
           "type": "output"
         },
         {
-          "text": "Runs global-reconcile.cjs script for cross-project reconciliation",
-          "type": "behavioral"
-        }
-      ],
-      "scenario_requires": [
-        "gsd_project"
-      ],
-      "tier": "full",
-      "tags": [
-        "happy-path",
-        "global"
-      ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "global",
-            "reconcil"
-          ]
-        }
-      ]
-    },
-    {
-      "id": 323,
-      "command": "update",
-      "prompt": "update --global",
-      "expected_output": "When plugin is already at latest version but --global is passed, should still run environment reconciliation on current project AND then proceed to global reconciliation across all discovered projects. Must NOT exit after current-project reconciliation.",
-      "files": [],
-      "assertions": [
-        {
-          "text": "Recognizes plugin is already up to date",
-          "type": "behavioral"
-        },
-        {
-          "text": "Runs environment reconciliation on current project first",
-          "type": "behavioral"
-        },
-        {
-          "text": "Proceeds to global project reconciliation (Step 6) despite already being up to date",
-          "type": "behavioral"
-        },
-        {
-          "text": "Does NOT exit after current-project reconciliation when --global is set",
-          "type": "guard"
-        }
-      ],
-      "scenario_requires": [
-        "gsd_project"
-      ],
-      "tier": "full",
-      "tags": [
-        "edge-case",
-        "guard",
-        "global"
-      ],
-      "checks": [
-        {
-          "type": "required_terms",
-          "terms": [
-            "global",
-            "reconcil"
-          ]
-        }
-      ]
-    },
-    {
-      "id": 324,
-      "command": "update",
-      "prompt": "I just updated the plugin from a different terminal. Now I want to update all my other projects too",
-      "expected_output": "Should detect plugin is already current, run local reconciliation, then recognize this is a --global use case and either suggest --global or if --global was passed, proceed to Step 6 global reconciliation.",
-      "files": [],
-      "assertions": [
-        {
-          "text": "Detects plugin is already at latest version",
-          "type": "behavioral"
-        },
-        {
-          "text": "Mentions --global flag for cross-project reconciliation",
+          "text": "Auto events are passed to ActivityFeed component",
           "type": "output"
         },
         {
-          "text": "Does NOT attempt to reinstall an already-current plugin",
+          "text": "Does NOT replace existing activity entries when merging auto events",
           "type": "guard"
         }
       ],
-      "scenario_requires": [
-        "gsd_project"
-      ],
-      "tier": "full",
+      "tier": "micro",
       "tags": [
-        "edge-case",
-        "global"
+        "auto",
+        "observability",
+        "04-03"
       ],
-      "checks": [
+      "deterministic_checks": [
         {
-          "type": "required_terms",
-          "terms": [
-            "global"
-          ]
+          "type": "file_contains",
+          "path": "templates/project-tracker/src/app.jsx",
+          "pattern": "autoState.activity_events"
         }
       ]
     }

--- a/templates/project-tracker/server.cjs
+++ b/templates/project-tracker/server.cjs
@@ -585,10 +585,22 @@ function buildState(changedFiles) {
   }
 
   const recentActivity = retros.concat(completionEvents);
-  recentActivity.sort((a, b) => (b.time || '').localeCompare(a.time || ''));
-  recentActivity.splice(10);
 
+  // Merge auto activity events from auto-state
   const autoState = readAutoState(activePlanningDir);
+  if (autoState && Array.isArray(autoState.activity_events)) {
+    for (const evt of autoState.activity_events) {
+      recentActivity.push({
+        type: evt.type || 'auto',
+        text: evt.text || evt.msg || '',
+        time: evt.timestamp || '',
+        timestamp: evt.timestamp || '',
+      });
+    }
+  }
+
+  recentActivity.sort((a, b) => (b.time || b.timestamp || '').localeCompare(a.time || a.timestamp || ''));
+  recentActivity.splice(20);
 
   const result = {
     project,
@@ -727,11 +739,12 @@ function serveState(req, res) {
 // API: /api/activity — returns recent activity (stub for now)
 // ---------------------------------------------------------------------------
 function serveActivity(res) {
+  const activities = lastState ? (lastState.recentActivity || []) : [];
   res.writeHead(200, {
     'Content-Type': 'application/json',
     'Cache-Control': 'no-cache',
   });
-  res.end('[]');
+  res.end(JSON.stringify(activities));
 }
 
 // ---------------------------------------------------------------------------
@@ -887,6 +900,25 @@ const server = http.createServer((req, res) => {
         res.end(JSON.stringify({ error: 'invalid JSON' }));
       }
     });
+    return;
+  }
+
+  // POST /api/kill — write .auto-kill sentinel to stop an active auto job
+  if (req.method === 'POST' && pathname === '/api/kill') {
+    if (!activePlanningDir) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'No active project' }));
+      return;
+    }
+    try {
+      const killFile = path.join(activePlanningDir, '.auto-kill');
+      fs.writeFileSync(killFile, new Date().toISOString(), 'utf8');
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    } catch (err) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: err.message }));
+    }
     return;
   }
 

--- a/templates/project-tracker/src/app.jsx
+++ b/templates/project-tracker/src/app.jsx
@@ -326,7 +326,18 @@ function App() {
                 <CostChart data={costData} title="Session Costs" />
               )}
 
-              <ActivityFeed activities={activities} />
+              <ActivityFeed activities={(() => {
+                const autoActivities = (autoState && autoState.activity_events) || [];
+                const merged = [...activities];
+                for (const evt of autoActivities) {
+                  const isDup = merged.some(a => a.timestamp === evt.timestamp && a.text === evt.text);
+                  if (!isDup) {
+                    merged.push({ type: evt.type, text: evt.text, timestamp: evt.timestamp });
+                  }
+                }
+                merged.sort((a, b) => (b.timestamp || b.time || '').localeCompare(a.timestamp || a.time || ''));
+                return merged.slice(0, 20);
+              })()} />
             </ProjectDetail>
           </div>
         )}

--- a/templates/project-tracker/src/components/AutoPipeline.jsx
+++ b/templates/project-tracker/src/components/AutoPipeline.jsx
@@ -170,8 +170,8 @@ function PhaseStepRow({ phaseNum, phaseName, phaseState, isCurrentPhase, current
 
 // -- LogTail -----------------------------------------------------------------
 
-function LogTail({ logBuffer, lastLogLine }) {
-  const [collapsed, setCollapsed] = useState(true);
+function LogTail({ logBuffer, lastLogLine, autoExpand }) {
+  const [collapsed, setCollapsed] = useState(!autoExpand);
   const scrollRef = useRef(null);
 
   const entries = Array.isArray(logBuffer) && logBuffer.length > 0
@@ -248,6 +248,91 @@ function formatLogTimestamp(ts) {
   }
 }
 
+// -- FreshnessIndicator -------------------------------------------------------
+
+function FreshnessIndicator({ lastActivityAt, now }) {
+  if (!lastActivityAt) return null;
+
+  const silenceMs = now - new Date(lastActivityAt).getTime();
+  if (isNaN(silenceMs) || silenceMs < 0) return null;
+
+  let color, label;
+  if (silenceMs < 60000) {
+    color = 'var(--color-status-done)'; // green
+    label = Math.round(silenceMs / 1000) + 's ago';
+  } else if (silenceMs < 180000) {
+    color = 'var(--color-status-warning)'; // yellow
+    label = Math.round(silenceMs / 60000) + 'm ago';
+  } else if (silenceMs < 480000) {
+    color = 'oklch(0.7 0.15 70)'; // amber
+    label = Math.round(silenceMs / 60000) + 'm ago (silent)';
+  } else {
+    color = 'var(--color-status-error)'; // red
+    label = Math.round(silenceMs / 60000) + 'm ago (silent)';
+  }
+
+  return (
+    <span style={{
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '4px',
+      fontFamily: 'var(--font-family-mono)',
+      fontSize: '11px',
+      color,
+    }}>
+      <span style={{
+        width: '6px',
+        height: '6px',
+        borderRadius: '50%',
+        background: color,
+        flexShrink: 0,
+      }} />
+      {label}
+    </span>
+  );
+}
+
+// -- KillButton ---------------------------------------------------------------
+
+function KillButton({ silenceMs }) {
+  const [sent, setSent] = useState(false);
+
+  if (!silenceMs || silenceMs < 180000) return null; // only show after 3min silence
+
+  const handleKill = () => {
+    fetch('/api/kill', { method: 'POST' })
+      .then(() => setSent(true))
+      .catch(() => setSent(true));
+  };
+
+  if (sent) {
+    return (
+      <span style={{
+        fontSize: '11px',
+        fontFamily: 'var(--font-family-mono)',
+        color: 'var(--color-status-warning)',
+      }}>Kill signal sent</span>
+    );
+  }
+
+  return (
+    <button
+      onClick={handleKill}
+      style={{
+        fontSize: '11px',
+        fontFamily: 'var(--font-family-mono)',
+        color: 'var(--color-status-error)',
+        background: 'transparent',
+        border: '1px solid var(--color-status-error)',
+        borderRadius: '3px',
+        padding: '1px 6px',
+        cursor: 'pointer',
+        lineHeight: '16px',
+      }}
+    >Kill</button>
+  );
+}
+
 // -- AutoPipeline (main) -----------------------------------------------------
 
 export function AutoPipeline({ autoState }) {
@@ -277,6 +362,7 @@ export function AutoPipeline({ autoState }) {
     step_history = [],
     log_buffer,
     last_log_line,
+    last_activity_at,
     build_order = [],
   } = autoState;
 
@@ -361,17 +447,21 @@ export function AutoPipeline({ autoState }) {
           )}
         </div>
 
-        <span style={{
-          fontFamily: 'var(--font-family-mono)',
-          fontSize: '12px',
-          fontVariantNumeric: 'tabular-nums',
-          color: 'var(--color-text-secondary)',
-        }}>
-          {formatDuration(liveElapsed)}
-          {total_cost_estimate != null && (
-            <span> \u00B7 {formatCost(total_cost_estimate)}</span>
-          )}
-        </span>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          <FreshnessIndicator lastActivityAt={last_activity_at} now={now} />
+          <span style={{
+            fontFamily: 'var(--font-family-mono)',
+            fontSize: '12px',
+            fontVariantNumeric: 'tabular-nums',
+            color: 'var(--color-text-secondary)',
+          }}>
+            {formatDuration(liveElapsed)}
+            {total_cost_estimate != null && (
+              <span> \u00B7 {formatCost(total_cost_estimate)}</span>
+            )}
+          </span>
+          <KillButton silenceMs={last_activity_at ? now - new Date(last_activity_at).getTime() : 0} />
+        </div>
       </div>
 
       {/* Wave label */}
@@ -417,7 +507,7 @@ export function AutoPipeline({ autoState }) {
       )}
 
       {/* Log tail */}
-      <LogTail logBuffer={log_buffer} lastLogLine={last_log_line} />
+      <LogTail logBuffer={log_buffer} lastLogLine={last_log_line} autoExpand={true} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Auto-symlinks `.planning/` to private `fhhs-planning` repo on worktree creation
- Sets `CLAUDE_MEM_PROJECT` and `CLAUDE_CODE_TASK_LIST_ID` env vars

New Conductor worktrees will automatically get the `.planning/` symlink without manual setup.