### PR TITLE
release: v1.57.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "fh",
       "description": "fhhs-skills: Composite workflow skills unifying engineering discipline, design quality, and project tracking. Includes /fh:plan-work, /fh:build, /fh:fix, /fh:review, /fh:ui-critique, /fh:polish, and 30+ more commands.",
-      "version": "1.57.0",
+      "version": "1.57.1",
       "author": {
         "name": "Konstantin"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fh",
   "description": "fhhs-skills: All-in-one workflow plugin — engineering discipline (TDD, verification, code review), design quality (critique, polish, normalize), and project tracking (phases, milestones, roadmaps). No other plugins required.",
-  "version": "1.57.0",
+  "version": "1.57.1",
   "author": {
     "name": "Konstantin"
   },

--- a/.claude/skills/map-codebase/SKILL.md
+++ b/.claude/skills/map-codebase/SKILL.md
@@ -72,10 +72,18 @@ Continue to create_structure.
 </step>
 
 <step name="create_structure">
-Create .planning/codebase/ directory:
+Create .planning/codebase/ directory and clean up legacy mapping files:
 
 ```bash
 mkdir -p .planning/codebase
+```
+
+**Remove legacy multi-document structure if present.** Previous versions produced separate files (ARCHITECTURE.md, STRUCTURE.md, CONVENTIONS.md, DEPENDENCIES.md, etc.) in `.planning/codebase/`. These are superseded by the single CODEBASE.md. Delete them:
+
+```bash
+for f in ARCHITECTURE.md STRUCTURE.md CONVENTIONS.md DEPENDENCIES.md PATTERNS.md TECH_STACK.md; do
+  [ -f ".planning/codebase/$f" ] && rm ".planning/codebase/$f" && echo "Removed legacy .planning/codebase/$f"
+done
 ```
 
 **Expected output:** A single `CODEBASE.md` (~150-200 lines) covering structure, conventions, and architecture.

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -632,7 +632,7 @@ Read `~/.claude-mem/settings.json` using the **Read tool**. If it doesn't exist,
   "CLAUDE_MEM_CONTEXT_SESSION_COUNT": "50",
   "CLAUDE_MEM_CONTEXT_FULL_COUNT": "15",
   "CLAUDE_MEM_CONTEXT_FULL_FIELD": "narrative",
-  "CLAUDE_MEM_FOLDER_CLAUDEMD_ENABLED": "true",
+  "CLAUDE_MEM_FOLDER_CLAUDEMD_ENABLED": "false",
   "CLAUDE_MEM_CONTEXT_SHOW_LAST_SUMMARY": "true",
   "CLAUDE_MEM_CONTEXT_SHOW_LAST_MESSAGE": "false",
   "CLAUDE_MEM_CONTEXT_SHOW_READ_TOKENS": "true",
@@ -657,7 +657,7 @@ After applying, display:
   │ CONTEXT_SESSION_COUNT               │ 10      │ 50          │
   │ CONTEXT_FULL_COUNT                  │ 5       │ 15          │
   │ CONTEXT_FULL_FIELD                  │ —       │ narrative   │
-  │ FOLDER_CLAUDEMD_ENABLED             │ false   │ true        │
+  │ FOLDER_CLAUDEMD_ENABLED             │ false   │ false       │
   │ CONTEXT_SHOW_LAST_SUMMARY           │ true    │ true        │
   │ CONTEXT_SHOW_LAST_MESSAGE           │ true    │ false       │
   │ CONTEXT_SHOW_READ/WORK/SAVINGS      │ —       │ true        │
@@ -669,8 +669,7 @@ After applying, display:
   continuity. /fh:auto runs many parallel agents that all generate
   observations — high limits ensure nothing is lost. "narrative"
   mode gives richer context than "facts" for complex multi-phase
-  work. Auto-CLAUDE.md enabled for project-level context files.
-  Token stats visible so users can monitor context budget.
+  work. Token stats visible so users can monitor context budget.
 
   Adjust further via dashboard at localhost:37777 or
   edit ~/.claude-mem/settings.json directly.

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -443,7 +443,7 @@ After installing `claude-mem@thedotmack` successfully, also apply fhhs-skills co
   "CLAUDE_MEM_CONTEXT_SESSION_COUNT": "50",
   "CLAUDE_MEM_CONTEXT_FULL_COUNT": "15",
   "CLAUDE_MEM_CONTEXT_FULL_FIELD": "narrative",
-  "CLAUDE_MEM_FOLDER_CLAUDEMD_ENABLED": "true",
+  "CLAUDE_MEM_FOLDER_CLAUDEMD_ENABLED": "false",
   "CLAUDE_MEM_CONTEXT_SHOW_LAST_SUMMARY": "true",
   "CLAUDE_MEM_CONTEXT_SHOW_LAST_MESSAGE": "false",
   "CLAUDE_MEM_CONTEXT_SHOW_READ_TOKENS": "true",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Entries affecting `/fh:setup` or `/fh:new-project` environment carry reconciliation tags
 (`[setup:TYPE:ID]`, `[project:TYPE:ID]`) used by `/fh:update` for post-update checks.
 
+## [1.57.1] - 2026-03-29
+
+### Changed
+- **claude-mem auto-CLAUDE.md disabled** — `FOLDER_CLAUDEMD_ENABLED` explicitly set to `false` in `/fh:setup` and `/fh:update` configs to prevent claude-mem from auto-generating CLAUDE.md files
+- **Codebase mapping legacy cleanup** — `/fh:map-codebase` now removes old multi-document files (ARCHITECTURE.md, STRUCTURE.md, CONVENTIONS.md, etc.) before writing the single CODEBASE.md
+
 ## [1.57.0] - 2026-03-29
 
 ### Added


### PR DESCRIPTION
Version bump and changelog for v1.57.1

### Changed
- claude-mem `FOLDER_CLAUDEMD_ENABLED` set to `false` in setup and update configs
- `/fh:map-codebase` cleans up legacy multi-document files before writing CODEBASE.md