### PR TITLE
release: v1.54.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "fh",
       "description": "fhhs-skills: Composite workflow skills unifying engineering discipline, design quality, and project tracking. Includes /fh:plan-work, /fh:build, /fh:fix, /fh:review, /fh:ui-critique, /fh:polish, and 30+ more commands.",
-      "version": "1.54.0",
+      "version": "1.54.1",
       "author": {
         "name": "Konstantin"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fh",
   "description": "fhhs-skills: All-in-one workflow plugin — engineering discipline (TDD, verification, code review), design quality (critique, polish, normalize), and project tracking (phases, milestones, roadmaps). No other plugins required.",
-  "version": "1.54.0",
+  "version": "1.54.1",
   "author": {
     "name": "Konstantin"
   },

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -295,6 +295,34 @@ else
 fi
 ```
 
+### 5a-cache: Clean plugin cache
+
+Remove old cached plugin versions (keeps only the current one) and orphaned temp directories. This speeds up plugin discovery on session start.
+
+```bash
+CACHE_DIR="$HOME/.claude/plugins/cache"
+CURRENT_VERSION="$(basename "$LATEST")"
+
+# Remove old fhhs-skills cache versions
+if [ -d "$CACHE_DIR/fhhs-skills/fh" ]; then
+  REMOVED=0
+  for dir in "$CACHE_DIR/fhhs-skills/fh"/*/; do
+    dir="${dir%/}"
+    if [ "$(basename "$dir")" != "$CURRENT_VERSION" ]; then
+      rm -rf "$dir" && REMOVED=$((REMOVED + 1))
+    fi
+  done
+  [ "$REMOVED" -gt 0 ] && echo "✓ Removed $REMOVED old cached version(s)" || echo "✓ Cache already clean"
+fi
+
+# Remove orphaned temp_git_* directories from failed installs/updates
+TEMP_REMOVED=0
+for dir in "$CACHE_DIR"/temp_git_*/; do
+  [ -d "$dir" ] && rm -rf "$dir" && TEMP_REMOVED=$((TEMP_REMOVED + 1))
+done
+[ "$TEMP_REMOVED" -gt 0 ] && echo "✓ Removed $TEMP_REMOVED orphaned temp directories"
+```
+
 ### 5a½ + 5a¾ + 5a⅞: Run post-update reconciliation script
 
 Steps 5a½ (claude-mem patch), 5a¾ (CLAUDE_MEM_PROJECT), and 5a⅞ (tracker refresh) are handled by a script in `bin/` which was just re-linked in Step 5a. This ensures the NEW version's logic runs even when the SKILL.md prompt was loaded from the old cached version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Entries affecting `/fh:setup` or `/fh:new-project` environment carry reconciliation tags
 (`[setup:TYPE:ID]`, `[project:TYPE:ID]`) used by `/fh:update` for post-update checks.
 
+## [1.54.1] - 2026-03-29
+
+### Changed
+- **Update skill cache cleanup** — `/fh:update` now removes old cached plugin versions and orphaned temp directories after updating, speeding up plugin discovery on new session start
+
 ## [1.54.0] - 2026-03-29
 
 ### Added


### PR DESCRIPTION
Update skill cache cleanup — removes old cached plugin versions and orphaned temp directories after updating, speeding up plugin discovery on new Conductor tabs.