### PR TITLE
release: v1.65.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "fh",
       "description": "fhhs-skills: 33 skills and 31 agents — plan, spec, build, review, fix, research, design, and ship autonomously. Includes /fh:plan-work, /fh:build, /fh:fix, /fh:review, /fh:research, /fh:auto, and more.",
-      "version": "1.64.0",
+      "version": "1.65.0",
       "author": {
         "name": "Konstantin"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fh",
   "description": "fhhs-skills: All-in-one workflow plugin — 33 skills and 31 agents for spec-driven development, TDD, design quality, web research, startup validation, and autonomous execution. No other plugins required.",
-  "version": "1.64.0",
+  "version": "1.65.0",
   "author": {
     "name": "Konstantin"
   },

--- a/.claude/skills/auto/SKILL.md
+++ b/.claude/skills/auto/SKILL.md
@@ -36,6 +36,25 @@ What to run autonomously: $ARGUMENTS
 
 ---
 
+## Step 0: Tool Readiness
+
+claude-mem tools are **deferred** — they must be fetched before they can be called. Do this first, before any other work.
+
+```
+ToolSearch("select:mcp__plugin_claude-mem_mcp-search__smart_search,mcp__plugin_claude-mem_mcp-search__smart_outline,mcp__plugin_claude-mem_mcp-search__smart_unfold,mcp__plugin_claude-mem_mcp-search__search,mcp__plugin_claude-mem_mcp-search__get_observations")
+```
+
+Also verify ast-grep CLI is available:
+```bash
+command -v sg &>/dev/null || command -v ast-grep &>/dev/null || echo "WARN: ast-grep not found"
+```
+
+These tools are used by downstream skills (plan-work, build, review) in their own sessions — no need to pass them forward.
+
+**If ToolSearch returns empty for claude-mem:** Fall back to Read-based approach for this session.
+
+---
+
 ## Step 1: Validate Prerequisites
 
 Check that the project is set up for autonomous execution:
@@ -160,7 +179,13 @@ If DESIGN.md exists, use it throughout to ground UX/UI guidance in the project's
 
 claude-mem observations persist across sequential `claude -p` sessions. No explicit pre-indexing needed.
 
-**Pattern A (Past Learnings Check):** Derive project name from `.planning/PROJECT.md` name field (fall back to basename of cwd). Call `mcp__plugin_claude-mem_mcp-search__search` with query=2-3 keywords from the project domain, project=<project-name>, limit=10. Scan the returned index for relevant IDs — prioritize types: gotcha, decision, trade-off. For the top 2-3 relevant IDs, call `mcp__plugin_claude-mem_mcp-search__get_observations` with ids=[ID1, ID2, ID3] to fetch full details. If temporal context would help, call `mcp__plugin_claude-mem_mcp-search__timeline` with query=project domain keywords, depth_before=3. Present as: "**From prior sessions:** - {full observation detail}" — max 3 items. Budget: <2% context. Skip silently if no relevant results.
+**Pattern A (Past Learnings Check):** Derive project name consistently:
+```bash
+PROJECT_NAME=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || basename "$(pwd)")
+```
+Use `$PROJECT_NAME` as the `project` parameter for all claude-mem calls.
+
+Call `mcp__plugin_claude-mem_mcp-search__search` with query=2-3 keywords from the project domain, project=<project-name>, limit=10. Scan the returned index for relevant IDs — prioritize types: gotcha, decision, trade-off. For the top 2-3 relevant IDs, call `mcp__plugin_claude-mem_mcp-search__get_observations` with ids=[ID1, ID2, ID3] to fetch full details. If temporal context would help, call `mcp__plugin_claude-mem_mcp-search__timeline` with query=project domain keywords, depth_before=3. Present as: "**From prior sessions:** - {full observation detail}" — max 3 items. Max 3 items. Skip silently if no relevant results.
 
 Identify what's well-defined vs what has gaps: missing vision, vague success criteria, no differentiation story, unclear scope ambition, missing UX/domain research, missing design context.
 
@@ -170,7 +195,11 @@ This step runs even when the full workshop is skipped. It takes <30 seconds and 
 
 1. **Read PROJECT.md, REQUIREMENTS.md, ROADMAP.md** — confirm they exist and are non-trivial (>3 lines each)
 2. **Flag critical gaps silently** — if any of these are missing or empty, warn the user: "I'm skipping the workshop as requested, but I noticed [gap]. The pipeline may produce suboptimal results."
-3. **Quick domain check (Pattern A)** — call `mcp__plugin_claude-mem_mcp-search__search` with query=2-3 project keywords, project=<project-name>, limit=10. Scan the returned index for relevant IDs — prioritize types: gotcha, decision. For the top 2-3 relevant IDs, call `mcp__plugin_claude-mem_mcp-search__get_observations` with ids=[ID1, ID2, ID3] to fetch full details. Surface any relevant prior learnings that might affect the build. Skip silently if no relevant results.
+3. **Quick domain check (Pattern A)** — derive project name consistently:
+   ```bash
+   PROJECT_NAME=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || basename "$(pwd)")
+   ```
+   Use `$PROJECT_NAME` as the `project` parameter for all claude-mem calls. Call `mcp__plugin_claude-mem_mcp-search__search` with query=2-3 project keywords, project=<project-name>, limit=10. Scan the returned index for relevant IDs — prioritize types: gotcha, decision. For the top 2-3 relevant IDs, call `mcp__plugin_claude-mem_mcp-search__get_observations` with ids=[ID1, ID2, ID3] to fetch full details. Surface any relevant prior learnings that might affect the build. Skip silently if no relevant results.
 4. **Validate phase readiness** — check that at least the first incomplete phase has a clear goal in ROADMAP.md. If the goal is vague (e.g., "improve things"), warn: "Phase N goal is vague — the planning step may struggle. Consider clarifying before proceeding."
 
 This step NEVER blocks execution. It only warns. The user already said "go" — respect that while providing visibility.
@@ -508,3 +537,9 @@ node "$ORCHESTRATOR" --project-dir "$(pwd)" --check-corrections
 ```
 
 This mode is useful after a human reviews DECISIONS.md and marks entries as CORRECTED — the cascade propagates those corrections to affected artifacts automatically where possible.
+
+---
+
+### Cross-Session Output
+
+**[auto-output]** Milestone: {name}. Phases completed: {count}/{total}. Total plans: {executed}. Decisions logged: {count}. Issues: {unresolved_count}.

--- a/.claude/skills/auto/SKILL.md
+++ b/.claude/skills/auto/SKILL.md
@@ -10,6 +10,38 @@ What to run autonomously: $ARGUMENTS
 
 ---
 
+## Architecture: 2-Layer Direct Dispatch
+
+The auto-orchestrator uses a 2-layer architecture:
+- **Layer 1: Orchestrator** (`auto-orchestrator.cjs`) — state machine managing phase lifecycle, spawning task sessions, handling retries and checkpoints
+- **Layer 2: Task sessions** (`claude -p` per task) — individual task execution with injected plan context
+
+For the build step, the orchestrator dispatches tasks directly via `claude -p` instead of invoking `/fh:build`. This eliminates the 3rd nesting layer.
+
+Interactive builds still use `/fh:build` with Agent tool dispatch.
+
+### Fallback
+
+Plans that can't be parsed for direct dispatch (missing XML tasks) fall back to `/fh:build` invocation.
+
+### State Machine
+
+Phase lifecycle: `pending → planning → planned → reviewing → reviewed → building → verifying → complete`
+Task lifecycle: `queued → dispatched → running → completed|failed|timed-out`
+
+Failed phases retry automatically (max 2 attempts). Timed-out tasks retry with extended timeout.
+
+### Shared Library
+
+Reusable modules at `.claude/skills/auto/lib/`:
+- `task-dispatch.cjs` — per-task `claude -p` spawning with process group kill
+- `context-injection.cjs` — build task prompts from plan context
+- `wave-analysis.cjs` — parse PLAN.md into ordered wave groups
+- `verification.cjs` — run verification commands
+- `summary-generation.cjs` — generate SUMMARY.md content
+
+---
+
 ## Walk-Away Guide
 
 `/fh:auto` plans, reviews, builds, and reviews each phase without human intervention.

--- a/.claude/skills/auto/SKILL.md
+++ b/.claude/skills/auto/SKILL.md
@@ -73,7 +73,7 @@ Reusable modules at `.claude/skills/auto/lib/`:
 claude-mem tools are **deferred** — they must be fetched before they can be called. Do this first, before any other work.
 
 ```
-ToolSearch("select:mcp__plugin_claude-mem_mcp-search__smart_search,mcp__plugin_claude-mem_mcp-search__smart_outline,mcp__plugin_claude-mem_mcp-search__smart_unfold,mcp__plugin_claude-mem_mcp-search__search,mcp__plugin_claude-mem_mcp-search__get_observations")
+ToolSearch("+mcp-search", max_results: 10)
 ```
 
 Also verify ast-grep CLI is available:

--- a/.claude/skills/auto/auto-orchestrator.cjs
+++ b/.claude/skills/auto/auto-orchestrator.cjs
@@ -864,6 +864,7 @@ function aggregatePhaseMetrics(stepHistory, phaseId) {
 // ─── Project Name Resolution ──────────────────────────────────────────────────
 
 function resolveProjectName(cwd) {
+  // Project name: git-based resolution (aligned with SKILL.md — D-261)
   try {
     const { execFileSync } = require('child_process');
 
@@ -922,6 +923,11 @@ function createJsonLineParser(onLine) {
   };
 }
 
+// ─── Tool Readiness Hint (injected into every downstream session) ────────────
+
+// ToolSearch preamble for downstream skills (D-265)
+const TOOL_READINESS_HINT = `\n## Tool Readiness (auto-injected)\n\nclaude-mem MCP tools are deferred. At session start, fetch them:\nToolSearch("select:mcp__plugin_claude-mem_mcp-search__smart_search,mcp__plugin_claude-mem_mcp-search__smart_outline,mcp__plugin_claude-mem_mcp-search__smart_unfold,mcp__plugin_claude-mem_mcp-search__search,mcp__plugin_claude-mem_mcp-search__get_observations")\n\nIf ToolSearch returns empty, fall back to Read-based approach.\n`;
+
 // ─── Claude Session Runner (with stuck detection + activity monitoring) ───────
 
 // INVARIANT: spawn('claude', ...) must appear ONLY inside runClaudeSession.
@@ -962,7 +968,9 @@ function runClaudeSession(prompt, opts) {
     const claudeMdPath = path.join(opts.cwd, 'CLAUDE.md');
     if (fs.existsSync(claudeMdPath)) {
       const claudeMd = fs.readFileSync(claudeMdPath, 'utf-8').slice(0, 4000);
-      args.push('--append-system-prompt', `Project conventions:\n${claudeMd}`);
+      args.push('--append-system-prompt', `Project conventions:\n${claudeMd}${TOOL_READINESS_HINT}`);
+    } else {
+      args.push('--append-system-prompt', TOOL_READINESS_HINT);
     }
     const projectName = resolveProjectName(opts.cwd);
     log(`  Running: claude -p "${prompt.slice(0, 80)}..." (plugin-dir=${pluginDir})`);
@@ -977,7 +985,7 @@ function runClaudeSession(prompt, opts) {
         ...(opts.sessionId ? { CLAUDE_SESSION_ID: opts.sessionId } : {}),
         CLAUDE_MEM_PROJECT: projectName,
         CLAUDE_MEM_CONTEXT_OBSERVATIONS: '0',
-        CLAUDE_MEM_SKIP_TOOLS: 'ListMcpResourcesTool,ReadMcpResourceTool,SlashCommand,Skill,TodoWrite,AskUserQuestion,ToolSearch,TaskCreate,TaskUpdate,TaskGet,TaskList,TaskOutput,TaskStop,SendMessage,EnterPlanMode,ExitPlanMode,EnterWorktree,ExitWorktree,LSP,CronCreate,CronDelete,CronList,TeamCreate,TeamDelete,NotebookEdit,mcp__plugin_claude-mem_mcp-search____IMPORTANT,mcp__plugin_claude-mem_mcp-search__search,mcp__plugin_claude-mem_mcp-search__get_observations,mcp__plugin_claude-mem_mcp-search__timeline,mcp__plugin_claude-mem_mcp-search__smart_search,mcp__plugin_claude-mem_mcp-search__smart_unfold,mcp__plugin_claude-mem_mcp-search__smart_outline',
+        CLAUDE_MEM_SKIP_TOOLS: 'ListMcpResourcesTool,ReadMcpResourceTool,SlashCommand,Skill,TodoWrite,AskUserQuestion,ToolSearch,TaskCreate,TaskUpdate,TaskGet,TaskList,TaskOutput,TaskStop,SendMessage,EnterPlanMode,ExitPlanMode,EnterWorktree,ExitWorktree,LSP,CronCreate,CronDelete,CronList,TeamCreate,TeamDelete,NotebookEdit',
       },
     });
 

--- a/.claude/skills/auto/auto-orchestrator.cjs
+++ b/.claude/skills/auto/auto-orchestrator.cjs
@@ -927,7 +927,7 @@ function createJsonLineParser(onLine) {
 // ─── Tool Readiness Hint (injected into every downstream session) ────────────
 
 // ToolSearch preamble for downstream skills (D-265)
-const TOOL_READINESS_HINT = `\n## Tool Readiness (auto-injected)\n\nclaude-mem MCP tools are deferred. At session start, fetch them:\nToolSearch("select:mcp__plugin_claude-mem_mcp-search__smart_search,mcp__plugin_claude-mem_mcp-search__smart_outline,mcp__plugin_claude-mem_mcp-search__smart_unfold,mcp__plugin_claude-mem_mcp-search__search,mcp__plugin_claude-mem_mcp-search__get_observations")\n\nIf ToolSearch returns empty, fall back to Read-based approach.\n`;
+const TOOL_READINESS_HINT = `\n## Tool Readiness (auto-injected)\n\nclaude-mem MCP tools are deferred. At session start, fetch them:\nToolSearch("+mcp-search", max_results: 10)\n\nIf ToolSearch returns empty, fall back to Read-based approach.\n`;
 
 // ─── Claude Session Runner (with stuck detection + activity monitoring) ───────
 

--- a/.claude/skills/auto/auto-orchestrator.cjs
+++ b/.claude/skills/auto/auto-orchestrator.cjs
@@ -21,6 +21,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { spawn } = require('child_process');
+const { parseWaves, buildTaskPrompt, dispatchTask, runVerification, generateSummary } = require('./lib/index.cjs');
 
 // ─── Enriched Auto-Status ─────────────────────────────────────────────────────
 
@@ -979,7 +980,7 @@ function runClaudeSession(prompt, opts) {
     const child = spawn('claude', args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       cwd: opts.cwd,
-      detached: false,
+      detached: true,
       env: {
         ...process.env,
         ...(opts.sessionId ? { CLAUDE_SESSION_ID: opts.sessionId } : {}),
@@ -1110,7 +1111,7 @@ function runClaudeSession(prompt, opts) {
         if (fs.existsSync(killFile)) {
           log('  Kill requested via .auto-kill sentinel — stopping gracefully');
           try { fs.unlinkSync(killFile); } catch {}
-          child.kill('SIGTERM');
+          try { process.kill(-child.pid, 'SIGTERM'); } catch { /* already dead */ }
           return;
         }
       }
@@ -1128,9 +1129,9 @@ function runClaudeSession(prompt, opts) {
           step: opts.stepName || null,
           extra: { reason: `stuck (no output for ${silenceMin}min)`, silence_s: Math.round(silenceMs / 1000), last_tool: lastToolName, elapsed_s: Math.round((Date.now() - sessionStart) / 1000), session: opts.sessionId }
         });
-        child.kill('SIGTERM');
+        try { process.kill(-child.pid, 'SIGTERM'); } catch { /* already dead */ }
         setTimeout(() => {
-          try { child.kill('SIGKILL'); } catch { /* already dead */ }
+          try { process.kill(-child.pid, 'SIGKILL'); } catch { /* already dead */ }
         }, 5000);
       } else if (silenceMs >= STUCK_SILENCE_MS && !stuckWarned) {
         stuckWarned = true;
@@ -1148,10 +1149,10 @@ function runClaudeSession(prompt, opts) {
     const hardTimer = setTimeout(() => {
       const elapsedMin = Math.round((Date.now() - sessionStart) / 60000);
       log(`  ✗ HARD TIMEOUT: killing session after ${elapsedMin}min`);
-      child.kill('SIGTERM');
+      try { process.kill(-child.pid, 'SIGTERM'); } catch { /* already dead */ }
       // Give SIGTERM 5s to take effect, then SIGKILL
       setTimeout(() => {
-        try { child.kill('SIGKILL'); } catch { /* already dead */ }
+        try { process.kill(-child.pid, 'SIGKILL'); } catch { /* already dead */ }
       }, 5000);
     }, HARD_TIMEOUT_MS);
 
@@ -1237,7 +1238,84 @@ function updateStateViaGsd(projectDir, phaseId) {
 
 // ─── Phase Steps ──────────────────────────────────────────────────────────────
 
+// PHASE_STEPS retained for speculative pipeline — state machine used in sequential mode
 const PHASE_STEPS = ['plan-work', 'plan-review', 'build', 'review'];
+
+// ─── Phase & Task State Machines ────────────────────────────────────────────
+// PHASE_STEPS retained for speculative pipeline — will be migrated in a future plan
+const PHASE_TRANSITIONS = {
+  pending:          ['planning'],
+  planning:         ['planned', 'plan-failed'],
+  'plan-failed':    ['planning'],        // retry
+  planned:          ['reviewing'],
+  reviewing:        ['reviewed', 'review-failed'],
+  'review-failed':  ['planned'],         // retry from planned
+  reviewed:         ['building'],
+  building:         ['verifying', 'build-failed'],
+  'build-failed':   ['reviewed'],        // retry from reviewed
+  verifying:        ['complete', 'verify-failed'],
+  'verify-failed':  ['reviewed'],        // re-build
+  complete:         [],                  // terminal
+};
+
+const TASK_TRANSITIONS = {
+  queued:      ['dispatched'],
+  dispatched:  ['running'],
+  running:     ['completed', 'failed', 'timed-out'],
+  failed:      ['queued'],              // retry
+  'timed-out': ['queued'],              // retry with extended timeout
+  completed:   [],                      // terminal
+};
+
+function transitionPhase(currentState, nextState) {
+  const allowed = PHASE_TRANSITIONS[currentState];
+  if (!allowed) throw new Error(`Unknown phase state: ${currentState}`);
+  if (!allowed.includes(nextState)) {
+    throw new Error(`Invalid phase transition: ${currentState} → ${nextState} (allowed: ${allowed.join(', ')})`);
+  }
+  return nextState;
+}
+
+function transitionTask(currentState, nextState) {
+  const allowed = TASK_TRANSITIONS[currentState];
+  if (!allowed) throw new Error(`Unknown task state: ${currentState}`);
+  if (!allowed.includes(nextState)) {
+    throw new Error(`Invalid task transition: ${currentState} → ${nextState} (allowed: ${allowed.join(', ')})`);
+  }
+  return nextState;
+}
+
+// Map phase states to the step they need to execute
+const STATE_TO_STEP = {
+  pending:          'plan-work',
+  'plan-failed':    'plan-work',    // retry
+  planned:          'plan-review',
+  'review-failed':  'plan-review',  // retry
+  reviewed:         'build',
+  'build-failed':   'build',        // retry
+  verifying:        'review',
+  'verify-failed':  'review',       // retry
+  planning:         null,           // in progress
+  reviewing:        null,           // in progress
+  building:         null,           // in progress
+  complete:         null,           // done
+};
+
+// Legacy state migration (D9)
+const LEGACY_STATE_MAP = {
+  'built': 'complete',
+  'rescheduled-sequential': 'pending',
+  'blocked': 'pending',
+};
+
+function migratePhaseState(state) {
+  return LEGACY_STATE_MAP[state] || state;
+}
+
+function updatePhaseState(autoState, phaseId, state) {
+  if (!autoState.phase_states) autoState.phase_states = {};
+  autoState.phase_states[phaseId] = state;
+}
 
 async function executeStep(projectDir, phaseId, step, planPath) {
   // Read phase goal from ROADMAP.md for richer autonomous prompts
@@ -1338,69 +1416,378 @@ async function executeStep(projectDir, phaseId, step, planPath) {
       }
       const relPlan = path.relative(projectDir, latestPlan);
 
-      // SPEC.md awareness: check for a sibling spec file and frontmatter spec: field
-      let specHint = '';
-      let taskStateHint = '';
+      // ── Attempt direct dispatch (D2: shared functions) ──────────────────────
+      let parsedPlan;
       try {
-        const planBase = path.basename(latestPlan);
-        const planDir = path.dirname(latestPlan);
-        // Derive spec path: XX-NN-PLAN.md → XX-NN-SPEC.md
-        const specBase = planBase.replace(/-PLAN\.md$/, '-SPEC.md').replace(/^PLAN\.md$/, 'SPEC.md');
-        const specPath = path.join(planDir, specBase);
-        const relSpecPath = path.relative(projectDir, specPath);
+        parsedPlan = parseWaves(latestPlan);
+      } catch (parseErr) {
+        log(`  Plan format not parseable for direct dispatch — falling back to /fh:build invocation: ${parseErr.message}`);
+        parsedPlan = null;
+      }
 
-        if (fs.existsSync(specPath)) {
-          specHint = ` SPEC.md exists at ${relSpecPath}. Build skill will inject relevant sections per task.`;
-        } else {
-          // Check if PLAN.md frontmatter has a spec: field referencing a missing file
+      // Fallback: old behavior if plan not parseable for direct dispatch
+      if (!parsedPlan || parsedPlan.waves.length === 0) {
+        if (parsedPlan && parsedPlan.waves.length === 0) {
+          log('  Plan format not parseable for direct dispatch — falling back to /fh:build invocation (no task waves found)');
+        }
+        const relPlanFallback = path.relative(projectDir, latestPlan);
+        return await runClaudeSession(
+          `You are in auto mode. Execute the plan at ${relPlanFallback} using /fh:build. ` +
+          `Phase goal: "${phaseGoal}". Build all tasks, run tests, commit changes. Do not ask questions.`,
+          { cwd: projectDir, sessionId, stepName: 'build' }
+        );
+      }
+
+      log(`  Direct dispatch: ${parsedPlan.waves.length} wave(s) found in ${relPlan}`);
+
+      // ── Derive plan number from filename (e.g. "23-02-PLAN.md" → "02") ──
+      const planBase = path.basename(latestPlan);
+      const planNumMatch = planBase.match(/^(?:\d+-)?(\d+)-PLAN\.md$/) || planBase.match(/^(\d+)-PLAN\.md$/);
+      const planNum = planNumMatch ? planNumMatch[1] : '01';
+
+      // ── Ensure .planning/build/ exists ───────────────────────────────────────
+      const buildDir = path.join(projectDir, '.planning', 'build');
+      fs.mkdirSync(buildDir, { recursive: true });
+
+      // ── Scan for existing checkpoints (crash resume) ─────────────────────────
+      const existingCheckpoints = {};
+      try {
+        const checkpointFiles = fs.readdirSync(buildDir).filter(function(f) {
+          return f.endsWith('-checkpoint.json');
+        });
+        for (const cf of checkpointFiles) {
           try {
-            const planContent = fs.readFileSync(latestPlan, 'utf-8');
-            const specFieldMatch = planContent.match(/^spec:\s*(.+)/m);
-            if (specFieldMatch) {
-              const referencedSpec = specFieldMatch[1].trim();
-              const referencedSpecPath = path.isAbsolute(referencedSpec)
-                ? referencedSpec
-                : path.join(planDir, referencedSpec);
-              if (!fs.existsSync(referencedSpecPath)) {
-                log(`  Warning: PLAN.md references spec: ${referencedSpec} but file not found at ${referencedSpecPath}`);
-              }
-            }
-          } catch { /* ignore */ }
+            const cp = JSON.parse(fs.readFileSync(path.join(buildDir, cf), 'utf-8'));
+            if (cp.taskId) existingCheckpoints[cp.taskId] = cp;
+          } catch { /* ignore malformed */ }
+        }
+        if (Object.keys(existingCheckpoints).length > 0) {
+          log('  Resume: found ' + Object.keys(existingCheckpoints).length + ' checkpoint(s) in ' + buildDir);
         }
       } catch { /* ignore */ }
 
-      // Task state resume awareness
+      // ── Clean up stale result files for this plan ────────────────────────────
       try {
-        const buildStateDir = path.join(projectDir, '.planning', 'build');
-        if (fs.existsSync(buildStateDir)) {
-          const stateFiles = fs.readdirSync(buildStateDir).filter(f => f.startsWith('task-') && f.endsWith('-state.md'));
-          if (stateFiles.length > 0) {
-            let completedCount = 0;
-            let pendingCount = 0;
-            for (const sf of stateFiles) {
-              try {
-                const sfContent = fs.readFileSync(path.join(buildStateDir, sf), 'utf-8');
-                if (/status:\s*(completed|done)/i.test(sfContent)) {
-                  completedCount++;
-                } else if (/status:\s*(in-progress|pending)/i.test(sfContent)) {
-                  pendingCount++;
-                }
-              } catch { /* ignore */ }
+        const staleFiles = fs.readdirSync(buildDir).filter(function(f) {
+          return f.startsWith('task-' + planNum + '-') && f.endsWith('-result.json');
+        });
+        for (const sf of staleFiles) {
+          try { fs.unlinkSync(path.join(buildDir, sf)); } catch { /* ignore */ }
+        }
+      } catch { /* ignore */ }
+
+      // ── Read CONTEXT.md decisions (try multiple naming patterns) ─────────────
+      let contextDecisions = '';
+      const phaseDir = findPhaseDir(projectDir, phaseId);
+      if (phaseDir) {
+        const contextCandidates = [
+          path.join(phaseDir, 'CONTEXT.md'),
+          path.join(phaseDir, `${normalizePhaseName(phaseId)}-CONTEXT.md`),
+        ];
+        for (const candidate of contextCandidates) {
+          try {
+            if (fs.existsSync(candidate)) {
+              const ctxContent = fs.readFileSync(candidate, 'utf-8');
+              // Extract the Decisions section
+              const decisionsMatch = ctxContent.match(/^##\s+Decisions[\s\S]*?(?=^##\s|$)/m);
+              contextDecisions = decisionsMatch ? decisionsMatch[0].trim() : ctxContent.slice(0, 3000);
+              break;
             }
-            if (pendingCount > 0 || completedCount > 0) {
-              log(`  Partial build detected for phase ${phaseId} — ${completedCount} tasks completed, ${pendingCount} remaining. Build will resume from exact task.`);
-              taskStateHint = ` Resume detected. Task state files at .planning/build/. Resume from incomplete tasks.`;
+          } catch { /* ignore */ }
+        }
+      }
+
+      // ── Read CLAUDE.md first 4000 chars for project constraints ─────────────
+      let projectConstraints = '';
+      try {
+        const claudeMdPath = path.join(projectDir, 'CLAUDE.md');
+        if (fs.existsSync(claudeMdPath)) {
+          projectConstraints = fs.readFileSync(claudeMdPath, 'utf-8').slice(0, 4000);
+        }
+      } catch { /* ignore */ }
+
+      // ── Read optional SPEC sections if frontmatter has spec: field ───────────
+      let specSections = null;
+      try {
+        const fm = parsedPlan.frontmatter || {};
+        if (fm.spec) {
+          const planDir = path.dirname(latestPlan);
+          const specRef = fm.spec;
+          const specPath = path.isAbsolute(specRef) ? specRef : path.join(planDir, specRef);
+          if (fs.existsSync(specPath)) {
+            const specContent = fs.readFileSync(specPath, 'utf-8');
+            // Extract named sections
+            function extractSpecSection(tag) {
+              const re = new RegExp('<' + tag + '[^>]*>([\\s\\S]*?)<\\/' + tag + '>', 's');
+              const m = specContent.match(re);
+              return m ? m[1].trim() : '';
             }
+            specSections = {
+              architecture: extractSpecSection('architecture'),
+              dataFlow: extractSpecSection('dataFlow') || extractSpecSection('data_flow'),
+              failureModes: extractSpecSection('failureModes') || extractSpecSection('failure_modes'),
+              qualityRubrics: extractSpecSection('qualityRubrics') || extractSpecSection('quality_rubrics'),
+            };
           }
         }
       } catch { /* ignore */ }
 
-      return await runClaudeSession(
-        `You are in auto mode. Execute the plan at ${relPlan} using /fh:build. ` +
-        `Phase goal: "${phaseGoal}". Build all tasks, run tests, commit changes. Do not ask questions.` +
-        specHint + taskStateHint,
-        { cwd: projectDir, sessionId, stepName: 'build' }
-      );
+      // ── Build plan-level context object ─────────────────────────────────────
+      const planContext = {
+        phaseId: String(phaseId),
+        phaseName: phaseDir ? path.basename(phaseDir).replace(/^\d+-/, '') : '',
+        phaseGoal: phaseGoal,
+        contextDecisions: contextDecisions,
+        projectConstraints: projectConstraints,
+        specSections: specSections,
+        planPath: relPlan,
+      };
+
+      // ── Iterate waves sequentially, dispatch tasks in parallel ───────────────
+      const buildStartTime = new Date();
+      const allTaskResults = [];
+      const pool = new ConcurrencyPool(2);
+
+      for (let waveIdx = 0; waveIdx < parsedPlan.waves.length; waveIdx++) {
+        const wave = parsedPlan.waves[waveIdx];
+        log(`  Wave ${waveIdx + 1}/${parsedPlan.waves.length}: dispatching ${wave.length} task(s)`);
+
+        // Build dispatch promises for this wave (D4: true process isolation)
+        const wavePromises = wave.map(function(taskDef) {
+          const taskSlug = taskDef.name
+            ? taskDef.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 40)
+            : 'task';
+          const taskId = 'task-' + planNum + '-' + taskSlug;
+          const prompt = buildTaskPrompt(taskDef, planContext);
+
+          return pool.run(function() {
+            // Skip if already completed in a previous run (crash resume)
+            if (existingCheckpoints[taskId] && existingCheckpoints[taskId].status === 'completed') {
+              log('  Skipping task "' + taskDef.name + '" — already completed (resume)');
+              return { taskName: taskDef.name, success: true, skipped: true };
+            }
+
+            // Task state machine: initialize as queued
+            let taskState = 'queued';
+            const checkpointPath = path.join(buildDir, taskId + '-checkpoint.json');
+
+            // Write intent checkpoint BEFORE dispatch (crash resilience)
+            // queued → dispatched
+            taskState = transitionTask(taskState, 'dispatched');
+            const checkpoint = {
+              taskId: taskId,
+              phaseId: String(phaseId),
+              planNumber: planNum,
+              taskState: taskState,
+              status: 'dispatched',
+              dispatchedAt: new Date().toISOString(),
+              pid: null,
+            };
+            try { fs.writeFileSync(checkpointPath, JSON.stringify(checkpoint, null, 2)); } catch { /* ignore */ }
+
+            // dispatched → running
+            taskState = transitionTask(taskState, 'running');
+            try {
+              fs.writeFileSync(checkpointPath, JSON.stringify(Object.assign({}, checkpoint, { taskState: taskState, status: 'running', startedAt: new Date().toISOString() }), null, 2));
+            } catch { /* ignore */ }
+
+            log('    Direct dispatch: ' + taskDef.name + ' (' + taskId + ')');
+            return dispatchTask(
+              { prompt: prompt, taskId: taskId, phaseId: String(phaseId), planPath: latestPlan, cwd: projectDir },
+              {
+                onToolCall: function(toolName, ts) {
+                  pushActivityEvent('tool_call', taskId + ' used ' + toolName);
+                },
+              }
+            ).then(function(result) {
+              // running → completed or failed or timed-out
+              const isTimeout = result.error && (result.error.includes('timeout') || result.error.includes('stuck'));
+              if (result.success) {
+                taskState = transitionTask(taskState, 'completed');
+              } else if (isTimeout) {
+                taskState = transitionTask(taskState, 'timed-out');
+              } else {
+                taskState = transitionTask(taskState, 'failed');
+              }
+              // Update checkpoint with final status
+              try {
+                const finalCheckpoint = Object.assign({}, checkpoint, {
+                  taskState: taskState,
+                  status: result.success ? 'completed' : 'failed',
+                  completedAt: new Date().toISOString(),
+                  metrics: result.metrics || {},
+                  error: result.error || null,
+                });
+                fs.writeFileSync(checkpointPath, JSON.stringify(finalCheckpoint, null, 2));
+              } catch { /* ignore */ }
+              return Object.assign({}, result, { taskState: taskState });
+            });
+          });
+        });
+
+        // D6: Promise.allSettled for wave dispatch
+        const waveSettled = await Promise.allSettled(wavePromises);
+
+        // Collect results and write sidecar files; retry failed tasks once
+        for (let ti = 0; ti < wave.length; ti++) {
+          const taskDef = wave[ti];
+          const taskSlug = taskDef.name
+            ? taskDef.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 40)
+            : 'task';
+          const taskId = 'task-' + planNum + '-' + taskSlug;
+          const settled = waveSettled[ti];
+
+          let taskResult;
+          if (settled.status === 'fulfilled') {
+            taskResult = settled.value;
+          } else {
+            // Pool or spawn error — treat as failure
+            taskResult = {
+              success: false,
+              stdout: '',
+              stderr: '',
+              metrics: { tokens_in: 0, tokens_out: 0, elapsed_ms: 0 },
+              error: settled.reason ? String(settled.reason.message || settled.reason) : 'Unknown error',
+            };
+          }
+
+          // Retry once on failure using task state machine (failed/timed-out → queued → dispatched → running)
+          if (!taskResult.success) {
+            const retryTaskState = taskResult.taskState || 'failed';
+            const isTimedOut = retryTaskState === 'timed-out';
+            log('    Retrying ' + (isTimedOut ? 'timed-out' : 'failed') + ' task: ' + taskDef.name);
+            try {
+              // failed/timed-out → queued (retry transition)
+              let retryState = transitionTask(retryTaskState, 'queued');
+              // queued → dispatched → running
+              retryState = transitionTask(retryState, 'dispatched');
+              retryState = transitionTask(retryState, 'running');
+              const retryCheckpointPath = path.join(buildDir, taskId + '-retry-checkpoint.json');
+              try {
+                fs.writeFileSync(retryCheckpointPath, JSON.stringify({
+                  taskId: taskId + '-retry', phaseId: String(phaseId), planNumber: planNum,
+                  taskState: retryState, status: 'running', isTimedOut: isTimedOut,
+                  startedAt: new Date().toISOString(),
+                }, null, 2));
+              } catch { /* ignore */ }
+              const prompt = buildTaskPrompt(taskDef, planContext);
+              // On timed-out retry, extend timeout by 50% (pass hint via taskId suffix)
+              const retryTaskId = isTimedOut ? taskId + '-retry-extended' : taskId + '-retry';
+              taskResult = await dispatchTask(
+                { prompt: prompt, taskId: retryTaskId, phaseId: String(phaseId), planPath: latestPlan, cwd: projectDir },
+                {
+                  onToolCall: function(toolName, ts) {
+                    pushActivityEvent('tool_call', retryTaskId + ' used ' + toolName);
+                  },
+                  timeoutMultiplier: isTimedOut ? 1.5 : 1,
+                }
+              );
+              // Update retry checkpoint with final state
+              const retryFinalState = taskResult.success ? 'completed' : (
+                (taskResult.error && (taskResult.error.includes('timeout') || taskResult.error.includes('stuck'))) ? 'timed-out' : 'failed'
+              );
+              try {
+                fs.writeFileSync(retryCheckpointPath, JSON.stringify({
+                  taskId: taskId + '-retry', phaseId: String(phaseId), planNumber: planNum,
+                  taskState: retryFinalState, status: taskResult.success ? 'completed' : 'failed',
+                  completedAt: new Date().toISOString(), error: taskResult.error || null,
+                }, null, 2));
+              } catch { /* ignore */ }
+            } catch (retryErr) {
+              taskResult = {
+                success: false,
+                stdout: '',
+                stderr: '',
+                metrics: { tokens_in: 0, tokens_out: 0, elapsed_ms: 0 },
+                error: 'Retry failed: ' + String(retryErr.message || retryErr),
+              };
+            }
+          }
+
+          // Write sidecar result file (Task 3)
+          const resultFile = path.join(buildDir, taskId + '-result.json');
+          const sidecarPayload = {
+            taskName: taskDef.name,
+            success: taskResult.success,
+            stdout: (taskResult.stdout || '').slice(0, 500),
+            stderr: (taskResult.stderr || '').slice(0, 200),
+            metrics: taskResult.metrics || {},
+            error: taskResult.error || null,
+          };
+          try {
+            fs.writeFileSync(resultFile, JSON.stringify(sidecarPayload, null, 2), 'utf-8');
+          } catch { /* ignore */ }
+
+          allTaskResults.push({ taskName: taskDef.name, success: taskResult.success, filesModified: [], error: taskResult.error });
+
+          if (taskResult.success) {
+            log('    [PASS] ' + taskDef.name);
+          } else {
+            log('    [FAIL] ' + taskDef.name + (taskResult.error ? ': ' + taskResult.error.slice(0, 120) : ''));
+          }
+        }
+      }
+
+      // ── Run verification from frontmatter ────────────────────────────────────
+      let verificationResult = { passed: true, results: [] };
+      const fm = parsedPlan.frontmatter || {};
+      if (Array.isArray(fm.verify) && fm.verify.length > 0) {
+        log('  Running verification commands...');
+        const verifyCommands = fm.verify.map(function(v) {
+          return typeof v === 'string' ? { command: v, expect: 'exit_0' } : v;
+        });
+        verificationResult = runVerification(verifyCommands, projectDir);
+        log('  Verification: ' + (verificationResult.passed ? 'PASSED' : 'FAILED'));
+      }
+
+      // ── Generate SUMMARY.md ──────────────────────────────────────────────────
+      // Derive commit hash after git commit below; placeholder for now
+      const buildEndTime = new Date();
+
+      // ── Git commit ───────────────────────────────────────────────────────────
+      let commitHash = '';
+      try {
+        const { execFileSync } = require('child_process');
+        execFileSync('git', ['add', '-u'], { cwd: projectDir, stdio: 'pipe' });
+        const commitMsg = `build(phase-${phaseId}): complete plan ${planNum} via direct dispatch`;
+        execFileSync('git', ['commit', '-m', commitMsg], { cwd: projectDir, stdio: 'pipe' });
+        try {
+          commitHash = execFileSync('git', ['rev-parse', '--short', 'HEAD'], {
+            cwd: projectDir, stdio: 'pipe', encoding: 'utf-8',
+          }).trim();
+        } catch { /* ignore */ }
+        log('  Git commit: ' + (commitHash || 'done'));
+      } catch (commitErr) {
+        log('  Git commit skipped: ' + String(commitErr.message || commitErr).slice(0, 120));
+      }
+
+      const summaryContent = generateSummary({
+        phaseId: String(phaseId),
+        planNumber: planNum,
+        planPath: latestPlan,
+        taskResults: allTaskResults,
+        verificationResult: verificationResult,
+        commitHash: commitHash,
+        startTime: buildStartTime,
+        endTime: buildEndTime,
+      });
+
+      // Write SUMMARY.md next to PLAN.md
+      const summaryBase = planBase.replace(/-PLAN\.md$/, '-SUMMARY.md').replace(/^PLAN\.md$/, 'SUMMARY.md');
+      const summaryPath = path.join(path.dirname(latestPlan), summaryBase);
+      try {
+        fs.writeFileSync(summaryPath, summaryContent, 'utf-8');
+        log('  SUMMARY.md written: ' + path.relative(projectDir, summaryPath));
+      } catch (writeErr) {
+        log('  Warning: could not write SUMMARY.md: ' + String(writeErr.message || writeErr).slice(0, 120));
+      }
+
+      const allSucceeded = allTaskResults.every(function(r) { return r.success; });
+      const buildStdout = allTaskResults.map(function(r) {
+        return (r.success ? '[PASS] ' : '[FAIL] ') + r.taskName;
+      }).join('\n');
+
+      return { success: allSucceeded, stdout: buildStdout };
     }
 
     case 'review':
@@ -2342,6 +2729,10 @@ async function main() {
     // ─── SEQUENTIAL FALLBACK (--no-speculative) ───────────────────────────────
     log('Mode: sequential (--no-speculative)');
 
+  // Load or initialize auto-state for phase_states tracking
+  let autoState = loadAutoState(projectDir) || {};
+  if (!autoState.phase_states) autoState.phase_states = {};
+
   for (const phase of phasesToRun) {
     // If resuming, skip phases before the saved phase
     if (resumeState && comparePhaseNum(phase.id, resumeState.phase) < 0) {
@@ -2392,20 +2783,40 @@ async function main() {
     pushActivityEvent('auto', `Phase ${phase.id}: ${phase.name} started`);
     logEvent('phase-start', { phase: phase.id, msg: phase.name });
 
-    // Determine which steps to run for this phase
-    let stepsToRun = [...PHASE_STEPS];
+    // ── State-machine-driven sequential execution ────────────────────────────
+    // Initialize phase state from auto-state or default to 'pending'
+    // Apply resume-state mapping for the first resuming phase
+    let initialPhaseState = 'pending';
     if (resumeState && phase.id === resumeState.phase) {
-      const completedSteps = resumeState.steps_completed || [];
-      stepsToRun = PHASE_STEPS.filter(s => !completedSteps.includes(s));
+      // Map resume step back to a retryable state so state machine can re-run it
+      const stepToState = { 'plan-work': 'pending', 'plan-review': 'planned', 'build': 'reviewed', 'review': 'verifying' };
+      initialPhaseState = stepToState[resumeState.step] || 'pending';
       resumeState = null; // Only apply resume logic to the first matching phase
+    } else if (autoState && autoState.phase_states && autoState.phase_states[phase.id]) {
+      initialPhaseState = migratePhaseState(autoState.phase_states[phase.id]);
     }
 
+    // Skip completed phases
+    if (initialPhaseState === 'complete') {
+      log(`  Phase ${phase.id} already complete — skipping`);
+      _autoStatus.phasesSkipped++;
+      continue;
+    }
+
+    let phaseState = initialPhaseState;
     const completedSteps = [];
     let currentPlanPath = null;
 
-    for (const step of stepsToRun) {
+    // Safety: prevent infinite loops
+    const MAX_PHASE_TRANSITIONS = 12;
+    let transitionCount = 0;
+
+    while (phaseState !== 'complete' && transitionCount < MAX_PHASE_TRANSITIONS) {
+      transitionCount++;
+
       // Budget check (with cost estimate)
       if (opts.budget && totalCostEstimate >= opts.budget) {
+        const step = STATE_TO_STEP[phaseState] || phaseState;
         log(`Budget ceiling reached ($${totalCostEstimate.toFixed(2)} >= $${opts.budget})`);
 
         // Log budget decision
@@ -2420,6 +2831,7 @@ async function main() {
           affects: phasesToRun.filter(p => comparePhaseNum(p.id, phase.id) >= 0).map(p => `Phase ${p.id}`).join(', '),
         });
 
+        updatePhaseState(autoState, phase.id, phaseState);
         writeAutoStatus(projectDir, buildAutoStatus(projectDir, {
           active: false,
           phase: phase.id,
@@ -2435,6 +2847,28 @@ async function main() {
         log('State saved for resume. Exiting.');
         process.exit(0);
       }
+
+      const step = STATE_TO_STEP[phaseState];
+      if (!step) {
+        log(`  Phase ${phase.id} in state "${phaseState}" — no step to execute`);
+        break;
+      }
+
+      // Map step to in-progress state
+      const IN_PROGRESS_MAP = { 'plan-work': 'planning', 'plan-review': 'reviewing', 'build': 'building', 'review': 'verifying' };
+      const inProgressState = IN_PROGRESS_MAP[step];
+      phaseState = transitionPhase(phaseState, inProgressState);
+      updatePhaseState(autoState, phase.id, phaseState);
+      saveAutoState(projectDir, {
+        phase: phase.id,
+        active: true,
+        step,
+        steps_completed: completedSteps,
+        total_cost_estimate: totalCostEstimate,
+        retry_count: retryCount,
+        phase_plan_paths: currentPlanPath ? { [phase.id]: path.relative(projectDir, currentPlanPath) } : {},
+        phase_states: autoState.phase_states,
+      });
 
       // Write enriched status before each step starts
       _autoStatus.stepStartedAt = new Date().toISOString();
@@ -2469,6 +2903,7 @@ async function main() {
           decision: `Saved state for --resume. Re-run after API recovery.`,
           affects: `Phase ${phase.id}, step ${step}`,
         });
+        updatePhaseState(autoState, phase.id, phaseState);
         writeAutoStatus(projectDir, buildAutoStatus(projectDir, {
           active: false,
           phase: phase.id,
@@ -2487,6 +2922,47 @@ async function main() {
 
       let stepSucceeded = !outcome.skipped;
       const sessionCost = outcome.cost || 0;
+
+      // Post-step artifact verification — treat missing artifacts as step failure, not fatal
+      if (step === 'plan-work' && stepSucceeded) {
+        currentPlanPath = findLatestPlan(projectDir, phase.id);
+        if (!currentPlanPath) {
+          log(`  ✗ plan-work succeeded but no PLAN.md found — treating as failure`);
+          stepSucceeded = false;
+          const decId = nextDecisionId(projectDir);
+          appendDecision(projectDir, {
+            id: decId,
+            title: `plan-work produced no PLAN.md for phase ${phase.id}`,
+            status: 'ACTIVE ⚠ NEEDS REVIEW',
+            confidence: 'LOW',
+            context: `plan-work exited 0 but no PLAN.md was created in the phase directory`,
+            decision: `Phase ${phase.id} cannot continue without a plan. Stopping phase.`,
+            affects: `Phase ${phase.id}`,
+          });
+        } else {
+          log(`    Plan created: ${path.relative(projectDir, currentPlanPath)}`);
+        }
+      }
+
+      if (step === 'build' && stepSucceeded) {
+        if (!summaryExists(currentPlanPath)) {
+          log(`  ✗ build succeeded but no SUMMARY.md found — treating as failure`);
+          stepSucceeded = false;
+          const decId = nextDecisionId(projectDir);
+          appendDecision(projectDir, {
+            id: decId,
+            title: `build produced no SUMMARY.md for phase ${phase.id}`,
+            status: 'ACTIVE ⚠ NEEDS REVIEW',
+            confidence: 'LOW',
+            context: `build exited 0 but no SUMMARY.md was created`,
+            decision: `Phase ${phase.id} build incomplete. Stopping phase.`,
+            affects: `Phase ${phase.id}`,
+          });
+        } else {
+          plansExecuted++;
+          log('    SUMMARY.md verified');
+        }
+      }
 
       if (stepSucceeded) {
         completedSteps.push(step);
@@ -2519,6 +2995,17 @@ async function main() {
           metrics,
         });
 
+        // Success: transition to next phase state
+        const SUCCESS_MAP = { planning: 'planned', reviewing: 'reviewed', building: 'verifying', verifying: 'complete' };
+        phaseState = transitionPhase(phaseState, SUCCESS_MAP[phaseState]);
+
+        const stepType = step === 'plan-work' ? 'plan' : step === 'plan-review' ? 'review' : step;
+        const elapsed = _autoStatus.stepStartedAt
+          ? Math.round((Date.now() - new Date(_autoStatus.stepStartedAt).getTime()) / 1000) + 's'
+          : '';
+        pushActivityEvent(stepType, `${step} completed for Phase ${phase.id}${elapsed ? ` (${elapsed})` : ''}`);
+        log(`  ✓ ${step} complete`);
+
         // Write enriched status after step completes
         writeAutoStatus(projectDir, buildAutoStatus(projectDir, {
           phase: phase.id,
@@ -2531,92 +3018,59 @@ async function main() {
           budget: opts.budget || null,
           last_log_line: `${step} complete`,
         }));
-      }
+      } else {
+        // Failure: transition to failed state
+        const FAIL_MAP = { planning: 'plan-failed', reviewing: 'review-failed', building: 'build-failed', verifying: 'verify-failed' };
+        phaseState = transitionPhase(phaseState, FAIL_MAP[phaseState]);
 
-      // Post-step verification — treat missing artifacts as step failure, not fatal
-      if (step === 'plan-work' && stepSucceeded) {
-        currentPlanPath = findLatestPlan(projectDir, phase.id);
-        if (!currentPlanPath) {
-          log(`  ✗ plan-work succeeded but no PLAN.md found — treating as failure`);
-          stepSucceeded = false;
-          completedSteps.pop(); // remove plan-work from completed
-          const decId = nextDecisionId(projectDir);
-          appendDecision(projectDir, {
-            id: decId,
-            title: `plan-work produced no PLAN.md for phase ${phase.id}`,
-            status: 'ACTIVE ⚠ NEEDS REVIEW',
-            confidence: 'LOW',
-            context: `plan-work exited 0 but no PLAN.md was created in the phase directory`,
-            decision: `Phase ${phase.id} cannot continue without a plan. Stopping phase.`,
-            affects: `Phase ${phase.id}`,
-          });
-          break; // exit steps loop — phase is incomplete
+        if (outcome.skipped) {
+          pushActivityEvent('error', `${step} failed for Phase ${phase.id}: ${outcome.reason || 'unknown'}`);
         }
-        log(`    Plan created: ${path.relative(projectDir, currentPlanPath)}`);
-      }
 
-      if (step === 'build' && stepSucceeded) {
-        if (!summaryExists(currentPlanPath)) {
-          log(`  ✗ build succeeded but no SUMMARY.md found — treating as failure`);
-          stepSucceeded = false;
-          completedSteps.pop(); // remove build from completed
-          const decId = nextDecisionId(projectDir);
-          appendDecision(projectDir, {
-            id: decId,
-            title: `build produced no SUMMARY.md for phase ${phase.id}`,
-            status: 'ACTIVE ⚠ NEEDS REVIEW',
-            confidence: 'LOW',
-            context: `build exited 0 but no SUMMARY.md was created`,
-            decision: `Phase ${phase.id} build incomplete. Stopping phase.`,
-            affects: `Phase ${phase.id}`,
-          });
-          break; // exit steps loop — phase is incomplete
+        // Check retry budget
+        const retryKey = `${phase.id}:${step}`;
+        const retries = retryCount[retryKey] || 0;
+        if (retries < 2) {
+          retryCount[retryKey] = retries + 1;
+          log(`  ${step} failed — retrying (attempt ${retries + 2})`);
+          // Transition back to retryable state
+          const retryTarget = PHASE_TRANSITIONS[phaseState][0];
+          phaseState = transitionPhase(phaseState, retryTarget);
+        } else {
+          log(`  ${step} failed after ${retries + 1} attempts — giving up on phase ${phase.id}`);
+          break;
         }
-        plansExecuted++;
-        log('    SUMMARY.md verified');
       }
 
-      if (stepSucceeded) {
-        const stepType = step === 'plan-work' ? 'plan' : step === 'plan-review' ? 'review' : step;
-        const elapsed = _autoStatus.stepStartedAt
-          ? Math.round((Date.now() - new Date(_autoStatus.stepStartedAt).getTime()) / 1000) + 's'
-          : '';
-        pushActivityEvent(stepType, `${step} completed for Phase ${phase.id}${elapsed ? ` (${elapsed})` : ''}`);
-        log(`  ✓ ${step} complete`);
-      } else if (outcome.skipped) {
-        pushActivityEvent('error', `${step} failed for Phase ${phase.id}: ${outcome.reason || 'unknown'}`);
-      }
-    }
-
-    // Only mark phase complete if critical steps succeeded
-    const criticalSteps = ['plan-work', 'plan-review', 'build'];
-    const criticalsMissing = criticalSteps.filter(s => !completedSteps.includes(s));
-    if (criticalsMissing.length > 0) {
-      log(`Phase ${phase.id} INCOMPLETE — missing critical steps: ${criticalsMissing.join(', ')}`);
-      log(`  Saving state for --resume. Run again to retry.`);
-      _autoStatus.phasesFailed++;
-      // Persist for --resume in sequential mode
+      updatePhaseState(autoState, phase.id, phaseState);
       saveAutoState(projectDir, {
         phase: phase.id,
         active: true,
-        step: criticalsMissing[0],
+        step: STATE_TO_STEP[phaseState] || step,
         steps_completed: completedSteps,
         total_cost_estimate: totalCostEstimate,
         retry_count: retryCount,
         phase_plan_paths: currentPlanPath ? { [phase.id]: path.relative(projectDir, currentPlanPath) } : {},
-        step_history: _autoStatus.stepHistory,
+        phase_states: autoState.phase_states,
       });
+    }
+
+    // Only mark phase complete if it reached the 'complete' state
+    if (phaseState !== 'complete') {
+      log(`Phase ${phase.id} INCOMPLETE — state: ${phaseState}`);
+      log(`  Saving state for --resume. Run again to retry.`);
+      _autoStatus.phasesFailed++;
       writeAutoStatus(projectDir, buildAutoStatus(projectDir, {
         active: false,
         phase: phase.id,
         phase_name: phase.name,
-        step: criticalsMissing[0],
-        step_index: PHASE_STEPS.indexOf(criticalsMissing[0]),
+        step: STATE_TO_STEP[phaseState] || phaseState,
+        step_index: PHASE_STEPS.indexOf(STATE_TO_STEP[phaseState] || ''),
         steps_completed: completedSteps,
         current_plan_path: currentPlanPath ? path.relative(projectDir, currentPlanPath) : null,
         total_cost_estimate: totalCostEstimate,
         budget: opts.budget || null,
-        last_log_line: `Phase ${phase.id} INCOMPLETE — missing: ${criticalsMissing.join(', ')}`,
+        last_log_line: `Phase ${phase.id} INCOMPLETE — state: ${phaseState}`,
       }));
       break; // exit phases loop — don't continue to next phase
     }
@@ -2628,6 +3082,7 @@ async function main() {
     });
     updateStateViaGsd(projectDir, phase.id);
     phase_costs[phase.id] = aggregatePhaseMetrics(_autoStatus.stepHistory, phase.id);
+    updatePhaseState(autoState, phase.id, 'complete');
     saveAutoState(projectDir, {
       phase: phase.id,
       active: true,
@@ -2636,6 +3091,7 @@ async function main() {
       retry_count: retryCount,
       phase_plan_paths: currentPlanPath ? { [phase.id]: path.relative(projectDir, currentPlanPath) } : {},
       phase_costs,
+      phase_states: autoState.phase_states,
     });
     _autoStatus.phasesCompleted++;
     writeAutoStatus(projectDir, buildAutoStatus(projectDir, {
@@ -3565,11 +4021,19 @@ function handleShutdown(signal) {
   const stateDir = _autoStatus.projectDir;
   try { process.stderr.write(`\nAuto-orchestrator received ${signal} — shutting down gracefully\n`); } catch { /* */ }
 
-  // Kill active child process
-  if (_activeChild) {
-    try { _activeChild.kill('SIGTERM'); } catch { /* already dead */ }
+  // Kill active child process (process group kill for reliable termination)
+  if (_activeChild && _activeChild.pid) {
+    try { process.kill(-_activeChild.pid, 'SIGTERM'); } catch { /* already dead */ }
     _activeChild = null;
   }
+
+  // Kill all active task children from direct dispatch (D11)
+  try {
+    const { _activeTaskChildren } = require('./lib/index.cjs');
+    for (const pid of _activeTaskChildren) {
+      try { process.kill(-pid, 'SIGTERM'); } catch { /* already dead */ }
+    }
+  } catch { /* ignore if module unavailable */ }
 
   // Write interrupted status to .auto-state.json
   if (stateDir) {

--- a/.claude/skills/auto/lib/context-injection.cjs
+++ b/.claude/skills/auto/lib/context-injection.cjs
@@ -1,0 +1,144 @@
+'use strict';
+
+/**
+ * context-injection.cjs
+ * Builds the prompt string for a single task session.
+ * Decision D3: Orchestrator injects plan-level context.
+ *              Task sessions discover code-level context themselves via smart tools.
+ */
+
+/**
+ * Build a complete prompt for a task session.
+ *
+ * @param {object} taskDef - Parsed task from PLAN.md
+ * @param {string} taskDef.name         - e.g. "Task 1: Create schema"
+ * @param {string[]} taskDef.files      - Files to create/modify
+ * @param {string[]} taskDef.readFirst  - Files to read before acting
+ * @param {string} taskDef.action       - Step-by-step instructions
+ * @param {string} taskDef.verify       - Verification steps
+ * @param {string} taskDef.done         - Acceptance criteria
+ * @param {string} taskDef.type         - "auto" | "tdd" | "checkpoint:human-verify"
+ *
+ * @param {object} planContext - Plan-level context pre-read by the orchestrator
+ * @param {string} planContext.phaseId
+ * @param {string} planContext.phaseName
+ * @param {string} planContext.phaseGoal
+ * @param {string} planContext.contextDecisions  - CONTEXT.md decisions section
+ * @param {string} planContext.projectConstraints - CLAUDE.md Gotchas (first 4000 chars)
+ * @param {object|null} planContext.specSections  - { architecture, dataFlow, failureModes, qualityRubrics }
+ * @param {string} planContext.planPath
+ *
+ * @returns {string} Complete prompt for `claude -p`
+ */
+function buildTaskPrompt(taskDef, planContext) {
+  const task = taskDef || {};
+  const ctx = planContext || {};
+
+  const parts = [];
+
+  // ── 1. Task instructions (FIRST — most important, lost-in-the-middle principle) ──
+  parts.push(`# Task: ${task.name || '(unnamed task)'}`);
+
+  if (task.action) {
+    parts.push(`## Instructions\n\n${task.action}`);
+  }
+
+  const files = Array.isArray(task.files) ? task.files : [];
+  if (files.length > 0) {
+    parts.push(`## Files to Create / Modify\n\n${files.map((f) => `- ${f}`).join('\n')}`);
+  }
+
+  const readFirst = Array.isArray(task.readFirst) ? task.readFirst : [];
+  if (readFirst.length > 0) {
+    parts.push(`## Read First\n\n${readFirst.map((f) => `- ${f}`).join('\n')}`);
+  }
+
+  if (task.verify) {
+    parts.push(`## Verification Steps\n\n${task.verify}`);
+  }
+
+  if (task.done) {
+    parts.push(`## Acceptance Criteria\n\n${task.done}`);
+  }
+
+  // ── 2. Plan-level context (phase goal + CONTEXT.md decisions) ──
+  const hasPhaseInfo = ctx.phaseId || ctx.phaseName || ctx.phaseGoal;
+  if (hasPhaseInfo) {
+    const phaseHeader = [ctx.phaseId, ctx.phaseName].filter(Boolean).join(' — ');
+    const phaseLines = [];
+    if (phaseHeader) phaseLines.push(`**Phase:** ${phaseHeader}`);
+    if (ctx.phaseGoal) phaseLines.push(`**Goal:** ${ctx.phaseGoal}`);
+    if (ctx.planPath) phaseLines.push(`**Plan:** ${ctx.planPath}`);
+    parts.push(`## Plan Context\n\n${phaseLines.join('\n')}`);
+  }
+
+  if (ctx.contextDecisions && ctx.contextDecisions.trim()) {
+    parts.push(`## Decisions (from CONTEXT.md)\n\n${ctx.contextDecisions.trim()}`);
+  }
+
+  // ── 3. SPEC sections if present ──
+  if (ctx.specSections && typeof ctx.specSections === 'object') {
+    const spec = ctx.specSections;
+    const specParts = [];
+
+    if (spec.architecture && spec.architecture.trim()) {
+      specParts.push(`### Architecture\n\n${spec.architecture.trim()}`);
+    }
+    if (spec.dataFlow && spec.dataFlow.trim()) {
+      specParts.push(`### Data Flow\n\n${spec.dataFlow.trim()}`);
+    }
+    if (spec.failureModes && spec.failureModes.trim()) {
+      specParts.push(`### Failure Modes\n\n${spec.failureModes.trim()}`);
+    }
+    if (spec.qualityRubrics && spec.qualityRubrics.trim()) {
+      specParts.push(`### Quality Rubrics\n\n${spec.qualityRubrics.trim()}`);
+    }
+
+    if (specParts.length > 0) {
+      parts.push(`## Spec\n\n${specParts.join('\n\n')}`);
+    }
+  }
+
+  // ── 4. Project constraints from CLAUDE.md — LAST ──
+  if (ctx.projectConstraints && ctx.projectConstraints.trim()) {
+    parts.push(`## Project Constraints\n\n${ctx.projectConstraints.trim()}`);
+  }
+
+  // ── 5. Smart tool instructions ──
+  parts.push(
+    `## Code Discovery\n\n` +
+      `Use smart_outline and smart_unfold for code exploration. ` +
+      `Use smart_search to find patterns across the codebase. ` +
+      `Only Read full files when you need to Edit them.`
+  );
+
+  // ── 6. Deviation rules ──
+  parts.push(
+    `## Deviation Rules\n\n` +
+      `If you encounter a blocking issue, stop immediately and report it. ` +
+      `Do not guess. Do not deviate from the task scope.`
+  );
+
+  // ── 7. Self-check instructions ──
+  parts.push(
+    `## Self-Check\n\n` +
+      `Before reporting completion, verify that every file listed under "Files to Create / Modify" ` +
+      `actually exists on disk. If any file is missing, create it or report it as a deviation.`
+  );
+
+  // ── 8. Report format ──
+  parts.push(
+    `## Report Format\n\n` +
+      `When done, respond with exactly these sections:\n\n` +
+      `**Implemented:** (what was built)\n` +
+      `**Tests:** (tests added or run)\n` +
+      `**Files Changed:** (list of files)\n` +
+      `**Deviations:** (any scope changes or skipped items)\n` +
+      `**Stubs:** (anything left intentionally incomplete)\n` +
+      `**Concerns:** (issues to flag for the orchestrator)`
+  );
+
+  return parts.join('\n\n');
+}
+
+module.exports = { buildTaskPrompt };

--- a/.claude/skills/auto/lib/index.cjs
+++ b/.claude/skills/auto/lib/index.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  ...require('./task-dispatch.cjs'),
+  ...require('./context-injection.cjs'),
+  ...require('./wave-analysis.cjs'),
+  ...require('./verification.cjs'),
+  ...require('./summary-generation.cjs'),
+};

--- a/.claude/skills/auto/lib/summary-generation.cjs
+++ b/.claude/skills/auto/lib/summary-generation.cjs
@@ -1,0 +1,153 @@
+'use strict';
+
+const fs = require('fs');
+
+/**
+ * Extract the text content of an XML element from a string.
+ */
+function extractXmlElement(tag, text) {
+  const re = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, 's');
+  const m = text.match(re);
+  if (!m) return '';
+  return m[1].trim();
+}
+
+/**
+ * Format a Date or ISO string as YYYY-MM-DDTHH:MM:SSZ.
+ */
+function formatDate(dateInput) {
+  if (!dateInput) return '';
+  const d = dateInput instanceof Date ? dateInput : new Date(dateInput);
+  return d.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+/**
+ * Generate SUMMARY.md content for a completed plan execution.
+ *
+ * @param {object} config
+ * @param {string} config.phaseId
+ * @param {string|number} config.planNumber
+ * @param {string} config.planPath
+ * @param {Array<{taskName: string, success: boolean, filesModified: string[], error?: string}>} config.taskResults
+ * @param {{passed: boolean, results: Array<{command, passed, output?, error?}>}} config.verificationResult
+ * @param {string} config.commitHash
+ * @param {Date|string} config.startTime
+ * @param {Date|string} config.endTime
+ * @returns {string} Full SUMMARY.md content
+ */
+function generateSummary(config) {
+  const {
+    phaseId = '',
+    planNumber = '',
+    planPath = '',
+    taskResults = [],
+    verificationResult = { passed: true, results: [] },
+    commitHash = '',
+    startTime,
+    endTime,
+  } = config;
+
+  // Determine overall status
+  const allTasksSucceeded = taskResults.every((t) => t.success);
+  const verificationPassed = verificationResult && verificationResult.passed;
+  const status = allTasksSucceeded && verificationPassed ? 'success' : 'partial';
+
+  // Read plan file to extract objective
+  let objective = '';
+  if (planPath) {
+    try {
+      const planContent = fs.readFileSync(planPath, 'utf8');
+      objective = extractXmlElement('objective', planContent);
+    } catch (_) {
+      // If plan file unreadable, leave objective blank
+    }
+  }
+
+  // Collect all files modified
+  const allFilesSet = new Set();
+  for (const t of taskResults) {
+    if (Array.isArray(t.filesModified)) {
+      for (const f of t.filesModified) {
+        allFilesSet.add(f);
+      }
+    }
+  }
+  const allFiles = [...allFilesSet];
+
+  // --- Build YAML frontmatter ---
+  const frontmatterLines = [
+    '---',
+    `phase: ${phaseId}`,
+    `plan: ${planNumber}`,
+    `status: ${status}`,
+    `commit: ${commitHash}`,
+    `started: ${formatDate(startTime)}`,
+    `completed: ${formatDate(endTime)}`,
+    '---',
+  ];
+
+  // --- Build body sections ---
+  const bodyLines = [];
+
+  // Objective section
+  bodyLines.push('## Objective');
+  bodyLines.push('');
+  if (objective) {
+    bodyLines.push(objective);
+  } else {
+    bodyLines.push('_(objective not found in plan)_');
+  }
+  bodyLines.push('');
+
+  // Task outcomes section
+  bodyLines.push('## Task Outcomes');
+  bodyLines.push('');
+  if (taskResults.length === 0) {
+    bodyLines.push('No tasks executed.');
+  } else {
+    for (const t of taskResults) {
+      const icon = t.success ? 'PASS' : 'FAIL';
+      bodyLines.push(`- [${icon}] ${t.taskName}`);
+      if (!t.success && t.error) {
+        bodyLines.push(`  - Error: ${t.error}`);
+      }
+    }
+  }
+  bodyLines.push('');
+
+  // Files modified section
+  bodyLines.push('## Files Modified');
+  bodyLines.push('');
+  if (allFiles.length === 0) {
+    bodyLines.push('No files recorded.');
+  } else {
+    for (const f of allFiles) {
+      bodyLines.push(`- ${f}`);
+    }
+  }
+  bodyLines.push('');
+
+  // Verification results section
+  bodyLines.push('## Verification Results');
+  bodyLines.push('');
+  const vrPassed = verificationResult && verificationResult.passed;
+  bodyLines.push(`Overall: ${vrPassed ? 'PASSED' : 'FAILED'}`);
+  bodyLines.push('');
+  const vrResults = (verificationResult && verificationResult.results) || [];
+  if (vrResults.length === 0) {
+    bodyLines.push('No verification commands run.');
+  } else {
+    for (const r of vrResults) {
+      const icon = r.passed ? 'PASS' : 'FAIL';
+      bodyLines.push(`- [${icon}] \`${r.command}\``);
+      if (!r.passed && r.error) {
+        bodyLines.push(`  - Error: ${r.error.trim()}`);
+      }
+    }
+  }
+  bodyLines.push('');
+
+  return [...frontmatterLines, '', ...bodyLines].join('\n');
+}
+
+module.exports = { generateSummary };

--- a/.claude/skills/auto/lib/task-dispatch.cjs
+++ b/.claude/skills/auto/lib/task-dispatch.cjs
@@ -166,7 +166,7 @@ function dispatchTask(taskConfig, opts) {
     const child = spawn('claude', args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       cwd: cwd,
-      detached: false,
+      detached: true,
       env: Object.assign({}, process.env, {
         CLAUDE_SESSION_ID: taskId,
         CLAUDE_MEM_PROJECT: projectName,
@@ -246,9 +246,9 @@ function dispatchTask(taskConfig, opts) {
             Math.round(silenceElapsed / 1000) + 's — sending SIGTERM\n'
           );
         }
-        child.kill('SIGTERM');
+        try { process.kill(-child.pid, 'SIGTERM'); } catch { /* already dead */ }
         setTimeout(function() {
-          try { child.kill('SIGKILL'); } catch { /* already dead */ }
+          try { process.kill(-child.pid, 'SIGKILL'); } catch { /* already dead */ }
         }, SIGKILL_GRACE_MS);
       }
     }, 30000); // check every 30s
@@ -259,9 +259,9 @@ function dispatchTask(taskConfig, opts) {
       process.stderr.write(
         '[task-dispatch] HARD TIMEOUT: task ' + taskId + ' killed after ' + elapsedMin + 'min\n'
       );
-      child.kill('SIGTERM');
+      try { process.kill(-child.pid, 'SIGTERM'); } catch { /* already dead */ }
       setTimeout(function() {
-        try { child.kill('SIGKILL'); } catch { /* already dead */ }
+        try { process.kill(-child.pid, 'SIGKILL'); } catch { /* already dead */ }
       }, SIGKILL_GRACE_MS);
     }, timeoutMs);
 
@@ -331,7 +331,7 @@ function dispatchTask(taskConfig, opts) {
 function handleShutdown() {
   for (const pid of _activeTaskChildren) {
     try {
-      process.kill(pid, 'SIGTERM');
+      process.kill(-pid, 'SIGTERM');
     } catch { /* already dead */ }
   }
   _activeTaskChildren.clear();

--- a/.claude/skills/auto/lib/task-dispatch.cjs
+++ b/.claude/skills/auto/lib/task-dispatch.cjs
@@ -33,7 +33,7 @@ const _activeTaskChildren = new Set();
 // ─── Tool Readiness Hint ──────────────────────────────────────────────────────
 
 // ToolSearch preamble for downstream skills (D-265)
-const TOOL_READINESS_HINT = `\n## Tool Readiness (auto-injected)\n\nclaude-mem MCP tools are deferred. At session start, fetch them:\nToolSearch("select:mcp__plugin_claude-mem_mcp-search__smart_search,mcp__plugin_claude-mem_mcp-search__smart_outline,mcp__plugin_claude-mem_mcp-search__smart_unfold,mcp__plugin_claude-mem_mcp-search__search,mcp__plugin_claude-mem_mcp-search__get_observations")\n\nIf ToolSearch returns empty, fall back to Read-based approach.\n`;
+const TOOL_READINESS_HINT = `\n## Tool Readiness (auto-injected)\n\nclaude-mem MCP tools are deferred. At session start, fetch them:\nToolSearch("+mcp-search", max_results: 10)\n\nIf ToolSearch returns empty, fall back to Read-based approach.\n`;
 
 // ─── Project Name Resolution ──────────────────────────────────────────────────
 

--- a/.claude/skills/auto/lib/task-dispatch.cjs
+++ b/.claude/skills/auto/lib/task-dispatch.cjs
@@ -1,0 +1,348 @@
+'use strict';
+
+/**
+ * task-dispatch.cjs — Per-task claude -p spawning
+ *
+ * Provides dispatchTask(taskConfig, opts) for spawning isolated claude -p
+ * sessions per task. Extracted from auto-orchestrator.cjs (D2).
+ *
+ * taskConfig: { prompt, taskId, phaseId, planPath, cwd }
+ * opts: { timeout, silenceTimeout, onToolCall, onOutput }
+ *
+ * Returns: { success, stdout, stderr, metrics: { tokens_in, tokens_out, elapsed_ms }, error? }
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawn } = require('child_process');
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const DEFAULT_TIMEOUT_MS = 15 * 60 * 1000;       // 15 minutes wall-clock
+const DEFAULT_SILENCE_MS = 5 * 60 * 1000;         // 5 minutes silence
+const SIGKILL_GRACE_MS = 5000;                     // time between SIGTERM and SIGKILL
+
+const CLAUDE_MEM_SKIP_TOOLS = 'ListMcpResourcesTool,ReadMcpResourceTool,SlashCommand,Skill,TodoWrite,AskUserQuestion,ToolSearch,TaskCreate,TaskUpdate,TaskGet,TaskList,TaskOutput,TaskStop,SendMessage,EnterPlanMode,ExitPlanMode,EnterWorktree,ExitWorktree,LSP,CronCreate,CronDelete,CronList,TeamCreate,TeamDelete,NotebookEdit';
+
+// ─── Orphan Process Registry (D11) ────────────────────────────────────────────
+
+// Set of active child PIDs — iterated by handleShutdown to kill orphans on exit
+const _activeTaskChildren = new Set();
+
+// ─── Tool Readiness Hint ──────────────────────────────────────────────────────
+
+// ToolSearch preamble for downstream skills (D-265)
+const TOOL_READINESS_HINT = `\n## Tool Readiness (auto-injected)\n\nclaude-mem MCP tools are deferred. At session start, fetch them:\nToolSearch("select:mcp__plugin_claude-mem_mcp-search__smart_search,mcp__plugin_claude-mem_mcp-search__smart_outline,mcp__plugin_claude-mem_mcp-search__smart_unfold,mcp__plugin_claude-mem_mcp-search__search,mcp__plugin_claude-mem_mcp-search__get_observations")\n\nIf ToolSearch returns empty, fall back to Read-based approach.\n`;
+
+// ─── Project Name Resolution ──────────────────────────────────────────────────
+
+function resolveProjectName(cwd) {
+  // Project name: git-based resolution (aligned with SKILL.md — D-261)
+  try {
+    const { execFileSync } = require('child_process');
+
+    // Tier 1: Check for CLAUDE_MEM_PROJECT already set (e.g., via .claude/settings.json)
+    if (process.env.CLAUDE_MEM_PROJECT && process.env.CLAUDE_MEM_PROJECT.trim()) {
+      return process.env.CLAUDE_MEM_PROJECT.trim();
+    }
+
+    // Tier 2: GitHub remote nameWithOwner (e.g., "cinjoff/fhhs-skills")
+    try {
+      const nameWithOwner = execFileSync('gh', ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'], {
+        cwd,
+        timeout: 5000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).toString().trim();
+      if (nameWithOwner && nameWithOwner.includes('/')) {
+        return nameWithOwner;
+      }
+    } catch {
+      // gh not installed or not in a GitHub repo — fall through
+    }
+
+    // Tier 3: Git toplevel basename (last resort)
+    const toplevel = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd,
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).toString().trim();
+    return path.basename(toplevel);
+  } catch {
+    return path.basename(cwd);
+  }
+}
+
+// ─── Real-time JSON Line Parser ───────────────────────────────────────────────
+
+function createJsonLineParser(onLine) {
+  let buffer = '';
+  return function feed(chunk) {
+    buffer += chunk;
+    // Buffer cap at 1MB to prevent OOM on non-newline output
+    if (buffer.length > 1024 * 1024) {
+      buffer = '';
+      return;
+    }
+    let nlIdx;
+    while ((nlIdx = buffer.indexOf('\n')) !== -1) {
+      const line = buffer.slice(0, nlIdx).trim();
+      buffer = buffer.slice(nlIdx + 1);
+      if (!line) continue;
+      try {
+        const obj = JSON.parse(line);
+        onLine(obj);
+      } catch { /* non-JSON line — ignore */ }
+    }
+  };
+}
+
+// ─── Task Dispatch ────────────────────────────────────────────────────────────
+
+/**
+ * Spawn an isolated claude -p session for a single task.
+ *
+ * @param {object} taskConfig
+ * @param {string} taskConfig.prompt      Full task prompt (built by context-injection.cjs)
+ * @param {string} taskConfig.taskId      e.g. "task-01-02" (plan-task)
+ * @param {string} taskConfig.phaseId     e.g. "23"
+ * @param {string} taskConfig.planPath    Path to PLAN.md
+ * @param {string} taskConfig.cwd         Project directory
+ *
+ * @param {object} [opts]
+ * @param {number}   [opts.timeout]          Wall-clock timeout in ms (default: 15min)
+ * @param {number}   [opts.silenceTimeout]   Stdout silence timeout in ms (default: 5min)
+ * @param {function} [opts.onToolCall]       Optional callback for tool activity: (toolName, ts) => void
+ * @param {function} [opts.onOutput]         Optional callback for stdout chunks: (chunk) => void
+ *
+ * @returns {Promise<{success: boolean, stdout: string, stderr: string, metrics: {tokens_in: number, tokens_out: number, elapsed_ms: number}, error?: string}>}
+ */
+function dispatchTask(taskConfig, opts) {
+  const { prompt, taskId, cwd } = taskConfig;
+  const timeoutMs = (opts && opts.timeout != null) ? opts.timeout : DEFAULT_TIMEOUT_MS;
+  const silenceMs = (opts && opts.silenceTimeout != null) ? opts.silenceTimeout : DEFAULT_SILENCE_MS;
+  const userOnToolCall = opts && opts.onToolCall;
+  const userOnOutput = opts && opts.onOutput;
+
+  return new Promise((resolve) => {
+    // Resolve plugin dir: this file lives at <plugin-root>/.claude/skills/auto/lib/
+    // so ../../../../ = plugin root where skills/SKILL.md etc. live
+    const pluginDir = path.resolve(__dirname, '..', '..', '..', '..');
+
+    const args = [
+      '-p', prompt,
+      '--permission-mode', 'bypassPermissions',
+      '--output-format', 'stream-json',
+      '--verbose',
+      '--plugin-dir', pluginDir,
+    ];
+
+    // Resolve MCP plugin directories for claude-mem
+    const homeDir = os.homedir();
+    const pluginCacheDir = path.join(homeDir, '.claude', 'plugins', 'cache');
+
+    // Find claude-mem
+    const claudeMemDirs = [
+      path.join(pluginCacheDir, 'thedotmack', 'claude-mem'),
+      path.join(pluginCacheDir, 'thedotmack'),
+    ];
+    const claudeMemDir = claudeMemDirs.find(function(d) { return fs.existsSync(d); });
+
+    if (claudeMemDir) {
+      args.push('--plugin-dir', claudeMemDir);
+    }
+
+    // Inject project conventions so the session has full context
+    const claudeMdPath = path.join(cwd, 'CLAUDE.md');
+    if (fs.existsSync(claudeMdPath)) {
+      const claudeMd = fs.readFileSync(claudeMdPath, 'utf-8').slice(0, 4000);
+      args.push('--append-system-prompt', 'Project conventions:\n' + claudeMd + TOOL_READINESS_HINT);
+    } else {
+      args.push('--append-system-prompt', TOOL_READINESS_HINT);
+    }
+
+    const projectName = resolveProjectName(cwd);
+
+    const child = spawn('claude', args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      cwd: cwd,
+      detached: false,
+      env: Object.assign({}, process.env, {
+        CLAUDE_SESSION_ID: taskId,
+        CLAUDE_MEM_PROJECT: projectName,
+        CLAUDE_MEM_CONTEXT_OBSERVATIONS: '0',
+        CLAUDE_MEM_SKIP_TOOLS: CLAUDE_MEM_SKIP_TOOLS,
+      }),
+    });
+
+    // Register in orphan process registry (D11)
+    if (child.pid != null) {
+      _activeTaskChildren.add(child.pid);
+    }
+
+    let stdout = '';
+    let stderr = '';
+    const sessionStart = Date.now();
+    let lastActivityAt = Date.now();
+    let stuckWarned = false;
+
+    // Token usage tracking
+    let tokensIn = 0;
+    let tokensOut = 0;
+
+    // Real-time JSON line parser — feeds parsed objects to onToolCall and usage tracking
+    const feedJsonLine = createJsonLineParser(function(obj) {
+      // stream-json format: tool calls are nested in assistant messages
+      // as content items with type "tool_use" and a "name" field
+      if (obj.type === 'assistant' && obj.message && Array.isArray(obj.message.content)) {
+        for (const item of obj.message.content) {
+          if (item.type === 'tool_use' && item.name) {
+            const ts = Date.now();
+            lastActivityAt = ts; // reset silence timer on tool call
+            if (userOnToolCall) {
+              userOnToolCall(item.name, ts);
+            }
+          }
+        }
+        // Usage nested in the message object
+        if (obj.message.usage) {
+          tokensIn += (obj.message.usage.input_tokens || 0);
+          tokensOut += (obj.message.usage.output_tokens || 0);
+        }
+      }
+      // Top-level usage (some events emit it at root)
+      if (obj.usage) {
+        tokensIn += (obj.usage.input_tokens || 0);
+        tokensOut += (obj.usage.output_tokens || 0);
+      }
+    });
+
+    child.stdout.on('data', function(data) {
+      const chunk = data.toString();
+      stdout += chunk;
+      lastActivityAt = Date.now();
+      stuckWarned = false; // reset warning on new output
+      feedJsonLine(chunk);
+      if (userOnOutput) {
+        userOnOutput(chunk);
+      }
+    });
+
+    child.stderr.on('data', function(data) {
+      stderr += data.toString();
+      lastActivityAt = Date.now();
+    });
+
+    // Stuck detection: silence timeout with SIGTERM escalation
+    const activityCheck = setInterval(function() {
+      const silenceElapsed = Date.now() - lastActivityAt;
+
+      if (silenceElapsed >= silenceMs) {
+        if (!stuckWarned) {
+          stuckWarned = true;
+          // Will be killed on next interval if still silent — log once
+          process.stderr.write(
+            '[task-dispatch] SILENT: task ' + taskId + ' no output for ' +
+            Math.round(silenceElapsed / 1000) + 's — sending SIGTERM\n'
+          );
+        }
+        child.kill('SIGTERM');
+        setTimeout(function() {
+          try { child.kill('SIGKILL'); } catch { /* already dead */ }
+        }, SIGKILL_GRACE_MS);
+      }
+    }, 30000); // check every 30s
+
+    // Wall-clock hard timeout
+    const hardTimer = setTimeout(function() {
+      const elapsedMin = Math.round((Date.now() - sessionStart) / 60000);
+      process.stderr.write(
+        '[task-dispatch] HARD TIMEOUT: task ' + taskId + ' killed after ' + elapsedMin + 'min\n'
+      );
+      child.kill('SIGTERM');
+      setTimeout(function() {
+        try { child.kill('SIGKILL'); } catch { /* already dead */ }
+      }, SIGKILL_GRACE_MS);
+    }, timeoutMs);
+
+    function cleanup() {
+      clearInterval(activityCheck);
+      clearTimeout(hardTimer);
+    }
+
+    child.on('error', function(err) {
+      cleanup();
+      if (child.pid != null) _activeTaskChildren.delete(child.pid);
+      resolve({
+        success: false,
+        stdout: stdout,
+        stderr: stderr,
+        metrics: {
+          tokens_in: tokensIn,
+          tokens_out: tokensOut,
+          elapsed_ms: Date.now() - sessionStart,
+        },
+        error: 'Failed to spawn claude: ' + err.message,
+      });
+    });
+
+    child.on('close', function(code, signal) {
+      cleanup();
+      if (child.pid != null) _activeTaskChildren.delete(child.pid);
+      const elapsedMs = Date.now() - sessionStart;
+
+      if (signal === 'SIGTERM' || signal === 'SIGKILL') {
+        const silenceElapsed = Date.now() - lastActivityAt;
+        const reason = silenceElapsed >= silenceMs
+          ? 'stuck (no output for ' + Math.round(silenceElapsed / 60000) + 'min)'
+          : 'hard timeout (' + Math.round(elapsedMs / 60000) + 'min)';
+        resolve({
+          success: false,
+          stdout: stdout,
+          stderr: stderr,
+          metrics: { tokens_in: tokensIn, tokens_out: tokensOut, elapsed_ms: elapsedMs },
+          error: 'Session killed: ' + reason,
+        });
+      } else if (code !== 0) {
+        resolve({
+          success: false,
+          stdout: stdout,
+          stderr: stderr,
+          metrics: { tokens_in: tokensIn, tokens_out: tokensOut, elapsed_ms: elapsedMs },
+          error: 'claude -p exited with code ' + code + '\nstderr: ' + stderr.slice(0, 500),
+        });
+      } else {
+        resolve({
+          success: true,
+          stdout: stdout,
+          stderr: stderr,
+          metrics: { tokens_in: tokensIn, tokens_out: tokensOut, elapsed_ms: elapsedMs },
+        });
+      }
+    });
+  });
+}
+
+// ─── Shutdown Handler ─────────────────────────────────────────────────────────
+
+/**
+ * Kill all active task children. Call this from the orchestrator's SIGTERM/SIGINT handler.
+ */
+function handleShutdown() {
+  for (const pid of _activeTaskChildren) {
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch { /* already dead */ }
+  }
+  _activeTaskChildren.clear();
+}
+
+// ─── Exports ──────────────────────────────────────────────────────────────────
+
+module.exports = {
+  dispatchTask,
+  createJsonLineParser,
+  TOOL_READINESS_HINT,
+  _activeTaskChildren,
+  handleShutdown,
+};

--- a/.claude/skills/auto/lib/verification.cjs
+++ b/.claude/skills/auto/lib/verification.cjs
@@ -1,0 +1,55 @@
+'use strict';
+
+const { execSync } = require('child_process');
+
+/**
+ * Run verification commands.
+ *
+ * @param {Array<{command: string, expect: string}>} commands
+ * @param {string} cwd
+ * @returns {{ passed: boolean, results: Array<{command, passed, output?, error?}> }}
+ */
+function runVerification(commands, cwd) {
+  if (!commands || commands.length === 0) {
+    return { passed: true, results: [] };
+  }
+
+  const results = [];
+
+  for (const { command, expect } of commands) {
+    let output = '';
+    let error = '';
+    let exitCode = 0;
+
+    try {
+      const buf = execSync(command, { cwd, timeout: 60000, stdio: 'pipe' });
+      output = buf ? buf.toString() : '';
+    } catch (err) {
+      exitCode = err.status !== undefined ? err.status : 1;
+      output = err.stdout ? err.stdout.toString() : '';
+      error = err.stderr ? err.stderr.toString() : (err.message || '');
+    }
+
+    let passed = false;
+
+    if (!expect || expect === 'exit_0') {
+      passed = exitCode === 0;
+    } else if (expect.startsWith('contains:')) {
+      const needle = expect.slice('contains:'.length);
+      passed = output.includes(needle);
+    } else {
+      // Unknown expect type — treat as exit_0
+      passed = exitCode === 0;
+    }
+
+    const result = { command, passed };
+    if (output) result.output = output;
+    if (error) result.error = error;
+    results.push(result);
+  }
+
+  const passed = results.every((r) => r.passed);
+  return { passed, results };
+}
+
+module.exports = { runVerification };

--- a/.claude/skills/auto/lib/wave-analysis.cjs
+++ b/.claude/skills/auto/lib/wave-analysis.cjs
@@ -1,0 +1,252 @@
+'use strict';
+
+/**
+ * Parse YAML frontmatter between --- markers.
+ * Returns a plain object with key-value pairs.
+ */
+function parseFrontmatter(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  const yaml = match[1];
+  const result = {};
+  const lines = yaml.split(/\r?\n/);
+  let currentKey = null;
+  let currentList = null;
+
+  for (const line of lines) {
+    // List item
+    const listMatch = line.match(/^(\s+)-\s+(.*)$/);
+    if (listMatch && currentList !== null) {
+      currentList.push(listMatch[2].trim());
+      continue;
+    }
+
+    // Key: value
+    const kvMatch = line.match(/^(\w[\w_-]*):\s*(.*)$/);
+    if (kvMatch) {
+      if (currentKey && currentList !== null) {
+        result[currentKey] = currentList;
+      }
+      currentKey = kvMatch[1];
+      const val = kvMatch[2].trim();
+      if (val === '' || val === '[]') {
+        if (val === '[]') {
+          result[currentKey] = [];
+          currentList = null;
+          currentKey = null;
+        } else {
+          currentList = [];
+        }
+      } else if (val === 'true') {
+        result[currentKey] = true;
+        currentList = null;
+        currentKey = null;
+      } else if (val === 'false') {
+        result[currentKey] = false;
+        currentList = null;
+        currentKey = null;
+      } else if (/^\d+$/.test(val)) {
+        result[currentKey] = parseInt(val, 10);
+        currentList = null;
+        currentKey = null;
+      } else {
+        result[currentKey] = val;
+        currentList = null;
+        currentKey = null;
+      }
+      continue;
+    }
+
+    // Continuation of a list started with no items yet
+    if (currentKey && currentList !== null) {
+      // blank line or something else — close the list
+      result[currentKey] = currentList;
+      currentList = null;
+      currentKey = null;
+    }
+  }
+
+  // Flush trailing list
+  if (currentKey && currentList !== null) {
+    result[currentKey] = currentList;
+  }
+
+  return result;
+}
+
+/**
+ * Extract trimmed text content from a simple XML element.
+ * Uses dotAll matching so content can span multiple lines.
+ */
+function extractElement(tag, xml) {
+  const re = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, 's');
+  const m = xml.match(re);
+  if (!m) return '';
+  return m[1].trim();
+}
+
+
+
+/**
+ * Parse a single <task ...>...</task> block into a TaskDef.
+ */
+function parseTask(taskBlock) {
+  // Extract wave and type from opening tag attributes
+  const openTagMatch = taskBlock.match(/^<task([^>]*)>/s);
+  const attrs = openTagMatch ? openTagMatch[1] : '';
+
+  const waveAttrMatch = attrs.match(/wave=["']?(\d+)["']?/);
+  const wave = waveAttrMatch ? parseInt(waveAttrMatch[1], 10) : 1;
+
+  const typeAttrMatch = attrs.match(/type=["']?([^"'\s>]+)["']?/);
+  const type = typeAttrMatch ? typeAttrMatch[1] : '';
+
+  const dependsOnAttrMatch = attrs.match(/depends_on=["']?([^"'>]*)["']?/);
+  const dependsOnAttr = dependsOnAttrMatch ? dependsOnAttrMatch[1].trim() : '';
+
+  const name = extractElement('name', taskBlock);
+
+  // files and read_first can appear multiple times; collect all
+  const filesMatches = [...taskBlock.matchAll(/<files[^>]*>([\s\S]*?)<\/files>/gs)];
+  const files = filesMatches
+    .flatMap((m) =>
+      m[1]
+        .split(/\r?\n/)
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0)
+    );
+
+  const readFirstMatches = [...taskBlock.matchAll(/<read_first[^>]*>([\s\S]*?)<\/read_first>/gs)];
+  const readFirst = readFirstMatches
+    .flatMap((m) =>
+      m[1]
+        .split(/\r?\n/)
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0)
+    );
+
+  const action = extractElement('action', taskBlock);
+  const verify = extractElement('verify', taskBlock);
+  const done = extractElement('done', taskBlock);
+
+  // depends_on can also be a child element
+  let dependsOn = [];
+  const dependsOnElem = extractElement('depends_on', taskBlock);
+  if (dependsOnElem) {
+    dependsOn = dependsOnElem
+      .split(/[\n,]+/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+  } else if (dependsOnAttr) {
+    dependsOn = dependsOnAttr
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+  }
+
+  return { name, files, readFirst, action, verify, done, type, wave, dependsOn };
+}
+
+/**
+ * Topological sort of tasks within a wave based on depends_on.
+ * Tasks not referenced in depends_on come first; dependent tasks follow.
+ * Falls back to original order if cycle detected.
+ */
+function topoSort(tasks) {
+  const nameSet = new Set(tasks.map((t) => t.name));
+  const inDegree = new Map();
+  const adj = new Map(); // name -> list of names that depend on it
+
+  for (const t of tasks) {
+    inDegree.set(t.name, 0);
+    adj.set(t.name, []);
+  }
+
+  for (const t of tasks) {
+    for (const dep of (t.dependsOn || [])) {
+      if (nameSet.has(dep)) {
+        inDegree.set(t.name, (inDegree.get(t.name) || 0) + 1);
+        adj.get(dep).push(t.name);
+      }
+    }
+  }
+
+  const queue = tasks.filter((t) => inDegree.get(t.name) === 0).map((t) => t.name);
+  const sorted = [];
+  const taskByName = new Map(tasks.map((t) => [t.name, t]));
+
+  while (queue.length > 0) {
+    const name = queue.shift();
+    sorted.push(taskByName.get(name));
+    for (const dep of (adj.get(name) || [])) {
+      const newDeg = inDegree.get(dep) - 1;
+      inDegree.set(dep, newDeg);
+      if (newDeg === 0) queue.push(dep);
+    }
+  }
+
+  // If cycle detected, return original order
+  if (sorted.length !== tasks.length) return tasks;
+  return sorted;
+}
+
+/**
+ * Parse PLAN.md at planPath.
+ * Returns { waves: Array<Array<TaskDef>>, frontmatter: object }
+ */
+function parseWaves(planPath) {
+  const fs = require('fs');
+  const content = fs.readFileSync(planPath, 'utf8');
+
+  const frontmatter = parseFrontmatter(content);
+
+  // Extract <tasks>...</tasks> outer block
+  const tasksBlockMatch = content.match(/<tasks[\s\S]*?>([\s\S]*?)<\/tasks>/s);
+  if (!tasksBlockMatch) {
+    return { waves: [], frontmatter };
+  }
+  const tasksBody = tasksBlockMatch[1];
+
+  // Split on <task boundaries — each segment starts with <task
+  const taskSegments = tasksBody.split(/(?=<task[\s>])/);
+
+  const allTasks = [];
+  for (const seg of taskSegments) {
+    const trimmed = seg.trim();
+    if (!trimmed.startsWith('<task')) continue;
+    // Find the closing </task> and include it
+    const closeIdx = trimmed.indexOf('</task>');
+    if (closeIdx === -1) continue;
+    const taskBlock = trimmed.slice(0, closeIdx + '</task>'.length);
+    allTasks.push(parseTask(taskBlock));
+  }
+
+  // Group by wave
+  const waveMap = new Map();
+  for (const task of allTasks) {
+    const w = task.wave;
+    if (!waveMap.has(w)) waveMap.set(w, []);
+    waveMap.get(w).push(task);
+  }
+
+  // Sort wave numbers, apply topo sort within each wave
+  const sortedWaveNumbers = [...waveMap.keys()].sort((a, b) => a - b);
+  const waves = sortedWaveNumbers.map((w) => topoSort(waveMap.get(w)));
+
+  // Strip internal wave/dependsOn from TaskDef (keep only public shape)
+  const cleanWaves = waves.map((waveTasks) =>
+    waveTasks.map(({ name, files, readFirst, action, verify, done, type }) => ({
+      name,
+      files,
+      readFirst,
+      action,
+      verify,
+      done,
+      type,
+    }))
+  );
+
+  return { waves: cleanWaves, frontmatter };
+}
+
+module.exports = { parseWaves };

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -33,7 +33,7 @@ You are the **build orchestrator**. Follow every step below — each one exists 
 claude-mem and ast-grep are manifest-required tools that power this entire skill. claude-mem tools are **deferred** — they must be fetched before they can be called. Do this first, before any other work.
 
 ```
-ToolSearch("select:mcp__plugin_claude-mem_mcp-search__smart_search,mcp__plugin_claude-mem_mcp-search__smart_outline,mcp__plugin_claude-mem_mcp-search__smart_unfold,mcp__plugin_claude-mem_mcp-search__search,mcp__plugin_claude-mem_mcp-search__get_observations")
+ToolSearch("+mcp-search", max_results: 10)
 ```
 
 Also verify ast-grep CLI is available:

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -8,23 +8,47 @@ Execute an existing plan. Delegates task execution to subagents for optimal cont
 
 What to build or which plan to execute: $ARGUMENTS
 
-You are a **lean orchestrator**. Stay under 15% context usage. Delegate all heavy work to subagents.
+You are the **build orchestrator**. Follow every step below — each one exists because skipping it caused real failures in past sessions. Delegate implementation work to subagents, but own the orchestration fully.
+
+> This skill handles interactive builds. For autonomous execution, `/fh:auto` dispatches tasks directly — see `auto-orchestrator.cjs`.
 
 > **Dependency check:** Verify `.planning/PROJECT.md` exists (required — if missing, tell user: "No project found.
-
 → Run /fh:new-project — set up project tracking before building").
 > If no unexecuted plan exists in the current phase, tell user: "No plan to execute.
-
 → Run /fh:plan-work — create a plan first".
 
 > **Execution pipeline:**
-> Task execution: **`general-purpose`** subagents using `references/implementer-prompt.md`. Model is resolved from config via `gsd-tools resolve-model gsd-executor --raw`. Fresh context per task.
+> Task execution: **`general-purpose`** subagents using the **Subagent Prompt Template** (inlined in Step 3). Model is resolved from config via `gsd-tools resolve-model gsd-executor --raw`. Fresh context per task.
 > Subagents write code but do NOT commit. Orchestrator makes one commit per plan after all waves complete.
 > Do not use `fh:gsd-executor` or `fh:gsd-planner` — their state management conflicts with this orchestrator.
 
 > **GSD project context:**
 > Read `STATE.md` and `ROADMAP.md` for current position. All state updates use `gsd-tools.cjs`.
 > For context ordering in subagent prompts, see @.claude/skills/shared/context-api-contract.md.
+
+---
+
+## Step 0: Tool Readiness
+
+claude-mem and ast-grep are manifest-required tools that power this entire skill. claude-mem tools are **deferred** — they must be fetched before they can be called. Do this first, before any other work.
+
+```
+ToolSearch("select:mcp__plugin_claude-mem_mcp-search__smart_search,mcp__plugin_claude-mem_mcp-search__smart_outline,mcp__plugin_claude-mem_mcp-search__smart_unfold,mcp__plugin_claude-mem_mcp-search__search,mcp__plugin_claude-mem_mcp-search__get_observations")
+```
+
+Also verify ast-grep CLI is available:
+```bash
+command -v sg &>/dev/null || command -v ast-grep &>/dev/null || echo "WARN: ast-grep not found"
+```
+
+These tools are used throughout:
+- **smart_outline** — see file structure without reading the whole file (11-27x cheaper than Read)
+- **smart_unfold** — extract one function/section from a file (never truncates)
+- **smart_search** — cross-codebase structural search by intent
+- **search + get_observations** — find prior decisions, gotchas, learnings from past sessions
+- **ast-grep (sg)** — structural code search and bulk transforms on source files
+
+**If ToolSearch returns empty for claude-mem:** Fall back to Read-based approach for this session. Note: this means reduced efficiency — the skill will still work but will use more context.
 
 ---
 
@@ -36,37 +60,64 @@ See @.claude/skills/shared/freshness-check.md
 
 ## Step 1: Find the Plan
 
-Resolve artifacts per @.claude/skills/shared/artifact-resolution.md
+### 1a. Locate the plan file
 
-- If the user specified a plan path, use that directly
-- Otherwise follow the resolution chain (claude-mem → STATE.md → phase dir → plans/)
-- If no plan exists, tell the user to run `/fh:plan-work` first
+Query claude-mem **first**, by intent — not by file path:
+
+```
+search({query: "current plan active tasks {phase-name}", project: "<project>", limit: 5})
+```
+
+Scan results for relevant observations (prioritize types: plan-artifact, decision, gotcha). If fresh observations found: use as primary input and skip redundant file reads.
+
+If no useful observations (or claude-mem unavailable): fall back to the resolution chain:
+1. Read `.planning/STATE.md` → extract current_phase + active_plan path
+2. `.planning/phases/{current_phase}/` → find PLAN*.md without matching SUMMARY.md
+3. Glob `.planning/plans/PLAN*.md` → most recent by mtime
+
+If the user specified a plan path, use that directly.
 
 Read only the plan frontmatter and task list — don't load all context files yet.
 
-### Load Planning Context (Pattern F)
-1. `search({query: "current plan active tasks {phase-name}", project: "<project>", limit: 5})`
-2. For relevant observations: `get_observations({ids: [top 2-3]})` — may contain PLAN.md content from prior sessions
-3. If observations are fresh (within current session): use as primary input, skip file reads
-4. If observations are stale or absent: Read PLAN.md and CONTEXT.md directly
+### 1b. Load Spec Context
 
-### Load Spec Context (Pattern G)
 If plan frontmatter has `spec:` field:
-1. `smart_unfold({path: "<spec-path>", symbol: "Architecture"})` — load only relevant sections
-2. Map to implementer-prompt placeholders: {SPEC_ARCHITECTURE}, {SPEC_FAILURE_MODES}, etc.
-3. Never load the whole SPEC.md at once
+1. `smart_unfold({path: "<spec-path>", symbol: "Architecture"})` — loads only that section
+2. `smart_unfold({path: "<spec-path>", symbol: "Failure Modes"})` — if relevant
+3. `smart_unfold({path: "<spec-path>", symbol: "Quality Rubrics"})` — if relevant
+4. `smart_unfold({path: "<spec-path>", symbol: "Data Flow"})` — if relevant
+5. Map to placeholders: `{SPEC_ARCHITECTURE}`, `{SPEC_FAILURE_MODES}`, `{SPEC_QUALITY_RUBRICS}`, `{SPEC_DATA_FLOW}`
+6. Never load the whole SPEC.md at once
 
-**Resume detection:** If multiple plans exist with partial SUMMARY.md coverage, report: "Found N plans, M already completed. Continuing from plan X." Skip completed plans.
+### 1c. Load Context Decisions
 
-**Task-level resume:** After identifying the plan, check `.planning/build/` for `task-{plan}-*-state.md` files per @references/task-state-protocol.md (Resume Protocol). `completed` tasks are skipped; `in-progress` tasks revert to `pending`; `failed` tasks with 2+ attempts surface to user before proceeding.
+```
+smart_search({query: "locked decisions for {phase-name}"})
+```
 
-**Phase dependency check:** Before executing, check if the current phase has declared prerequisites (in CONTEXT.md, RESEARCH.md, or ROADMAP.md — look for "depends on Phase", "requires Phase", "prerequisite"). For each declared dependency, verify the prerequisite phase is complete in STATE.md. If incomplete: **WARN** "Phase X depends on Phase Y (status: {status}). Building on incomplete prerequisites risks rework. Proceed anyway?" Wait for user confirmation before executing.
+If no results: read CONTEXT.md directly via `smart_unfold({path: "...", symbol: "Decisions"})` + `smart_unfold({..., symbol: "Discretion Areas"})`.
 
-**Previous phase check (GSD only):** If a previous SUMMARY exists, scan for unresolved "Issues Encountered". If found, ask user: "Previous plan had unresolved issues — proceed anyway, address first, or review?"
+Store as `{DESIGN_DECISIONS}` for subagent prompts.
+
+### 1d. Resume detection
+
+If multiple plans exist with partial SUMMARY.md coverage, report: "Found N plans, M already completed. Continuing from plan X." Skip completed plans.
+
+**Task-level resume:** Check `.planning/build/` for `task-{plan}-*-state.md` files per @references/task-state-protocol.md (Resume Protocol). `completed` tasks are skipped; `in-progress` tasks revert to `pending`; `failed` tasks with 2+ attempts surface to user before proceeding.
+
+### 1e. Phase dependency check
+
+Check if the current phase has declared prerequisites (in CONTEXT.md, RESEARCH.md, or ROADMAP.md — look for "depends on Phase", "requires Phase", "prerequisite"). For each declared dependency, verify the prerequisite phase is complete in STATE.md. If incomplete: **WARN** "Phase X depends on Phase Y (status: {status}). Building on incomplete prerequisites risks rework. Proceed anyway?" Wait for user confirmation.
+
+**Previous plan check (GSD only):** If a previous SUMMARY exists, scan for unresolved "Issues Encountered". If found, ask user: "Previous plan had unresolved issues — proceed anyway, address first, or review?"
 
 ---
 
-## Step 2: Analyze Waves
+## Step 2: Prepare for Execution
+
+### 2a. Analyze Waves
+
+> Plan parsing logic is shared with the auto-orchestrator via `.claude/skills/auto/lib/wave-analysis.cjs`. When modifying plan format, update both.
 
 Group tasks by their `wave` number (or dependency order if no waves specified):
 - Wave 1: tasks with no dependencies (can run in parallel)
@@ -79,30 +130,69 @@ Report the execution plan to the user: "N tasks in M waves. Wave 1 has X paralle
 ```bash
 PLAN_START_EPOCH=$(date +%s)
 WAVE_START_SHA=$(git rev-parse HEAD)
-AUTO_MODE=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get workflow.auto_advance 2>/dev/null || echo "false")
 ```
 
-If `AUTO_MODE` is `"true"` AND `.planning/DECISIONS.md` exists, include the last 10 entries for this phase as `{DECISIONS_CONTEXT}`. Otherwise empty string.
+### 2b. Reference Warm-Up (do this once, reuse across all subagents)
 
-See @references/wave-execution.md for Smart Context Loading, Reference Warm-Up, subagent prompt placeholders, token efficiency notes, post-wave triage, and pre-wave dependency checks.
+Shared references (testing-guide.md, claude-mem-rules.md) are the same across all tasks. Extract relevant sections once here and inject into all subagent prompts — this eliminates N redundant full-file reads per build.
 
----
+1. `smart_outline({path: ".claude/skills/shared/testing-guide.md"})` — get heading structure
+2. For each task type, `smart_unfold` the relevant section:
+   - Tasks with `tdd="true"`: `smart_unfold({..., symbol: "Part B"})` + `smart_unfold({..., symbol: "Part C"})`
+   - Tasks with E2E/Playwright scope: `smart_unfold({..., symbol: "Part D"})` + `smart_unfold({..., symbol: "Part C"})`
+   - All other tasks: `smart_unfold({..., symbol: "Part A"})` + `smart_unfold({..., symbol: "Part C"})`
+3. If tasks involve tests: also check `.planning/codebase/TESTING.md` for project-specific test patterns (runner, mocking approach, fixture conventions)
+4. Store extracted sections as `SHARED_REFERENCES_CACHE` — inject into each subagent prompt as `{SHARED_REFERENCES}`
 
-## Step 2.5: Test-Spec Generation
+**If smart tools returned nothing useful**: Read `testing-guide.md` once via Read tool. Store as `SHARED_REFERENCES_CACHE`.
 
-Resolve the execution model (needed for both this step and Step 3):
+### 2c. Past Learnings Check
+
+Query claude-mem for prior mistakes in this domain:
+
+```
+smart_search({query: "past mistakes {primary_module} build-learning"})
+search({query: "gotcha decision trade-off {phase-name}", project: "<project>", limit: 10})
+```
+
+For relevant results: `get_observations({ids: [top 2-3]})`. Store as `{PAST_LEARNINGS}` for subagent prompts.
+
+### 2d. Populate Project Constraints
+
+Read the `## Gotchas` section from `./CLAUDE.md`. Extract each gotcha as an imperative constraint:
+- Convert "X renamed Y to Z" → "Use Z, not Y"
+- Convert "X are async" → "Always await X"
+- Convert "X uses TEXT IDs" → "All FKs to X tables must be TEXT, never UUID"
+
+Store as `{PROJECT_CONSTRAINTS}`. Max 15 lines. If no Gotchas section exists, leave empty.
+
+### 2e. Populate Conventions Context
+
+Route by task type — load only relevant codebase mapping files:
+- UI tasks (`.tsx`, `.css`, `.scss`) → CONVENTIONS.md + STRUCTURE.md
+- API tasks (routes, handlers, endpoints) → ARCHITECTURE.md + CONVENTIONS.md
+- DB tasks (migrations, models, schemas) → ARCHITECTURE.md + STACK.md
+- Test tasks → TESTING.md + CONVENTIONS.md
+- Infrastructure/config tasks → STACK.md + INTEGRATIONS.md
+- General tasks → STRUCTURE.md + CONVENTIONS.md
+
+Use `smart_search` for task-relevant conventions instead of reading full files. Store as `{CLAUDE_MD_SECTIONS}`.
+
+### 2f. Test-Spec Generation
+
+Resolve the execution model:
 
 ```bash
 EXEC_MODEL=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" resolve-model gsd-executor --raw)
 ```
 
-Follow @references/test-spec-generation.md
+Follow @references/test-spec-generation.md (if plan has `must_haves.truths` and code tasks exist).
 
 ---
 
 ## Step 3: Execute Waves
 
-Use `$EXEC_MODEL` resolved in Step 2.5 (or resolve here if Step 2.5 was skipped):
+Use `$EXEC_MODEL` resolved in Step 2f (or resolve here if skipped):
 
 ```bash
 [ -z "$EXEC_MODEL" ] && EXEC_MODEL=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" resolve-model gsd-executor --raw)
@@ -112,36 +202,263 @@ Use `$EXEC_MODEL` resolved in Step 2.5 (or resolve here if Step 2.5 was skipped)
 
 For each wave, dispatch **one subagent per task** using the Agent tool with **`subagent_type: "general-purpose"`** and **`model: "$EXEC_MODEL"`** (use the resolved value, e.g. `"sonnet"` or `"opus"`).
 
-### Subagent prompt
+### 3a. Build each subagent prompt
 
-Use the structured template at `references/implementer-prompt.md`. Fill placeholders per @references/wave-execution.md (Subagent Prompt Placeholders section).
+> Task prompt structure follows `.claude/skills/auto/lib/context-injection.cjs`. Include: task instructions, phase goal, CONTEXT.md decisions, project constraints, smart tool discovery instructions.
 
-**SPEC.md enrichment (before dispatching each task):**
+Use the template below. Fill all `{PLACEHOLDERS}` from data gathered in Steps 1 and 2. Do NOT write ad-hoc prompts — the template exists because subagents need the Tool Decision Tree, Code Navigation, and Deviation Rules to work effectively.
 
-1. Check if the plan frontmatter has a `spec:` field pointing to a SPEC.md path.
-2. If SPEC.md exists: use `smart_unfold` to extract sections relevant to the task domain — Architecture, Failure Modes, Quality Rubrics, Data Flow. Map to placeholders: `{SPEC_ARCHITECTURE}`, `{SPEC_FAILURE_MODES}`, `{SPEC_QUALITY_RUBRICS}`, `{SPEC_DATA_FLOW}`.
-3. Query claude-mem for past mistakes in the task domain: `smart_search({query: "past mistakes {task_domain} build-learning"})`. Populate `{PAST_LEARNINGS}`.
-4. If `.planning/DECISIONS.md` exists, extract entries affecting this task's files. Populate `{DECISION_RATIONALE}`.
-5. If no SPEC.md exists: leave spec placeholders empty — the implementer-prompt guards ("If empty, skip this section") ensure graceful degradation.
+**ast-grep hint (per task):** When the task involves renaming, moving, extracting, or replacing patterns across multiple files, prepend this to `{TASK_TEXT}`:
+```
+**Tool hint:** This task involves multi-file structural changes. Use ast-grep (`sg`) for the transform — it's faster and more reliable than editing files one by one. See the Tool Decision Tree below.
+```
+Detect by scanning the task for keywords: "rename", "move", "extract", "replace across", "refactor", "migrate", "update all", or tasks listing 3+ files with the same kind of change.
 
-### Checkpoint protocol
+**File context pre-loading (per task, before dispatching):**
+
+Each task lists files it will modify. Pre-load their structure so the subagent doesn't waste tool calls on exploration:
+
+1. For each file in the task's `Files:` list, run `smart_outline({path: "<file>"})` — this returns function/class/export signatures without reading the full file (~11-27x cheaper than Read).
+2. Collect all outlines into `{FILE_OUTLINES}` — inject after `{TASK_TEXT}` in the prompt.
+3. For each file being modified, trace imports using ast-grep for structural accuracy:
+   ```bash
+   sg --pattern 'import $$$IMPORTS from "$FILE"' --lang typescript src/
+   ```
+   Replace `$FILE` with the file's import path (e.g. `@/lib/repositories/obligations` for `src/lib/repositories/obligations.ts`). This finds all files that structurally import from the target — no false positives from comments or strings.
+   If ast-grep is unavailable, fall back to `Grep` for `from.*<filename>`.
+   If LSP tools are available, `findReferences` on key exports is even more precise.
+4. Summarize as `{IMPACT_CONTEXT}`: "Files that import X: [list]. Changes to exported interfaces in X may affect these consumers."
+
+This gives the subagent a structural map of every file it needs to touch, plus awareness of what depends on those files — without reading any source code as orchestrator.
+
+**SPEC.md enrichment (per task, before dispatching):**
+
+1. If SPEC.md exists: use `smart_unfold` to extract sections relevant to the task domain. Map to `{SPEC_ARCHITECTURE}`, `{SPEC_FAILURE_MODES}`, `{SPEC_QUALITY_RUBRICS}`, `{SPEC_DATA_FLOW}`.
+2. Query claude-mem for past mistakes: `smart_search({query: "past mistakes {task_domain} build-learning"})`. Populate `{PAST_LEARNINGS}`.
+3. If `.planning/DECISIONS.md` exists, extract entries affecting this task's files. Populate `{DECISION_RATIONALE}`.
+4. If no SPEC.md: leave spec placeholders empty — the template guards ("If empty, skip this section") handle graceful degradation.
+
+---
+
+### SUBAGENT PROMPT TEMPLATE
+
+Copy this template verbatim for each task. Fill `{PLACEHOLDERS}` with values from Steps 1-2. Do not omit sections — each one prevents a class of failure.
+
+````
+You are implementing a task from a plan.
+
+## Your Task
+
+{TASK_TEXT}
+
+## File Structure (pre-loaded by orchestrator)
+
+{FILE_OUTLINES}
+
+These are the function/class/export signatures of each file you'll modify. Use this to orient yourself — you already know the structure. Use `smart_unfold` to read specific functions when you need implementation details, and `Read` only when you're ready to `Edit`.
+
+## Impact Context
+
+{IMPACT_CONTEXT}
+
+If empty, skip. If present: these files import or depend on the files you're modifying. Be aware of downstream effects — if you change an exported interface, check that callers still match.
+
+## Tool Decision Tree
+
+Choose the right tool for each change type:
+
+| Change type | Primary tool | Fallback |
+|-------------|-------------|---------|
+| Structural transforms (rename pattern, extract across many files) | ast-grep CLI (`sg`) | Edit tool per file |
+| Single-file targeted change | Edit tool | — |
+| Non-code files (Markdown, JSON, YAML) | Edit tool | — |
+| Find all instances of a code pattern | ast-grep MCP `find_code_by_rule` | Grep |
+
+**ast-grep rules:**
+- Only use ast-grep on source code files with language support (TypeScript, JavaScript, Python, etc.)
+- Do NOT use ast-grep on Markdown files — no language support
+- For bulk replace: verify each transform output before proceeding
+- Check availability: `command -v sg &>/dev/null || command -v ast-grep &>/dev/null`
+
+## Code Navigation
+
+Use claude-mem smart tools for understanding code you haven't seen:
+- `smart_outline({path: "file"})` — function signatures without full read
+- `smart_unfold({path: "file", symbol: "name"})` — extract one function/class
+- `smart_search({query: "pattern"})` — cross-codebase structural search
+
+Use `Read` only for files you intend to `Edit`. Use LSP (`goToDefinition`, `findReferences`, `hover`) for type navigation if available.
+
+## Project Context
+
+### Conventions
+
+{CLAUDE_MD_SECTIONS}
+
+If empty: try `smart_search({query: "conventions for {FILE_TYPES}"})`, then fall back to reading relevant files in `.planning/codebase/` (CONVENTIONS.md for style, STRUCTURE.md for placement, ARCHITECTURE.md for layers).
+
+### Decisions & Scope
+
+{DESIGN_DECISIONS}
+
+If empty: try `smart_search({query: "locked decisions for {PHASE_NAME}"})`, then fall back to reading `.planning/phases/{PHASE_DIR}/CONTEXT.md`.
+
+Respect locked decisions. Stay within discretion bounds. Do not implement deferred ideas.
+
+### Architecture Context
+
+{SPEC_ARCHITECTURE}
+
+If empty, skip this section.
+
+### Data Flow
+
+{SPEC_DATA_FLOW}
+
+If empty, skip this section.
+
+### Hard Constraints
+
+{PROJECT_CONSTRAINTS}
+
+If empty, read the "Gotchas" section of `./CLAUDE.md`. These are project-level rules — violations cause runtime failures.
+
+## Before You Begin
+
+You are a subagent — no interactive questions. Make reasonable assumptions and document them.
+
+**BLOCKED?** (missing file, broken API, unclear requirement) — STOP immediately. Report: Status: BLOCKED, Task, Blocker, What you need. Do not guess on blockers.
+
+**Do NOT commit.** The orchestrator commits once after all tasks complete.
+
+## Testing
+
+{SHARED_REFERENCES}
+
+If the above is empty, read `.claude/skills/shared/testing-guide.md` for testing rules, TDD, stack defaults, and Playwright patterns.
+
+**Key rules:**
+- Write tests alongside implementation for any business logic, state, or data transformation
+- Non-watch mode only (watch hangs subagents): `pnpm test --run` or prefix `CI=true`
+- React: `@testing-library/react` with `getByRole` > `getByLabel` > `getByTestId`
+- TDD tasks (`tdd="true"`): follow Part B (Red-Green-Refactor) — watch each test fail before implementing
+- E2E/Playwright: read `.claude/skills/playwright-testing/PROMPT.md` for the full decision tree
+- If pre-generated test skeletons exist in `__tests__/` or `e2e/`, implement to make them pass
+
+**Context-aware references** — read if relevant:
+- Frontend work (`.tsx`, `.css`): `.planning/DESIGN.md`
+- Next.js (`next.config.*`): `.claude/skills/nextjs-perf/PROMPT.md`
+
+Do not add features, abstractions, or error handling beyond what the task specifies.
+
+## Deviation Rules
+
+You will discover work not in the plan. Apply:
+
+| Rule | Trigger | Action | Permission |
+|------|---------|--------|------------|
+| 1 | Bug: broken behavior, errors, type errors, security vulns | Fix -> test -> verify -> track `[Rule 1 - Bug]` | Auto |
+| 2 | Missing critical: validation, auth, CSRF, rate limiting | Fix -> test -> verify -> track `[Rule 2 - Missing Critical]` | Auto |
+| 3 | Blocking: missing deps, wrong types, broken imports | Fix -> verify -> track `[Rule 3 - Blocking]` | Auto |
+| 4 | Architectural: new DB table, schema change, new service | STOP -> report to orchestrator: what, why, impact, alternatives | Ask user |
+
+Only fix issues directly caused by your changes. After 3 failed attempts on one issue, document and move on.
+
+## Guardrails
+
+If you make 5+ consecutive read/search calls without writing code, you're stuck — either write code or report "blocked". This keeps you from over-analyzing when the task needs action.
+
+Out-of-scope discoveries go to `{PHASE_DIR}/deferred-items.md`:
+```
+- [{TASK_NAME}] {description} (found in {file}:{line})
+```
+
+## Stub Check (before reporting)
+
+Before reporting, scan all files you created or modified for stub patterns:
+- Hardcoded empty values: `=[]`, `={}`, `=null`, `=""` that flow to UI rendering
+- Placeholder text: "not available", "coming soon", "placeholder", "TODO", "FIXME"
+- Components with no data source wired (props always receiving empty/mock data)
+
+If any stubs exist, include them in your report under **Stubs** with file, line, and reason. Do NOT claim a task complete if stubs prevent the task's goal from being achieved.
+
+## Spec Quality Targets
+
+{SPEC_QUALITY_RUBRICS}
+
+If empty, skip this section. If present: treat these rubrics as acceptance criteria.
+
+{SPEC_FAILURE_MODES}
+
+If empty, skip this section. If present: ensure your implementation handles each listed failure mode.
+
+## Past Context
+
+{PAST_LEARNINGS}
+
+If empty, skip this section. If present: avoid repeating these past mistakes.
+
+{DECISION_RATIONALE}
+
+If empty, skip this section. If present: do not reverse these design decisions without flagging as a deviation.
+
+## Self-Check (before reporting)
+
+Verify your key claims:
+
+```bash
+# Check created files exist:
+[ -f "path/to/created/file" ] && echo "FOUND" || echo "MISSING: path/to/created/file"
+```
+
+If any expected file is missing: fix it before reporting, or explain why it's absent.
+
+## Report
+
+Before reporting: self-review for completeness, quality, no overbuilding, and test coverage.
+
+**Implemented:** What you built (file paths)
+**Tests:** `{pass_count}/{total_count} passing` | New test files: `{list}` | If skipped: `UNTESTED: {file} — {reason}`
+**Files Changed:** Created/modified files
+**Deviations:** Rule 1-3 fixes applied
+**Stubs:** Stub patterns found (if any) with file:line — or "None"
+**Concerns:** Issues for downstream tasks
+**Deferred:** Items logged (if any)
+````
+
+### END OF SUBAGENT PROMPT TEMPLATE
+
+---
+
+### 3b. Checkpoint protocol
 
 If a task has `type="checkpoint:*"`, handle inline:
 
-- `checkpoint:human-verify` — Show the subagent's output (screenshot/command output), await user approval. In auto-mode: auto-approve (confidence=MEDIUM).
-- `checkpoint:decision` — Present options with pros/cons, await user choice. In auto-mode: auto-select first option (confidence=MEDIUM).
-- `checkpoint:human-action` — Describe the manual step needed, await confirmation. In auto-mode: STOP (auth gates cannot be automated).
+- `checkpoint:human-verify` — Show the subagent's output (screenshot/command output), await user approval.
+- `checkpoint:decision` — Present options with pros/cons, await user choice.
+- `checkpoint:human-action` — Describe the manual step needed, await confirmation.
 
-When auto-approving checkpoints, log as a decision in `.planning/DECISIONS.md` with `confidence=MEDIUM`, `step='build checkpoint'`. Follow format from `references/decisions-template.md`.
+### 3c. After each wave completes
 
-### After each wave completes
+**Post-wave triage:** Classify subagent outcomes (see @references/wave-execution.md for detailed triage patterns):
+
+- **BLOCKED:** Surface immediately with options (fix/skip/adjust). Do not proceed to next wave until resolved.
+- **Interrupted/stuck:** Re-dispatch with revised prompt.
+- **Silent failure (no files changed):** Treat as BLOCKED.
+- **`classifyHandoffIfNeeded` false failure:** If a subagent reports "failed" with this error, it's a Claude Code runtime bug. Spot-check key files on disk — if they exist and no `## Self-Check: FAILED` marker, treat as successful.
+
+**Spot-check:** Verify key files from subagent reports exist on disk (`[ -f path ]`). Check for `## Self-Check: FAILED` marker. Compare each task's `done` criteria against subagent output.
 
 **Quality gate:** Run structural checks per @references/quality-gate.md.
 - PASS → proceed to next wave
 - WARN → proceed, note in SUMMARY.md "Quality Warnings"
 - FAIL → adaptive response per quality-gate.md (retry single task, stop for architectural or multiple failures)
 
-Follow post-wave triage and pre-wave dependency check from @references/wave-execution.md
+**Pre-wave dependency check (wave 2+ only):** Before dispatching each subsequent wave, verify artifacts from prior waves are present:
+```bash
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" verify key-links {phase_dir}/{plan}-PLAN.md 2>/dev/null
+```
+If key-links from prior wave artifacts fail verification, warn about cross-plan wiring gaps. Key-links referencing files in the upcoming wave itself are skipped.
 
 ---
 
@@ -167,104 +484,19 @@ Run verification commands directly:
 4. **Coverage report** (if Vitest/Jest config exists): `pnpm test --run --coverage 2>/dev/null || npx vitest run --coverage 2>/dev/null`
    Parse output for line/branch percentages. Include in SUMMARY.md `test_metrics` frontmatter.
    If coverage isn't configured or command fails, skip with note "Coverage not configured — consider adding vitest coverage."
-5. **Spec test count:** If Step 2.5 ran, capture the test-spec subagent's reported test count as `spec_tests_count` in `test_metrics`. If Step 2.5 was skipped, set to 0.
+5. **Spec test count:** If Step 2f ran, capture the test-spec subagent's reported test count as `spec_tests_count` in `test_metrics`. If Step 2f was skipped, set to 0.
 6. **Test creation check:** If the plan included tasks with `tdd="true"` or companion test tasks, verify at least one `*.test.*` or `*.spec.*` file was created or modified in this build (check via `git diff --name-only $WAVE_START_SHA HEAD`). If none found: WARN "Plan required tests but no test files were created — check subagent reports for UNTESTED flags."
 
 If any fail: flag in SUMMARY under "Issues Encountered". Do NOT claim success if verification failed.
 
-### Post-Build Reflection
+### Step 5: Finalize
 
-Run complexity-gated reflection per @references/reflection-protocol.md.
+Read @references/finalize-build.md and execute all steps: reflection, SUMMARY.md generation, concerns review, drift check, persist findings, GSD state updates, phase completion detection, and report + route.
 
-Evaluate complexity after all waves complete (before generating SUMMARY.md):
-- **Simple** (≤3 tasks, no cross-cutting concerns): skip reflection entirely.
-- **Medium** (4-7 tasks): light reflection — answer 3 questions, write 1-2 `[reflection-learning]` observations.
-- **Complex** (8+ tasks, OR architectural, OR cross-phase): dispatch the reflector agent (`subagent_type: "fh:reflector"`) with SUMMARY path, SPEC path, diff range, and task list.
-
-Append the `## Reflection` section to SUMMARY.md (medium/complex tiers only).
-
-### Generate SUMMARY.md
-
-Read `references/summary-template.md` for the template. Write SUMMARY.md (include `## Reflection` if produced above). Commit: `docs({phase}-{plan}): complete {description}`
-
-**Archive task state files** (after SUMMARY.md commit) per @references/task-state-protocol.md (Cleanup):
-```bash
-mkdir -p .planning/build/archive && mv .planning/build/task-{plan}-*-state.md .planning/build/archive/ 2>/dev/null || true
-```
-
-### Concerns Review (after SUMMARY.md)
-
-If `.planning/codebase/CONCERNS.md` exists, do a quick scan:
-1. Read CONCERNS.md categories and items
-2. Check if this build addressed any listed concerns (compare files modified against concern file paths)
-3. If a concern was addressed: add a note to SUMMARY.md under "Concerns Addressed" with the concern title and what was done
-4. If this build introduced patterns matching known concern categories (new tech debt, missing tests, security gaps): note in SUMMARY.md under "New Concerns" as advisory
-5. If CONCERNS.md is stale (`.last-mapped` > 50 commits behind HEAD): note in SUMMARY.md: "Codebase concerns may be outdated — consider `/fh:map-codebase`"
-
-This is advisory only — never block completion. Budget: <1% context.
-
-### Post-build drift check (advisory)
-
-If `.planning/codebase/` exists:
-1. `smart_search({query: "new pattern convention not documented"})` across recent observations
-2. If 3+ drift signals found since last mapping:
-   - Log: "⚠️ Codebase mapping may be stale — {N} convention changes detected since last map. Consider `/fh:map-codebase --refresh-stale`"
-3. Never auto-run mapping — just advise. User decides when to spend the tokens.
-
-### Persist Findings (after SUMMARY.md)
-
-Follow **Pattern D** (Persist Findings) from `shared/claude-mem-rules.md`. Use tag `[build-learning]`. Focus on: architectural decisions made during implementation, trade-offs chosen, patterns that worked or didn't.
-
----
-
-## Step 5: GSD State Updates
-
-**Skip if not in GSD mode.**
-
-Read `references/gsd-state-updates.md` and run the batch state update command. This covers: advance-plan, update-progress, record-metric, add-decision, record-session, and roadmap update.
-
-These run once at plan completion. No state writes during wave execution. Use `gsd-codebase-mapper` model for mechanical state updates.
-
----
-
-## Step 6: Phase Completion Detection
-
-```bash
-node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" verify phase-completeness "${PHASE_NUM}"
-```
-
-**If NOT all plans complete:** Report "Plan X of Y complete, Z remaining." Suggest `/fh:build` for next plan. Done.
-
-**If ALL plans complete (phase done):** Run phase completion gates per @references/phase-completion-gates.md
-
----
-
-## Step 7: Report + Route
-
-Report what was built:
-- Tasks completed, key files created/modified
-- Verification results
-
-Route based on phase status:
-
-| Condition | Action |
-|-----------|--------|
-| More plans in phase | "Plan X of Y complete." Suggest `/fh:build` for next plan. |
-| Phase complete, more phases | "Phase complete." Suggest `/fh:plan-work {next}` or `/fh:review`. Also suggest `/fh:learnings`. |
-| Last phase in milestone | "Milestone complete." Run `gsd-tools.cjs milestone complete`. Suggest `/fh:learnings`. |
-
-Run `/fh:review` for quality refinement. If phase/milestone just completed, suggest `/fh:learnings`.
-
----
-
-## Context Budget Rules
-
-- **Orchestrator (you):** Stay lean. Don't read source files. Don't load more than 2 `.planning/` files at a time. Delegate all file reading to subagents.
-- **Task subagents (Sonnet):** Fresh context each. Load only what that task needs.
-- **GSD state updates (Haiku):** Mechanical commands only.
+Pass these values: `PHASE_NUM`, `PLAN_NUM`, `PLAN_DESCRIPTION`, `WAVE_START_SHA`, `PLAN_START_EPOCH`, verification results, and subagent reports.
 
 ---
 
 ## Context Pressure Priority
 
-If context is running low: Step 3 > Step 4 > Step 6 > Step 5. Never skip Step 3 or Step 4.
+If context is running low: Step 3 > Step 4 > Step 5. Never skip Step 3 or Step 4.

--- a/.claude/skills/build/references/implementer-prompt.md
+++ b/.claude/skills/build/references/implementer-prompt.md
@@ -1,176 +1,57 @@
 # Task Subagent Prompt Template
 
-Reference template for `/build` Step 3. The orchestrator fills placeholders and dispatches
-one `general-purpose` subagent per task.
-
----
-
-```
-You are implementing a task from a plan.
-
-## Your Task
-
-{TASK_TEXT}
-
-## Tool Decision Tree
-
-Choose the right tool for each change type. See `@.claude/skills/shared/tool-availability.md` for availability checks.
-
-| Change type | Primary tool | Fallback |
-|-------------|-------------|---------|
-| Structural transforms (rename pattern, extract across many files) | ast-grep CLI (`sg`) | Edit tool per file |
-| Single-file targeted change | Edit tool | — |
-| Non-code files (Markdown, JSON, YAML) | Edit tool | — |
-| Find all instances of a code pattern | ast-grep MCP `find_code_by_rule` | Grep |
-
-**ast-grep rules:**
-- Only use ast-grep on source code files with language support (TypeScript, JavaScript, Python, etc.)
-- Do NOT use ast-grep on Markdown files — no language support
-- For bulk replace: verify each transform output before proceeding (CONDITIONAL GO status)
-- Check availability before use: `command -v sg &>/dev/null || command -v ast-grep &>/dev/null`
-
-## Code Navigation
-
-Use claude-mem smart tools for understanding code you haven't seen:
-- `smart_outline({path: "file"})` — function signatures without full read
-- `smart_unfold({path: "file", symbol: "name"})` — extract one function/class
-- `smart_search({query: "pattern"})` — cross-codebase structural search
-
-Use `Read` only for files you intend to `Edit`. Use LSP (`goToDefinition`, `findReferences`, `hover`) for type navigation.
-
-## Project Context
-
-### Conventions
-
-{CLAUDE_MD_SECTIONS}
-
-If empty: try `smart_search({query: "conventions for {FILE_TYPES}"})`, then fall back to reading relevant files in `.planning/codebase/` (CONVENTIONS.md for style, STRUCTURE.md for placement, ARCHITECTURE.md for layers).
-
-### Decisions & Scope
-
-{DESIGN_DECISIONS}
-
-If empty: try `smart_search({query: "locked decisions for {PHASE_NAME}"})`, then fall back to reading `.planning/phases/{PHASE_DIR}/CONTEXT.md`.
-
-Respect locked decisions. Stay within discretion bounds. Do not implement deferred ideas.
-
-### Architecture Context
-
-{SPEC_ARCHITECTURE}
-
-If empty, skip this section.
-
-### Data Flow
-
-{SPEC_DATA_FLOW}
-
-If empty, skip this section.
-
-### Hard Constraints
-
-{PROJECT_CONSTRAINTS}
-
-If empty, read the "Gotchas" section of `./CLAUDE.md`. These are project-level rules — violations cause runtime failures.
-
-## Before You Begin
-
-You are a subagent — no interactive questions. Make reasonable assumptions and document them.
-
-**BLOCKED?** (missing file, broken API, unclear requirement) — STOP immediately. Report: Status: BLOCKED, Task, Blocker, What you need. Do not guess on blockers.
-
-**Do NOT commit.** The orchestrator commits once after all tasks complete.
-
-## Testing
-
-{SHARED_REFERENCES}
-
-If the above is empty, read `.claude/skills/shared/testing-guide.md` for testing rules, TDD, stack defaults, and Playwright patterns.
-
-**Key rules:**
-- Write tests alongside implementation for any business logic, state, or data transformation
-- Non-watch mode only (watch hangs subagents): `pnpm test --run` or prefix `CI=true`
-- React: `@testing-library/react` with `getByRole` > `getByLabel` > `getByTestId`
-- TDD tasks (`tdd="true"`): follow Part B (Red-Green-Refactor) — watch each test fail before implementing
-- E2E/Playwright: read `.claude/skills/playwright-testing/PROMPT.md` for the full decision tree
-- If pre-generated test skeletons exist in `__tests__/` or `e2e/`, implement to make them pass
-
-**Context-aware references** — read if relevant:
-- Frontend work (`.tsx`, `.css`): `.planning/DESIGN.md`
-- Next.js (`next.config.*`): `.claude/skills/nextjs-perf/PROMPT.md`
-
-Do not add features, abstractions, or error handling beyond what the task specifies.
-
-## Deviation Rules
-
-You will discover work not in the plan. Apply:
-
-| Rule | Trigger | Action | Permission |
-|------|---------|--------|------------|
-| 1 | Bug: broken behavior, errors, type errors, security vulns | Fix -> test -> verify -> track `[Rule 1 - Bug]` | Auto |
-| 2 | Missing critical: validation, auth, CSRF, rate limiting | Fix -> test -> verify -> track `[Rule 2 - Missing Critical]` | Auto |
-| 3 | Blocking: missing deps, wrong types, broken imports | Fix -> verify -> track `[Rule 3 - Blocking]` | Auto |
-| 4 | Architectural: new DB table, schema change, new service | STOP -> report to orchestrator: what, why, impact, alternatives | Ask user |
-
-Only fix issues directly caused by your changes. After 3 failed attempts on one issue, document and move on.
-
-## Guardrails
-
-If you make 5+ consecutive read/search calls without writing code, you're stuck — either write code or report "blocked". This keeps you from over-analyzing when the task needs action.
-
-Out-of-scope discoveries go to `{PHASE_DIR}/deferred-items.md`:
-```
-- [{TASK_NAME}] {description} (found in {file}:{line})
-```
-
-## Stub Check (before reporting)
-
-Before reporting, scan all files you created or modified for stub patterns:
-- Hardcoded empty values: `=[]`, `={}`, `=null`, `=""` that flow to UI rendering
-- Placeholder text: "not available", "coming soon", "placeholder", "TODO", "FIXME"
-- Components with no data source wired (props always receiving empty/mock data)
-
-If any stubs exist, include them in your report under **Stubs** with file, line, and reason. Do NOT claim a task complete if stubs prevent the task's goal from being achieved — either wire the data or explain which future task will resolve it.
-
-## Spec Quality Targets
-
-{SPEC_QUALITY_RUBRICS}
-
-If empty, skip this section. If present: treat these rubrics as acceptance criteria — functional correctness, resilience, quality, and testability requirements specified for this task.
-
-{SPEC_FAILURE_MODES}
-
-If empty, skip this section. If present: these are predicted failure modes for this task's codepaths — ensure your implementation handles each listed mode explicitly.
-
-## Past Context
-
-{PAST_LEARNINGS}
-
-If empty, skip this section. If present: avoid repeating these past mistakes.
-
-{DECISION_RATIONALE}
-
-If empty, skip this section. If present: these are the reasons behind key design decisions — do not reverse them without flagging as a deviation.
-
-## Self-Check (before reporting)
-
-Verify your key claims before reporting:
-
-```bash
-# Check created files exist:
-[ -f "path/to/created/file" ] && echo "FOUND" || echo "MISSING: path/to/created/file"
-```
-
-If any expected file is missing: fix it before reporting, or explain why it's absent.
-
-## Report
-
-Before reporting: self-review for completeness, quality, no overbuilding, and test coverage.
-
-**Implemented:** What you built (file paths)
-**Tests:** `{pass_count}/{total_count} passing` | New test files: `{list}` | If skipped: `UNTESTED: {file} — {reason}`
-**Files Changed:** Created/modified files
-**Deviations:** Rule 1-3 fixes applied
-**Stubs:** Stub patterns found (if any) with file:line — or "None"
-**Concerns:** Issues for downstream tasks
-**Deferred:** Items logged (if any)
-```
+> **This template is now inlined in SKILL.md Step 3a** to ensure the orchestrator always uses it.
+> This file is kept as a reference for other skills that may need to understand the subagent contract.
+
+The canonical template lives in `SKILL.md` under the heading "SUBAGENT PROMPT TEMPLATE". It includes:
+
+- **Tool Decision Tree** — ast-grep for structural transforms, Edit for targeted changes
+- **Code Navigation** — claude-mem smart tools (smart_outline, smart_unfold, smart_search)
+- **Project Context** — conventions, decisions, architecture, constraints (filled by orchestrator)
+- **Testing** — shared references cache, TDD rules, Playwright patterns
+- **Deviation Rules** — when to fix vs. stop and report
+- **Stub Check** — catch placeholder code before reporting
+- **Self-Check** — verify claims with filesystem checks
+- **Report Format** — structured output for orchestrator triage
+
+## Code Discovery
+
+Use smart tools for efficient code navigation:
+- `smart_outline({path: "file"})` — see file structure without reading the whole file
+- `smart_unfold({path: "file", symbol: "name"})` — read a specific function/class
+- `smart_search({query: "pattern"})` — find patterns across the codebase
+
+Only Read full files when you need to Edit them.
+
+## Why Inlined?
+
+The template was previously in this file and referenced via `@references/implementer-prompt.md`.
+In practice, the orchestrator skipped loading this file and wrote ad-hoc prompts instead — losing
+the Tool Decision Tree, Code Navigation, Deviation Rules, and Stub Check sections entirely.
+
+Inlining the template directly in SKILL.md eliminates the indirection and ensures every subagent
+receives the full contract.
+
+## Placeholder Reference
+
+These placeholders are filled by the orchestrator from Steps 1-2:
+
+| Placeholder | Source |
+|---|---|
+| `{TASK_TEXT}` | Full task content from PLAN.md |
+| `{FILE_OUTLINES}` | smart_outline results for each file listed in the task (Step 3a) |
+| `{IMPACT_CONTEXT}` | Files that import/depend on task files — blast radius (Step 3a) |
+| `{CLAUDE_MD_SECTIONS}` | Conventions from codebase mapping (Step 2e) |
+| `{DESIGN_DECISIONS}` | CONTEXT.md decisions (Step 1c) |
+| `{SPEC_ARCHITECTURE}` | SPEC.md Architecture section (Step 1b) |
+| `{SPEC_DATA_FLOW}` | SPEC.md Data Flow section (Step 1b) |
+| `{SPEC_QUALITY_RUBRICS}` | SPEC.md Quality Rubrics section (Step 1b) |
+| `{SPEC_FAILURE_MODES}` | SPEC.md Failure Modes section (Step 1b) |
+| `{PROJECT_CONSTRAINTS}` | CLAUDE.md Gotchas section (Step 2d) |
+| `{SHARED_REFERENCES}` | Testing guide sections from Reference Warm-Up (Step 2b) |
+| `{PAST_LEARNINGS}` | claude-mem past mistakes (Step 2c) |
+| `{DECISION_RATIONALE}` | DECISIONS.md entries affecting task files (Step 3a) |
+| `{PHASE_DIR}` | Path to `.planning/phases/{phase}/` |
+| `{PHASE_NAME}` | Phase directory name |
+| `{FILE_TYPES}` | Comma-separated file type descriptions |
+| `{TASK_NAME}` | Task identifier for deferred items |

--- a/.claude/skills/build/references/wave-execution.md
+++ b/.claude/skills/build/references/wave-execution.md
@@ -1,75 +1,7 @@
 # Wave Execution Details
 
-## Smart Context Loading
-
-Use smart_search to find relevant patterns before reading files. Use smart_outline to understand file structure before editing. Don't read full files to find one function — use smart_outline then smart_unfold, then Read only when you need to Edit.
-
-Specifically before wave execution:
-1. `smart_search({query: "patterns in <primary module>"})` to find existing conventions
-2. `smart_outline({path: "<plan target files>"})` to understand structure without full reads
-3. `smart_search({query: "locked decisions for <phase>"})` to retrieve phase context compactly
-
-## Reference Warm-Up (once per build)
-
-Shared references (`testing-guide.md`, `claude-mem-rules.md`) are static between plugin updates. Extract task-relevant sections once here and inject into all subagent prompts — eliminates N redundant full-file reads per build.
-
-1. `smart_outline({path: ".claude/skills/shared/testing-guide.md"})` — get heading structure
-2. For each task type, `smart_unfold` the relevant section:
-   - Tasks with `tdd="true"`: `smart_unfold({path: "...", symbol: "Part B"})` + `smart_unfold({..., symbol: "Part C"})`
-   - Tasks with E2E/Playwright scope: `smart_unfold({..., symbol: "Part D"})` + `smart_unfold({..., symbol: "Part C"})`
-   - All other tasks: `smart_unfold({..., symbol: "Part A"})` + `smart_unfold({..., symbol: "Part C"})`
-3. For tasks involving tests (tdd="true", test tasks, or E2E tasks): also read `.planning/codebase/TESTING.md` if it exists — inject project-specific test patterns (runner, mocking approach, fixture conventions) alongside testing-guide.md sections for full TDD discipline.
-4. Store extracted sections as `SHARED_REFERENCES_CACHE`
-
-**Project-specific testing context:**
-For test runner commands, mocking patterns, fixture locations, and coverage targets: inject from `.planning/codebase/TESTING.md` (project-specific).
-For TDD discipline and philosophy: inject from `testing-guide.md` (universal).
-Use `smart_search({query: "test patterns for {task type}"})` to find the right source.
-Never read both full docs when only one is needed.
-
-**If smart tools return no relevant results**: Read `testing-guide.md` once via the Read tool. Store full content as `SHARED_REFERENCES_CACHE`.
-
-**If all lookups fail**: Leave `SHARED_REFERENCES_CACHE` empty — subagents will read files directly.
-
-Inject `SHARED_REFERENCES_CACHE` into each subagent prompt via the `{SHARED_REFERENCES}` placeholder in the implementer-prompt.
-
-## Subagent Prompt Placeholders
-
-Use the structured template at `references/implementer-prompt.md`. Fill its placeholders:
-
-- `{TASK_TEXT}` — Full task content (files, action, verify, done). Copy the text, don't reference the plan file.
-- `{CLAUDE_MD_SECTIONS}` — Relevant sections from CLAUDE.md for this task type, plus task-type-routed codebase mapping files from `.planning/codebase/`:
-  - UI tasks (`.tsx`, `.css`, `.scss`) → inject CONVENTIONS.md + STRUCTURE.md
-  - API tasks (routes, handlers, endpoints) → inject ARCHITECTURE.md + CONVENTIONS.md
-  - DB tasks (migrations, models, schemas) → inject ARCHITECTURE.md + STACK.md
-  - Test tasks → inject TESTING.md + CONVENTIONS.md
-  - Infrastructure/config tasks → inject STACK.md + INTEGRATIONS.md
-  - General tasks → inject STRUCTURE.md + CONVENTIONS.md
-
-  Use smart_search for task-relevant conventions instead of reading full files.
-- `{DESIGN_DECISIONS}` — If `.planning/phases/{phase}/{phase}-CONTEXT.md` exists, include the "Decisions", "Discretion Areas", and "Deferred Ideas" sections.
-- `{PHASE_DIR}` — Path to `.planning/phases/{phase}/` for deferred items logging.
-- `{PHASE_NAME}` — Phase directory name for smart_search queries (e.g. "13-pending-payments-invoicing").
-- `{FILE_TYPES}` — Comma-separated file type descriptions for convention queries (e.g. "tsx components", "test files").
-- `{TASK_NAME}` — Task identifier for deferred items format.
-- `{PROJECT_CONSTRAINTS}` — See population rule below.
-- `{SHARED_REFERENCES}` — Pre-loaded testing/TDD rules from `SHARED_REFERENCES_CACHE` (populated in Reference Warm-Up). Task-filtered: TDD tasks get Part B, E2E tasks get Part D, all get Part A + C. If empty, subagent reads files directly.
-
-**{PROJECT_CONSTRAINTS} population:**
-Read the `## Gotchas` section from `./CLAUDE.md`. Extract each gotcha as an imperative constraint:
-- Convert "X renamed Y to Z" → "Use Z, not Y"
-- Convert "X are async" → "Always await X"
-- Convert "X uses TEXT IDs" → "All FKs to X tables must be TEXT, never UUID"
-Inject as `{PROJECT_CONSTRAINTS}`. Max 15 lines.
-If no Gotchas section exists, leave {PROJECT_CONSTRAINTS} empty (do not error).
-
-## claude-mem Context Acceleration
-
-Before reading CONTEXT.md and DECISIONS.md files directly:
-- Use `smart_search({query: "locked decisions for phase {phase}"})` and `smart_search({query: "decisions affecting {files}"})` to find relevant entries.
-- Use `smart_outline` to understand file structure before editing. Don't read full files to find one function — use `smart_outline` → `smart_unfold`, then Read only when you need to Edit.
-
-The template tells subagents to self-discover relevant skill context (Playwright, Next.js, frontend design) by reading skill files when their task involves those domains. No orchestrator pre-processing needed.
+> **Smart Context Loading, Reference Warm-Up, and Subagent Prompt Placeholders are now inlined in SKILL.md Steps 2b-2e.**
+> This file retains supplementary details that SKILL.md references for post-wave handling.
 
 ## Token Efficiency Notes
 
@@ -79,6 +11,12 @@ When executing tasks, be aware of tool call efficiency:
 - **Fallow output is authoritative** — do not re-derive dead code, complexity, or duplication findings that Fallow already provided
 - **Note tool call patterns:** If you find yourself reading the same file multiple times across tasks, flag it as a context optimization opportunity in the SUMMARY.md
 
+## claude-mem Context Acceleration
+
+Before reading CONTEXT.md and DECISIONS.md files directly:
+- Use `smart_search({query: "locked decisions for phase {phase}"})` and `smart_search({query: "decisions affecting {files}"})` to find relevant entries.
+- Use `smart_outline` to understand file structure before editing. Don't read full files to find one function — use `smart_outline` then `smart_unfold`, then Read only when you need to Edit.
+
 ## Post-Wave Triage
 
 claude-mem's PostToolUse hook automatically observes all file reads and edits from each wave's agents. Subsequent waves can query these observations via `search` or `timeline` — no explicit re-indexing needed.
@@ -87,7 +25,7 @@ Triage subagent outcomes:
 
 **BLOCKED:** Surface immediately:
 ```
-⚠ Task "{task}" is BLOCKED: {blocker}
+Task "{task}" is BLOCKED: {blocker}
 Options:
   A) Fix the blocker and retry
   B) Skip and defer

--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -33,7 +33,7 @@ Follow **Pattern A** (Past Learnings Check) from `shared/claude-mem-rules.md`. K
 claude-mem tools are **deferred** — they must be fetched before they can be called. Do this first, before any other work.
 
 ```
-ToolSearch("select:mcp__plugin_claude-mem_mcp-search__smart_search,mcp__plugin_claude-mem_mcp-search__smart_outline,mcp__plugin_claude-mem_mcp-search__smart_unfold,mcp__plugin_claude-mem_mcp-search__search,mcp__plugin_claude-mem_mcp-search__get_observations")
+ToolSearch("+mcp-search", max_results: 10)
 ```
 
 Also verify ast-grep CLI is available:

--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -28,7 +28,24 @@ Follow **Pattern A** (Past Learnings Check) from `shared/claude-mem-rules.md`. K
 
 ---
 
-## Step 0: Check Runtime Errors
+## Step 0: Tool Readiness
+
+claude-mem tools are **deferred** — they must be fetched before they can be called. Do this first, before any other work.
+
+```
+ToolSearch("select:mcp__plugin_claude-mem_mcp-search__smart_search,mcp__plugin_claude-mem_mcp-search__smart_outline,mcp__plugin_claude-mem_mcp-search__smart_unfold,mcp__plugin_claude-mem_mcp-search__search,mcp__plugin_claude-mem_mcp-search__get_observations")
+```
+
+Also verify ast-grep CLI is available:
+```bash
+command -v sg &>/dev/null || command -v ast-grep &>/dev/null || echo "WARN: ast-grep not found"
+```
+
+**If ToolSearch returns empty for claude-mem:** Fall back to Read-based approach for this session.
+
+---
+
+## Step 0.5: Check Runtime Errors
 
 Before triaging from code alone, check if the local error store has runtime context.
 
@@ -49,7 +66,7 @@ node lib/sentry-local-query.mjs recent --minutes 60
 
 4. If `NO_STORE`: skip this step silently. The project may not have observability set up.
 
-This step should consume <2% context. Don't deep-dive the errors yet — just surface them as input to triage.
+Don't deep-dive the errors yet — just surface them as input to triage.
 
 ---
 
@@ -68,13 +85,11 @@ If Fallow ran and produced non-empty output, scan results for entries related to
 
 If fallow is NOT installed: skip this step silently. Do not mention Fallow.
 
-Budget: less than 1% context.
-
 ---
 
 ## Step 1: Triage
 
-Quickly assess bug depth before choosing strategy. Spend <5% context.
+Quickly assess bug depth before choosing strategy.
 
 **Token-efficient code navigation:** Use **Pattern B** (Code Structure Exploration) from `shared/claude-mem-rules.md` — smart_outline/smart_unfold before full Read.
 
@@ -105,9 +120,57 @@ If Fallow findings were collected in Step 0.5, cross-reference them here first �
 
 Execute the chosen path:
 - **SIMPLE:** Skip to Step 2 — cause is clear from triage.
-- **MODERATE:** Read `skills/systematic-debugging/PROMPT.md` and follow it completely. Then Step 2.
-- **PARALLEL:** Dispatch one **`fh:gsd-debugger`** agent per subsystem (specialized — scientific debugging with hypothesis tracking). Each agent gets: the specific failure, relevant files, and instruction to produce root cause + proposed fix. Collect results. Then Step 2 for each fix.
-- **COMPLEX:** Write triage findings to `.planning/debug/{issue-slug}.md` with: error message, files investigated, hypotheses formed, test results observed. Slug convention: `YYYY-MM-DD-{first-3-words-kebab}` (e.g., `2026-03-06-payment-timeout-error`). If slug exists, append `-2`. Then dispatch a `fh:gsd-debugger` agent with the session file for sustained scientific investigation. If user says try anyway → MODERATE path.
+- **MODERATE:** Follow the debugging methodology in @references/debugging-protocol.md. Then Step 2.
+- **PARALLEL:** Dispatch one **`fh:gsd-debugger`** agent per subsystem via:
+  ```
+  Agent({
+    subagent_type: "fh:gsd-debugger",
+    prompt: "<structured prompt below>"
+  })
+  ```
+  Each agent prompt includes:
+  1. The specific failure description and reproduction steps
+  2. Relevant files and error messages from triage
+  3. Tool instructions:
+     ```
+     ## Tools Available
+     Use claude-mem smart tools for code navigation:
+     - `smart_outline({path})` — see file structure without full read
+     - `smart_unfold({path, symbol})` — extract one function
+     - `smart_search({query})` — cross-codebase structural search
+
+     Use ast-grep for structural code search:
+     - `sg --pattern '<pattern>' --lang typescript src/` — find code patterns structurally
+     - Prefer over grep for code-aware matching (ignores comments/strings)
+
+     Use `Read` only for files you intend to `Edit`.
+     ```
+  4. Debugging methodology: "Follow hypothesis-driven debugging per @references/debugging-protocol.md"
+  5. Output format: "Report: Root Cause, Evidence, Proposed Fix, Files to Change, Confidence Level"
+
+  Collect results. Then Step 2 for each fix.
+- **COMPLEX:** Write triage findings to `.planning/debug/{issue-slug}.md` with: error message, files investigated, hypotheses formed, test results observed. Slug convention: `YYYY-MM-DD-{first-3-words-kebab}` (e.g., `2026-03-06-payment-timeout-error`). If slug exists, append `-2`. Then dispatch a `fh:gsd-debugger` agent with the session file for sustained scientific investigation via:
+  ```
+  Agent({
+    subagent_type: "fh:gsd-debugger",
+    prompt: "<session file path + structured prompt>"
+  })
+  ```
+  Include tool instructions in the agent prompt:
+  ```
+  ## Tools Available
+  Use claude-mem smart tools for code navigation:
+  - `smart_outline({path})` — see file structure without full read
+  - `smart_unfold({path, symbol})` — extract one function
+  - `smart_search({query})` — cross-codebase structural search
+
+  Use ast-grep for structural code search:
+  - `sg --pattern '<pattern>' --lang typescript src/` — find code patterns structurally
+  - Prefer over grep for code-aware matching (ignores comments/strings)
+
+  Use `Read` only for files you intend to `Edit`.
+  ```
+  Follow hypothesis-driven debugging per @references/debugging-protocol.md. If user says try anyway → MODERATE path.
 
 **Todo integration:** After triage, scan `.planning/todos/` for items matching the bug (same file, same subsystem, or same error). If a todo matches, note its ID — mark it resolved after the fix lands in Step 2.
 
@@ -143,7 +206,7 @@ If the fix touches `.tsx`, `.css`, components, or styles:
 - Read `.planning/DESIGN.md` for design context
 - Quick check: does the fix maintain visual consistency?
 
-Use **Pattern B** from `shared/claude-mem-rules.md` for reading DECISIONS.md and DESIGN.md context. Check against `skills/frontend-design/PROMPT.md` anti-patterns — no generic cards, cyan-on-dark, purple gradients, or other AI slop introduced by the fix.
+Use **Pattern B** from `shared/claude-mem-rules.md` for reading DECISIONS.md and DESIGN.md context. Check against @references/frontend-review.md anti-patterns — no generic cards, cyan-on-dark, purple gradients, or other AI slop introduced by the fix.
 - If significant UI change, suggest `/fh:ui-test`
 
 ---
@@ -152,8 +215,7 @@ Use **Pattern B** from `shared/claude-mem-rules.md` for reading DECISIONS.md and
 
 ### Verification gate
 
-Before claiming the fix is complete, read `skills/verification-before-completion/PROMPT.md`
-and follow its gate function:
+Before claiming the fix is complete, follow the verification gate in @references/verification-checklist.md:
 
 1. **IDENTIFY** the verification command that proves the fix works:
    - The test written in Step 2 must pass
@@ -213,6 +275,12 @@ If `.planning/DECISIONS.md` exists, scan active decisions for entries whose Affe
 ### Persist Findings
 
 Follow **Pattern D** (Persist Findings) from `shared/claude-mem-rules.md`. Use tag `[fix-learning]`. Skip trivial fixes (typo, missing import, config change).
+
+---
+
+### Cross-Session Output
+
+**[fix-output]** Bug: {description}. Root cause: {summary}. Files fixed: {list}. Tests: {pass_count}/{total}. Pattern search: {similar_count} similar instances.
 
 ---
 

--- a/.claude/skills/fix/references/debugging-protocol.md
+++ b/.claude/skills/fix/references/debugging-protocol.md
@@ -1,0 +1,58 @@
+# Debugging Protocol
+
+## The Iron Law
+
+```
+NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST
+```
+
+If you haven't completed Phase 1, you cannot propose fixes. Symptom fixes are failure.
+
+## Phase 1: Root Cause Investigation
+
+**BEFORE attempting ANY fix:**
+
+1. **Read errors carefully** — don't skip past stack traces; note line numbers, file paths, error codes
+2. **Reproduce consistently** — if not reliably reproducible, gather more data; do not guess
+3. **Check recent changes** — git diff, recent commits, new dependencies, config changes
+4. **Gather evidence in multi-component systems** — add diagnostic instrumentation at each component boundary to see WHERE it breaks before investigating WHY
+5. **Trace data flow** — use LSP (`goToDefinition`, `incomingCalls`, `findReferences`, `hover`) to trace bad values back to their source; fix at source, not at symptom
+
+## Phase 2: Pattern Analysis
+
+1. Find working examples of similar code in the codebase
+2. Compare against the working version — list every difference, however small
+3. Understand dependencies: config, environment, assumptions
+
+## Phase 3: Hypothesis and Testing (Scientific Method)
+
+1. **Form a single hypothesis:** "I think X is the root cause because Y" — write it down, be specific
+2. **Test minimally:** make the smallest possible change to test the hypothesis, one variable at a time
+3. **Verify before continuing:** worked → Phase 4; didn't work → form NEW hypothesis, do NOT stack more fixes
+
+## Phase 4: Implementation
+
+1. **Create failing test** before writing any fix
+2. **Implement single fix** addressing the root cause — no "while I'm here" changes
+3. **Verify:** test passes, no regressions, issue resolved
+4. **3-fix escalation rule:** if 3+ fixes have failed, STOP — question the architecture, discuss with your human partner before attempting more
+
+## Red Flags — STOP and Return to Phase 1
+
+Any of these mean you are guessing, not debugging:
+- "Quick fix for now, investigate later"
+- "Just try changing X and see if it works"
+- "It's probably X, let me fix that"
+- "I don't fully understand but this might work"
+- Proposing solutions before tracing data flow
+- "One more fix attempt" after already trying 2+
+- Each fix reveals a new problem in a different place
+
+## Quick Reference
+
+| Phase | Key Activities | Success Criteria |
+|-------|---------------|------------------|
+| **1. Root Cause** | Read errors, reproduce, check changes, gather evidence, trace data flow | Understand WHAT and WHY |
+| **2. Pattern** | Find working examples, compare | Identify differences |
+| **3. Hypothesis** | Form theory, test minimally | Confirmed or new hypothesis |
+| **4. Implementation** | Create failing test, single fix, verify | Bug resolved, tests pass |

--- a/.claude/skills/fix/references/frontend-review.md
+++ b/.claude/skills/fix/references/frontend-review.md
@@ -1,0 +1,45 @@
+# Frontend Review Checklist
+
+Use this when a fix touches `.tsx`, `.css`, components, or styles.
+
+## The AI Slop Test
+
+Would someone believe AI made this immediately? If yes, that is the problem. A fix must not introduce generic "AI aesthetic" patterns.
+
+## Color Anti-Patterns (DON'T introduce)
+
+- Cyan-on-dark color schemes
+- Purple-to-blue gradients
+- Neon accents on dark backgrounds
+- Gradient text for headings or metrics
+- Pure black (#000) or pure white (#fff) — always tint
+- Gray text on colored backgrounds — use a shade of the background instead
+
+## Layout Anti-Patterns (DON'T introduce)
+
+- Wrapping everything in cards — not everything needs a container
+- Identical card grids — same-sized cards with icon + heading + text, repeated endlessly
+- Hero metric template — big number, small label, supporting stats, gradient accent
+- Centering everything — left-aligned with asymmetric layouts feels more designed
+- Same spacing everywhere — without rhythm, layouts feel monotonous
+
+## Visual Anti-Patterns (DON'T introduce)
+
+- Glassmorphism everywhere — blur effects, glass cards, glow borders used decoratively
+- Rounded rectangles with generic drop shadows — safe, forgettable
+- Sparklines as decoration — tiny charts that convey nothing
+- Large icons with rounded corners above every heading — templated appearance
+
+## Accessibility Basics
+
+- **Contrast:** text meets WCAG AA minimums; don't use gray-on-color combos
+- **Focus management:** all interactive elements are keyboard-reachable with visible focus rings
+- **ARIA:** interactive custom components have appropriate roles, labels, and state attributes
+- **Component states:** every interactive component must handle loading, error, empty, and success states
+
+## Responsive Check
+
+- Use container queries (`@container`) for component-level responsiveness
+- Adapt the interface for different contexts — don't just shrink it
+- Never hide critical functionality on mobile — adapt, don't amputate
+- Verify at the specific breakpoint the fix targets (e.g., `page.setViewportSize({width: 375, height: 812})`)

--- a/.claude/skills/fix/references/verification-checklist.md
+++ b/.claude/skills/fix/references/verification-checklist.md
@@ -1,0 +1,33 @@
+# Verification Checklist
+
+**When to apply:** Before any completion claim, commit, PR, or task status update.
+
+## The Gate Function
+
+```
+BEFORE claiming any status or expressing satisfaction:
+
+1. IDENTIFY: What command proves this claim?
+2. RUN:      Execute the FULL command (fresh, complete)
+3. READ:     Full output — check exit code, count failures
+4. VERIFY:   Does output confirm the claim?
+           - If NO: State actual status with evidence
+           - If YES: State claim WITH evidence
+5. CLAIM:    Only then make the claim
+
+Skip any step = lying, not verifying
+```
+
+**Key principle:** Evidence before assertions. Running the command and reading its output is the only acceptable proof.
+
+## Common Failures
+
+| Claim | Requires | Not Sufficient |
+|-------|----------|----------------|
+| Tests pass | Test command output: 0 failures | Previous run, "should pass" |
+| Linter clean | Linter output: 0 errors | Partial check, extrapolation |
+| Build succeeds | Build command: exit 0 | Linter passing, logs look good |
+| Bug fixed | Test original symptom: passes | Code changed, assumed fixed |
+| Regression test works | Red-green cycle verified | Test passes once |
+| Agent completed | VCS diff shows changes | Agent reports "success" |
+| Requirements met | Line-by-line checklist | Tests passing |

--- a/.claude/skills/plan-review/SKILL.md
+++ b/.claude/skills/plan-review/SKILL.md
@@ -15,7 +15,7 @@ allowed-tools:
 claude-mem tools are **deferred** — they must be fetched before they can be called. Do this first, before any other work.
 
 ```
-ToolSearch("select:mcp__plugin_claude-mem_mcp-search__smart_search,mcp__plugin_claude-mem_mcp-search__smart_outline,mcp__plugin_claude-mem_mcp-search__smart_unfold,mcp__plugin_claude-mem_mcp-search__search,mcp__plugin_claude-mem_mcp-search__get_observations")
+ToolSearch("+mcp-search", max_results: 10)
 ```
 
 Also verify ast-grep CLI is available:

--- a/.claude/skills/plan-review/SKILL.md
+++ b/.claude/skills/plan-review/SKILL.md
@@ -10,6 +10,23 @@ allowed-tools:
   - mcp__conductor__AskUserQuestion
 ---
 
+## Step 0: Tool Readiness
+
+claude-mem tools are **deferred** — they must be fetched before they can be called. Do this first, before any other work.
+
+```
+ToolSearch("select:mcp__plugin_claude-mem_mcp-search__smart_search,mcp__plugin_claude-mem_mcp-search__smart_outline,mcp__plugin_claude-mem_mcp-search__smart_unfold,mcp__plugin_claude-mem_mcp-search__search,mcp__plugin_claude-mem_mcp-search__get_observations")
+```
+
+Also verify ast-grep CLI is available:
+```bash
+command -v sg &>/dev/null || command -v ast-grep &>/dev/null || echo "WARN: ast-grep not found"
+```
+
+**If ToolSearch returns empty for claude-mem:** Fall back to Read-based approach for this session.
+
+---
+
 > **Dependency check:** Verify `.planning/PROJECT.md` exists (required — if missing, tell user: "No project found.\n\n→ Run `/fh:new-project` — set up project tracking before reviewing plans"). If no plan exists in the current phase, tell user: "No plan to review.\n\n→ Run `/fh:plan-work` — create a plan first".
 
 > Forked from gstack plan-ceo-review (v0.3.3)
@@ -18,7 +35,7 @@ allowed-tools:
 
 The user wants reviewed: $ARGUMENTS
 
-You are a **lean orchestrator**. Stay under 20% context usage. This skill is interactive — preserve context for the back-and-forth with the user.
+You are the **review orchestrator**. Follow every step below — each one exists because skipping it caused real failures in past sessions. This skill is interactive — preserve context for the back-and-forth with the user.
 
 Do NOT make any code changes. Do NOT start implementation. Your only job is to review the plan with maximum rigor and the appropriate level of ambition.
 
@@ -70,7 +87,7 @@ Never skip Step 0, the system audit, the error/rescue map, or the failure modes 
 
 ## Past Learnings Check (Pattern A)
 
-Run at the start of this review. Derive project name from `.planning/PROJECT.md` name field (fall back to basename of cwd). Call `mcp__plugin_claude-mem_mcp-search__search` with query=2-3 keywords from the plan's domain, project=<project-name>, limit=10. Scan for relevant IDs — prioritize types: gotcha, decision, trade-off. For the top 2-3 IDs, call `mcp__plugin_claude-mem_mcp-search__get_observations` with ids=[ID1, ID2, ID3]. Present as: "**Prior context:** - {observation}" — max 3 items. Feed into review as input context. Budget: <2% context. Skip silently if no relevant results.
+Run at the start of this review. Derive project name from `.planning/PROJECT.md` name field (fall back to basename of cwd). Call `mcp__plugin_claude-mem_mcp-search__search` with query=2-3 keywords from the plan's domain, project=<project-name>, limit=10. Scan for relevant IDs — prioritize types: gotcha, decision, trade-off. For the top 2-3 IDs, call `mcp__plugin_claude-mem_mcp-search__get_observations` with ids=[ID1, ID2, ID3]. Present as: "**Prior context:** - {observation}" — max 3 items. Feed into review as input context. Max 3 items. Skip silently if no relevant results.
 
 ---
 
@@ -103,15 +120,90 @@ Run scope challenge per @references/scope-challenge.md
 
 ---
 
-## Review Sections (6 sections, after scope and mode are agreed)
+## Step 2: Parallel Review Dispatch
 
-Run business review sections per @references/review-sections.md
+Dispatch 2 agents in parallel via the Agent tool. Each receives the plan, CONTEXT.md, mode selection, and system audit findings.
+
+### Agent 1: Business Review (Sections 1-6)
+
+```
+Agent({
+  subagent_type: "fh:code-reviewer",
+  prompt: "<business review prompt>"
+})
+```
+
+**Business review prompt includes:**
+- PLAN.md content (full)
+- CONTEXT.md locked decisions
+- Mode: {EXPANSION|HOLD|REDUCTION}
+- System audit findings from PRE-REVIEW SYSTEM AUDIT
+- Review criteria from @references/review-sections.md
+- Review sections to cover:
+  1. Scope & Requirements Alignment
+  2. User Stories & Acceptance Criteria
+  3. UX & Design Consistency
+  4. Risk Assessment & Mitigation
+  5. Dependencies & Integration Points
+  6. Correctness & Completeness
+
+**Tool instructions:**
+```
+Use claude-mem smart tools for codebase context:
+- smart_search({query}) — find code patterns across codebase
+- smart_outline({path}) — see file structure without full read
+- smart_unfold({path, symbol}) — extract specific functions
+- search({query, project}) + get_observations({ids}) — find prior decisions
+
+Use ast-grep for structural code analysis:
+- sg --pattern '<pattern>' --lang typescript src/
+```
+
+**Output format:** Each finding: Section number, Severity (CRITICAL/WARNING/OK), Description, Recommendation, Evidence (file:line or code snippet).
+
+### Agent 2: Engineering Review (Sections 7-10)
+
+```
+Agent({
+  subagent_type: "fh:code-reviewer",
+  prompt: "<engineering review prompt>"
+})
+```
+
+**Engineering review prompt includes:**
+- PLAN.md content (full)
+- CONTEXT.md locked decisions
+- Engineering review criteria from @references/engineering-review.md
+- Architecture artifacts (FLOWS.md, ERD.md if exist)
+- Review sections to cover:
+  7. Architecture & Code Quality
+  8. Testing Strategy & Coverage
+  9. Performance & Scalability
+  10. Security & Error Handling
+
+**Same tool instructions block as Agent 1.**
+
+**Output format:** Same as Agent 1.
+
+### Agent Failure Handling
+
+- Timeout: 5 minutes per agent. If one times out, proceed with the other agent's findings only.
+- If one agent fails entirely: log WARNING "Business/Engineering review incomplete — {agent} failed: {error}". Continue with other agent's findings.
+- If both fail: fall back to inline review (run sections manually) as degraded mode.
 
 ---
 
-## Engineering Review Sections (4 sections, after business review)
+## Step 3: Merge & Gate
 
-Run engineering review per @references/engineering-review.md
+After both agents complete (or one completes + other failed/timed out):
+
+1. Collect findings from both agents (or single agent if one failed)
+2. Deduplicate (same issue found by both → keep higher severity)
+3. Classify: CRITICAL GAP / WARNING / OK per section
+4. If mode is EXPANSION: identify delight opportunities from Agent 1 findings
+5. Present merged findings to user via AskUserQuestion (one per CRITICAL, batched for WARNING)
+6. Update PLAN.md: add new must_haves.truths with [review] prefix
+7. Update CONTEXT.md: append review decisions
 
 ---
 
@@ -274,6 +366,12 @@ After the review is complete, run Pattern D from @.claude/skills/shared/claude-m
    **[plan-review-learning]** {area}: {decision or concern} — {rationale}
 4. Max 3 findings per review
 5. Skip silently if no significant architectural decisions were made
+
+---
+
+### Cross-Session Output
+
+**[plan-review-output]** Phase {N} Plan {NN}: Mode={mode}. New truths: {count}. Decisions added: {count}. Gate: {PASS/WARN/BLOCK}. Critical findings: {summary}.
 
 ---
 

--- a/.claude/skills/plan-work/SKILL.md
+++ b/.claude/skills/plan-work/SKILL.md
@@ -27,7 +27,7 @@ This creates the .planning/ directory that all planning and build skills depend 
 claude-mem tools are **deferred** — they must be fetched before they can be called. Do this first, before any other work.
 
 ```
-ToolSearch("select:mcp__plugin_claude-mem_mcp-search__smart_search,mcp__plugin_claude-mem_mcp-search__smart_outline,mcp__plugin_claude-mem_mcp-search__smart_unfold,mcp__plugin_claude-mem_mcp-search__search,mcp__plugin_claude-mem_mcp-search__get_observations")
+ToolSearch("+mcp-search", max_results: 10)
 ```
 
 Also verify ast-grep CLI is available:

--- a/.claude/skills/plan-work/SKILL.md
+++ b/.claude/skills/plan-work/SKILL.md
@@ -8,7 +8,7 @@ Plan a feature before building it. Brainstorm, research, and produce an executio
 
 The user wants to plan: $ARGUMENTS
 
-You are a **lean orchestrator**. Your job is to coordinate, not to do heavy work yourself. Delegate research and analysis to subagents to keep your context clean.
+You are the **planning orchestrator**. Follow every step below — each one exists because skipping it caused real failures in past sessions. Delegate research and analysis to subagents to keep your context clean.
 
 > **CRITICAL — GSD project required:**
 > Check if `.planning/PROJECT.md` exists.
@@ -22,9 +22,43 @@ This creates the .planning/ directory that all planning and build skills depend 
 
 ---
 
+## Step 0: Tool Readiness
+
+claude-mem tools are **deferred** — they must be fetched before they can be called. Do this first, before any other work.
+
+```
+ToolSearch("select:mcp__plugin_claude-mem_mcp-search__smart_search,mcp__plugin_claude-mem_mcp-search__smart_outline,mcp__plugin_claude-mem_mcp-search__smart_unfold,mcp__plugin_claude-mem_mcp-search__search,mcp__plugin_claude-mem_mcp-search__get_observations")
+```
+
+Also verify ast-grep CLI is available:
+```bash
+command -v sg &>/dev/null || command -v ast-grep &>/dev/null || echo "WARN: ast-grep not found"
+```
+
+**If ToolSearch returns empty for claude-mem:** Fall back to Read-based approach for this session.
+
+---
+
+### Cross-Session Cache Check
+
+Before reading planning files, check if a prior skill already loaded this context:
+
+```
+search({query: "[plan-work-output] {phase-name}", project: "<project>", limit: 3})
+search({query: "[auto-output] {phase-name}", project: "<project>", limit: 3})
+```
+
+If fresh results found (< 2 hours): use the observation's summary as primary context. Skip redundant STATE.md / ROADMAP.md reads. If stale or absent: proceed with normal file reading.
+
+---
+
 ## Step -0.5: Past Context Check
 
-1. Derive project name from `.planning/PROJECT.md` name field (fall back to basename of cwd). Use this as the `project` parameter for all claude-mem calls.
+1. Derive project name consistently:
+```bash
+PROJECT_NAME=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || basename "$(pwd)")
+```
+Use `$PROJECT_NAME` as the `project` parameter for all claude-mem calls in this session.
 2. Call `search` with query=2-3 keywords from the phase/project domain, project=<project-name>, limit=10
 3. Scan the returned index for relevant IDs — prioritize types: gotcha, decision, trade-off
 4. For the top 2-3 relevant IDs, call `get_observations` to fetch full details
@@ -214,6 +248,21 @@ Hold these must_haves — they feed directly into the PLAN.md frontmatter and th
 | **Medium** | Create SPEC.md per @references/spec-creation-process.md (streamlined path). Present to user for approval before Step 5. |
 | **Complex** | Create SPEC.md per @references/spec-creation-process.md (full 5-step path, dispatches spec-architect agent). Present to user for approval before Step 5. |
 
+When dispatching the spec-architect agent, include tool instructions in the prompt:
+```
+## Tools Available
+Use claude-mem smart tools for codebase understanding:
+- `smart_outline({path})` — file structure without full read
+- `smart_unfold({path, symbol})` — extract one function
+- `smart_search({query})` — cross-codebase structural search
+
+Use ast-grep for structural code analysis:
+- `sg --pattern '<pattern>' --lang typescript src/`
+
+Use `smart_outline` on files in the bounded context before reading them fully.
+Use `smart_search` to find existing patterns when designing architecture sections.
+```
+
 Output: `.planning/phases/XX-name/XX-NN-SPEC.md`
 
 ---
@@ -234,6 +283,16 @@ Run plan-check protocol per @references/plan-check-protocol.md
 
 ---
 
+### Cross-Session Output
+
+Emit a structured observation for downstream skills:
+
+**[plan-work-output]** Phase {N}: Plan created at `{plan_path}`. Must-haves: {count} truths, {count} artifacts. Spec: {yes/no}. Decisions locked: {count}. Key files: {top 3 files_modified}.
+
+This observation is queryable by plan-review and build via `search({query: "[plan-work-output] phase {N}"})`, avoiding redundant file re-reads in auto flows.
+
+---
+
 ## Step 7: Handoff
 
 After plan approval:
@@ -249,7 +308,7 @@ After plan approval:
 
 ## Priority Hierarchy
 
-If context pressure is high: **Step 0** (phase matching) > **Step 3** (diagrams + failure modes) > **Step 5** (plan creation) > **Step 4** (must_haves) > **Step 2** (brainstorm) > **Step 1** (research). Never skip Step 0 or Step 5.
+Follow all steps. If a step produces no findings, move on quickly. Priority: **Step 0** (phase matching) > **Step 5** (plan creation) > **Step 3** (diagrams + failure modes) > **Step 4** (must_haves) > **Step 2** (brainstorm) > **Step 1** (research). Never skip Step 0 or Step 5.
 
 ---
 

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -10,7 +10,7 @@ Comprehensive code review — quality, architecture, spec verification, goal ver
 
 Context or flags: $ARGUMENTS
 
-You are a **lean orchestrator**. Stay under 15% context usage. Delegate all analysis to subagents.
+You are the **code review orchestrator**. Follow every step below — each one exists because skipping it caused real failures in past sessions. Delegate all analysis to subagents.
 
 **IMPORTANT:** This skill does NOT touch GSD state (STATE.md, ROADMAP.md). State updates are the caller's responsibility.
 
@@ -22,6 +22,23 @@ You are a **lean orchestrator**. Stay under 15% context usage. Delegate all anal
 |------|-----------|-------------|
 | *(default — full)* | All steps including Step 2.5 (Quality Refinement) | Deep scrutiny before promoting |
 | `--quick` | Steps 1, 1.5, 1.7, 1.8, 2, 3, 4, 5, 6, 7 — **skips Step 2.5** | Fast pre-commit sanity check |
+
+---
+
+## Step 0: Tool Readiness
+
+claude-mem tools are **deferred** — they must be fetched before they can be called. Do this first, before any other work.
+
+```
+ToolSearch("select:mcp__plugin_claude-mem_mcp-search__smart_search,mcp__plugin_claude-mem_mcp-search__smart_outline,mcp__plugin_claude-mem_mcp-search__smart_unfold,mcp__plugin_claude-mem_mcp-search__search,mcp__plugin_claude-mem_mcp-search__get_observations")
+```
+
+Also verify ast-grep CLI is available:
+```bash
+command -v sg &>/dev/null || command -v ast-grep &>/dev/null || echo "WARN: ast-grep not found"
+```
+
+**If ToolSearch returns empty for claude-mem:** Fall back to Read-based approach for this session.
 
 ---
 
@@ -70,7 +87,7 @@ node lib/sentry-local-query.mjs recent --minutes 120
 
 4. If `NO_STORE`: skip this step silently. Do not mention observability in the report.
 
-Budget: less than 2% context. Don't deep-dive errors — just surface file matches for the gap analysis agent.
+Don't deep-dive errors — just surface file matches for the gap analysis agent.
 
 ---
 
@@ -99,8 +116,6 @@ If non-empty, extract: affected modules, fan-out count, and any hub files in the
 
 If Codemap is NOT installed or command fails: fall back to grep-based blast radius estimation in Step 1. Skip silently.
 
-Budget: less than 1% context.
-
 ---
 
 ## Step 1.7: Static Analysis (if available)
@@ -123,7 +138,7 @@ If Fallow ran successfully and produced non-empty output, include it in the agen
 
 If fallow is NOT installed or all commands fail: skip silently. Do not mention Fallow in the report.
 
-Budget: less than 1% context. Fallow runs in <1 second.
+Fallow runs in <1 second.
 
 ---
 
@@ -175,11 +190,42 @@ Based on mode, dispatch parallel subagents. Each agent receives ONLY the diff + 
 - If Next.js: include `.claude/skills/nextjs-perf/PROMPT.md` criteria
 - **Note:** The production safety checklist has an explicit suppressions section — the subagent must honor it to reduce noise.
 
+**Tool instructions (include in agent prompt):**
+```
+## Code Navigation (claude-mem)
+- `smart_outline({path})` — file structure without full read (11-27x cheaper than Read)
+- `smart_unfold({path, symbol})` — extract one function (never truncates)
+- `smart_search({query})` — cross-codebase structural search by intent
+- `search({query, project})` + `get_observations({ids})` — prior decisions, gotchas
+
+## Structural Analysis (ast-grep)
+- `sg --pattern '<pattern>' --lang typescript src/` — structural code search
+- Prefer over Grep for code-aware matching (ignores comments, strings)
+
+Use `Read` only for files you need detailed analysis of.
+```
+
 **Agent 2 — Gap Analysis** (`subagent_type: "fh:code-reviewer"`)
 - Prompt: gap analysis section of `skills/review/references/review-prompt.md`
 - Input: full diff
 - If Fallow data is available from Step 1.7, include the `FALLOW_CHECK` unused-exports findings in the agent prompt
 - Covers: untested code paths, unhandled error states, incomplete features (TODO/FIXME/PLACEHOLDER), missing edge cases, API contract gaps
+- Project name for claude-mem queries: {project_name} (derived from git rev-parse --show-toplevel | xargs basename)
+
+**Tool instructions (include in agent prompt):**
+```
+## Code Navigation (claude-mem)
+- `smart_outline({path})` — file structure without full read (11-27x cheaper than Read)
+- `smart_unfold({path, symbol})` — extract one function (never truncates)
+- `smart_search({query})` — cross-codebase structural search by intent
+- `search({query, project})` + `get_observations({ids})` — prior decisions, gotchas
+
+## Structural Analysis (ast-grep)
+- `sg --pattern '<pattern>' --lang typescript src/` — structural code search
+- Prefer over Grep for code-aware matching (ignores comments, strings)
+
+Use `Read` only for files you need detailed analysis of.
+```
 
 For security vulnerability detection, dispatch the `fh:design-secure` agent or configure a pre-PR hook (see `/fh:setup`).
 
@@ -191,54 +237,39 @@ For security vulnerability detection, dispatch the `fh:design-secure` agent or c
 
 ---
 
-## Step 2.5: Quality Refinement (full mode only)
+## Step 2.5: Quality Refinement (direct dispatch)
 
-**Triage findings from Steps 2 and dispatch sub-skills as needed.**
+**Full mode only.** Skip entirely in `--quick` mode.
 
-This step runs only in full mode (not `--quick`). Skip entirely in `--quick` mode.
+After Agent 1 and Agent 2 findings are collected, check the trigger table. Dispatch sub-skills **directly** — no intermediate intermediary agent.
 
-### a. Evaluate findings against the trigger table
-
-After Agent 1 (Code Quality) and Agent 2 (Gap Analysis) return, evaluate each finding category:
-
-| Finding pattern | Agent | Trigger condition |
-|---|---|---|
-| DRY violations, code duplication, redundant patterns | `fh:design-simplify` | 2+ DRY/duplication findings |
-| Unhandled error paths, missing edge cases, brittle patterns | `fh:design-harden` | Any unhandled error path in changed code |
-| Cross-device/responsive issues, accessibility gaps | `fh:design-adapt` | Frontend files changed + accessibility/responsive findings |
-| Design system drift, inconsistent tokens/spacing | `fh:design-normalize` | Frontend files + design system defined in DESIGN.md |
-| Visual quality issues, layout problems, AI slop | `/fh:ui-critique` | Visual file ratio > 30% OR explicit UI concerns in findings |
+| Finding Pattern | Sub-skill to dispatch | Trigger threshold |
+|----------------|----------------------|-------------------|
+| DRY violations, code duplication | `fh:design-simplify` | 2+ duplication findings |
+| Unhandled error paths, missing edge cases | `fh:design-harden` | 2+ unhandled error findings |
+| Inconsistent patterns, non-standard code | `fh:design-normalize` | 3+ consistency findings |
+| Cross-device/responsive issues | `fh:design-adapt` | Any responsive finding |
+| Visual quality, AI slop, layout problems | `/fh:ui-critique` | Visual file ratio > 30% OR explicit UI concerns |
 | Final polish pass | `fh:design-polish` | Only after other agents ran AND findings remain |
 
-If **no findings trigger any sub-skill**: skip to Step 3 entirely. Most reviews won't need this step.
+**Dispatch each triggered sub-skill directly:**
 
-### b. Dispatch a single "quality-refine" subagent
+```
+Agent({
+  subagent_type: "fh:design-simplify",  // or whichever sub-skill triggered
+  prompt: "Review and fix the following issues in the changed files:\n\n{filtered_findings}\n\nChanged files:\n{file_list}\n\n## Tools\nUse smart_outline to understand file structure before editing.\nUse smart_unfold to read specific functions.\nUse ast-grep (sg) for structural transforms across files.\n\nScope: only touch files in the changed set. Do not commit."
+})
+```
 
-If any trigger condition is met, dispatch **one** `quality-refine` subagent (general-purpose). Do NOT dispatch N sequential inline agent calls.
+- Dispatch triggered sub-skills **sequentially** (each may modify files the next needs to read)
+- If no findings trigger any sub-skill: skip Step 2.5 entirely
+- Each sub-skill reports: files changed, what was improved, any new concerns
+- Timeout: 3 minutes per sub-skill. If exceeded, log warning and continue
 
-The subagent receives:
-- Findings from Agent 1 and Agent 2 (verbatim)
-- The trigger table above
-- The changed file list (from Step 1)
-- Project name (so subagent can call `mcp__plugin_claude-mem_mcp-search__smart_search` for cross-session pattern detection)
+### Performance checks (conditional)
 
-The subagent:
-1. Decides which agents to apply based on findings and the trigger table
-2. Dispatches triggered agents (`subagent_type: "fh:design-{name}"`) **in sequence**, scoped to changed files only — not the whole codebase
-3. Reports back with: which agents ran, what was changed, any remaining issues
-
-### c. Performance checks (conditional)
-
-- If Next.js project detected (Step 1) AND performance-related findings: reference `.claude/skills/nextjs-perf/PROMPT.md` criteria
-- If frontend changes AND significant bundle/render concerns: suggest `/fh:ui-test` for visual verification
-
-### d. Cross-session pattern detection
-
-Use **Pattern A** from `shared/claude-mem-rules.md` to check if the same quality issues were flagged in prior reviews. Keywords: each triggered sub-skill category + primary module name. If a pattern recurs 3+ times: escalate severity (Minor → Important, Important → Critical) and annotate "⚠ Recurring pattern (seen N times)". Pass recurring-pattern context to the quality-refine subagent.
-
-### e. Failure handling
-
-If the quality-refine subagent times out or fails: log a warning ("Quality refinement skipped: subagent timeout/error") and continue to Step 3. Do NOT block the review.
+- If Next.js project detected AND performance-related findings: reference `.claude/skills/nextjs-perf/PROMPT.md`
+- If frontend changes AND significant bundle/render concerns: suggest `/fh:ui-test`
 
 ---
 
@@ -434,6 +465,12 @@ Derive the type and scope from the diff analysis. Present options:
 ### Persist Findings
 
 Follow **Pattern D** (Persist Findings) from `shared/claude-mem-rules.md`. Use tag `[review-learning]`.
+
+---
+
+### Cross-Session Output
+
+**[review-output]** Phase {N}: Gate={PASS/WARN/BLOCK}. Findings: {critical_count} critical, {important_count} important. Files reviewed: {count}. Test results: {pass/fail}.
 
 ---
 

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -30,7 +30,7 @@ You are the **code review orchestrator**. Follow every step below — each one e
 claude-mem tools are **deferred** — they must be fetched before they can be called. Do this first, before any other work.
 
 ```
-ToolSearch("select:mcp__plugin_claude-mem_mcp-search__smart_search,mcp__plugin_claude-mem_mcp-search__smart_outline,mcp__plugin_claude-mem_mcp-search__smart_unfold,mcp__plugin_claude-mem_mcp-search__search,mcp__plugin_claude-mem_mcp-search__get_observations")
+ToolSearch("+mcp-search", max_results: 10)
 ```
 
 Also verify ast-grep CLI is available:

--- a/.claude/skills/shared/claude-mem-rules.md
+++ b/.claude/skills/shared/claude-mem-rules.md
@@ -32,15 +32,17 @@ Smart tools are 11-27x cheaper than Read. Use `smart_outline` before reading any
 
 ## Tool Expectations
 
-claude-mem, ast-grep, and bun are **manifest-required** tools — they are declared in `plugin.json` and expected to be present in every session. Skills do not guard for their absence.
+claude-mem, ast-grep, and bun are **manifest-required** tools — they are declared in `plugin.json` and expected to be present in every session.
+
+**Important:** claude-mem MCP tools are **deferred** — their schemas must be fetched via `ToolSearch` before they can be called. Every skill that uses claude-mem must include a Step 0: Tool Readiness block:
 
 ```
-claude-mem tools (mcp__plugin_claude-mem_*): expected, not guarded
-ast-grep: expected, not guarded
-bun: expected, not guarded
+ToolSearch("select:mcp__plugin_claude-mem_mcp-search__smart_search,mcp__plugin_claude-mem_mcp-search__smart_outline,mcp__plugin_claude-mem_mcp-search__smart_unfold,mcp__plugin_claude-mem_mcp-search__search,mcp__plugin_claude-mem_mcp-search__get_observations")
 ```
 
-Use these tools directly. Do not add `if available` checks, `try/catch` guards, or fallback paths for manifest-required tools. They are part of the contract, not optional enhancements.
+If ToolSearch returns empty, fall back to Read-based approach. Do not add `if available` guards for these tools — they are part of the contract. The ToolSearch step is the guard.
+
+ast-grep and bun are directly available (not deferred) — no ToolSearch needed.
 
 ## Patterns
 
@@ -62,7 +64,7 @@ Run at the start of any skill that investigates, plans, or builds. Surfaces prio
 7. Feed into the skill's next step as input context
 ```
 
-Budget: <2% context. Skip silently if no relevant results.
+Max 3 items. Skip silently if no relevant results.
 
 ---
 
@@ -103,7 +105,7 @@ Before dispatching a new researcher agent, check if prior research exists:
 2. If relevant research found from recent session (within 7 days): present findings, ask "Prior research found — reuse or re-research?"
 3. If reused: skip researcher dispatch, feed existing findings into brainstorm/spec
 4. New research findings are auto-indexed by PostToolUse hook — tagged with [research-finding]
-Budget: <1% context for the check. Skip silently if no results.
+Skip silently if no results.
 ```
 
 ---
@@ -129,7 +131,7 @@ Query by **intent** (what you need), not by file path (where it lives). Resolves
 4. If relevant observations found (within 7 days): use as primary input
    If observations are stale or absent: fall back to artifact-resolution.md chain
 
-5. Budget: <2% context. Skip silently if no results.
+5. Skip silently if no results.
 ```
 
 **Tag priority hierarchy** (highest → lowest value per token):
@@ -173,7 +175,28 @@ Load SPEC.md sections on demand via `smart_unfold` instead of reading the full f
    Never fail — the implementer-prompt guards empty placeholders.
 ```
 
-Budget: 1-3 sections per task dispatch. Never load the whole SPEC.md at once unless the task explicitly requires full spec review.
+Load 1-3 sections per task dispatch. Never load the whole SPEC.md at once unless the task explicitly requires full spec review.
+
+---
+
+### Pattern H: Cross-Session Pipeline Cache
+
+When a skill completes, it emits a structured observation (Pattern D) with a skill-specific tag. The next skill in the pipeline queries for this tag before re-reading planning files.
+
+```
+1. At skill exit, emit: **[{skill}-output]** {structured summary of outputs}
+   Tags: [plan-work-output], [plan-review-output], [build-output], [review-output], [fix-output], [auto-output]
+
+2. At skill entry (after Step 0), query for prior skill output:
+   search({query: "[prior-skill-output] {phase-name}", project, limit: 3})
+
+3. If fresh result found (< 2 hours old): use as primary input, skip redundant file reads
+   If stale or absent: fall back to normal file reading
+
+4. Budget: 1 search call. Skip silently if no results.
+```
+
+This eliminates redundant STATE.md / ROADMAP.md / CONTEXT.md reads in auto flows where plan-work → plan-review → build → review execute sequentially.
 
 ---
 

--- a/.claude/skills/shared/claude-mem-rules.md
+++ b/.claude/skills/shared/claude-mem-rules.md
@@ -37,7 +37,7 @@ claude-mem, ast-grep, and bun are **manifest-required** tools — they are decla
 **Important:** claude-mem MCP tools are **deferred** — their schemas must be fetched via `ToolSearch` before they can be called. Every skill that uses claude-mem must include a Step 0: Tool Readiness block:
 
 ```
-ToolSearch("select:mcp__plugin_claude-mem_mcp-search__smart_search,mcp__plugin_claude-mem_mcp-search__smart_outline,mcp__plugin_claude-mem_mcp-search__smart_unfold,mcp__plugin_claude-mem_mcp-search__search,mcp__plugin_claude-mem_mcp-search__get_observations")
+ToolSearch("+mcp-search", max_results: 10)
 ```
 
 If ToolSearch returns empty, fall back to Read-based approach. Do not add `if available` guards for these tools — they are part of the contract. The ToolSearch step is the guard.

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__/
 fhhs-skills-workspace/full-run-*/
 fhhs-skills-workspace/auto-improve/iteration-*/
 .claude/skills/*/CLAUDE.md
+.planning/build/
+.planning/.auto-state.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ Entries affecting `/fh:setup` or `/fh:new-project` environment carry reconciliat
 
 ## [Unreleased]
 
+## [1.65.0] - 2026-04-07
+
+### Added
+- **Auto-orchestrator shared library** — 6 reusable CJS modules in `.claude/skills/auto/lib/` for task dispatch, context injection, wave analysis, verification, and summary generation
+- **2-layer direct dispatch** — auto-orchestrator build step dispatches per-task `claude -p` sessions directly instead of invoking `/fh:build`, eliminating 3rd nesting layer that caused the Prague incident
+- **Process group kill** — `detached: true` with `process.kill(-pid)` for reliable termination of task sessions and all subprocesses
+- **Checkpoint-before-spawn** — intent checkpoints before each task dispatch enable crash recovery and task-level resume on restart
+- **Phase & task state machines** — formal lifecycle states (12 phase states, 6 task states) with validated transitions, retry logic, and legacy state migration
+- **15 new evals** — orchestrator evals covering shared lib, direct dispatch, process resilience, state machine, and documentation compliance
+
+### Changed
+- **ToolSearch preamble simplified** — `ToolSearch("+mcp-search", max_results: 10)` replaces verbose 300-char `select:` string across all skills
+- **Build skill interactive-only** — removed auto-mode code paths (`auto_advance` checks, auto-approve checkpoints), added shared lib cross-references
+- **Auto skill documentation** — documents 2-layer architecture, state machine lifecycles, and shared library modules
+- **Implementer prompt** — adds smart tool discovery instructions (smart_outline, smart_unfold, smart_search)
+- **Plan-review parallel agents** — scope and engineering review run as parallel subagents
+- **Review Step 2.5 flattened** — direct sub-skill dispatch instead of intermediary agent
+
 ## [1.64.0] - 2026-04-06
 
 ### Added

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -16870,6 +16870,407 @@
         "wave-analysis"
       ],
       "tier": "smoke"
+    },
+    {
+      "id": 460,
+      "command": "auto",
+      "prompt": "When auto-orchestrator runs a build step on a plan with XML tasks, it should use direct dispatch (dispatchTask) instead of invoking /fh:build",
+      "expected_output": "Should confirm the orchestrator's build step uses parseWaves to parse the plan, then calls buildTaskPrompt and dispatchTask for each task rather than spawning a /fh:build session. Direct dispatch eliminates the middle layer in auto mode.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Uses direct dispatch via dispatchTask",
+          "type": "behavioral"
+        },
+        {
+          "text": "Calls parseWaves and buildTaskPrompt",
+          "type": "behavioral"
+        },
+        {
+          "text": "Does NOT invoke /fh:build as the primary path for parseable plans",
+          "type": "guard"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "Direct dispatch|dispatchTask"
+        },
+        {
+          "type": "regex",
+          "pattern": "parseWaves|buildTaskPrompt"
+        },
+        {
+          "type": "regex",
+          "pattern": "wave|task.*dispatch|parallel"
+        }
+      ],
+      "tags": [
+        "auto",
+        "orchestrator",
+        "direct-dispatch"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 461,
+      "command": "auto",
+      "prompt": "When auto-orchestrator encounters a plan it cannot parse for direct dispatch, it falls back to invoking /fh:build via runClaudeSession",
+      "expected_output": "Should confirm the orchestrator catches parseWaves errors and logs a fallback message, then calls runClaudeSession with /fh:build. The fallback also triggers when no task waves are found in the plan.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Falls back to runClaudeSession on parse failure",
+          "type": "behavioral"
+        },
+        {
+          "text": "Logs a fallback message",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "falling back|fallback"
+        },
+        {
+          "type": "regex",
+          "pattern": "fh:build|runClaudeSession"
+        },
+        {
+          "type": "regex",
+          "pattern": "parseWaves|parseable"
+        }
+      ],
+      "tags": [
+        "auto",
+        "orchestrator",
+        "fallback"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 462,
+      "command": "auto",
+      "prompt": "After each task dispatch, the orchestrator writes a sidecar result JSON file to .planning/build/",
+      "expected_output": "Should confirm the orchestrator creates .planning/build/ with recursive mkdir, writes task-{planNum}-{taskId}-result.json after each task containing taskName, success, stdout (first 500 chars), stderr (first 200 chars), metrics, and error. Stale result files for the plan are cleaned up at build start.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Writes sidecar result JSON to .planning/build/",
+          "type": "behavioral"
+        },
+        {
+          "text": "Cleans stale result files at build start",
+          "type": "behavioral"
+        },
+        {
+          "text": "Creates .planning/build/ directory if missing",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "result\\.json|sidecar"
+        },
+        {
+          "type": "regex",
+          "pattern": "writeFileSync|task-"
+        },
+        {
+          "type": "regex",
+          "pattern": "planning/build|buildDir"
+        }
+      ],
+      "tags": [
+        "auto",
+        "orchestrator",
+        "sidecar"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 463,
+      "name": "auto-process-group-kill",
+      "command": "auto",
+      "prompt": "Task dispatch uses detached process groups and kills via process.kill(-pid) for reliable termination",
+      "expected_output": "Should confirm that task-dispatch.cjs spawns claude with detached: true and kills processes via process.kill(-child.pid, signal) to target the entire process group, ensuring subprocesses are terminated and not orphaned.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Spawns with detached: true for process group isolation",
+          "type": "behavioral"
+        },
+        {
+          "text": "Kills via process.kill(-pid) to target process group",
+          "type": "behavioral"
+        },
+        {
+          "text": "Uses SIGTERM then SIGKILL with grace period",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "detached.*true|process\\.kill\\(-"
+        },
+        {
+          "type": "regex",
+          "pattern": "SIGKILL|SIGTERM"
+        },
+        {
+          "type": "regex",
+          "pattern": "process group|orphan|detached"
+        }
+      ],
+      "tags": [
+        "auto",
+        "orchestrator",
+        "process-kill"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 464,
+      "name": "auto-checkpoint-before-spawn",
+      "command": "auto",
+      "prompt": "Orchestrator writes intent checkpoint before dispatching each task, enabling crash recovery",
+      "expected_output": "Should confirm that before calling dispatchTask, the orchestrator writes a checkpoint JSON file with status 'dispatched' to .planning/build/{taskId}-checkpoint.json, then updates it with final status and metrics after completion.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Writes checkpoint file before dispatch with status 'dispatched'",
+          "type": "behavioral"
+        },
+        {
+          "text": "Updates checkpoint after completion with final status and metrics",
+          "type": "behavioral"
+        },
+        {
+          "text": "Checkpoint file named {taskId}-checkpoint.json in .planning/build/",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "checkpoint|dispatched"
+        },
+        {
+          "type": "regex",
+          "pattern": "writeFileSync|checkpoint\\.json"
+        },
+        {
+          "type": "regex",
+          "pattern": "dispatchedAt|completedAt"
+        }
+      ],
+      "tags": [
+        "auto",
+        "orchestrator",
+        "checkpoint"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 465,
+      "name": "auto-task-resume",
+      "command": "auto",
+      "prompt": "On resume, orchestrator skips tasks already marked completed in checkpoint files",
+      "expected_output": "Should confirm that at build step start the orchestrator scans .planning/build/ for existing *-checkpoint.json files, and before dispatching each task checks if it is already completed, skipping it with a log message if so.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Scans .planning/build/ for existing checkpoint files at build start",
+          "type": "behavioral"
+        },
+        {
+          "text": "Skips tasks with status 'completed' in checkpoint, logging a resume message",
+          "type": "behavioral"
+        },
+        {
+          "text": "Returns success:true with skipped:true for resumed tasks",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "already completed|skipped"
+        },
+        {
+          "type": "regex",
+          "pattern": "checkpoint|resume"
+        },
+        {
+          "type": "regex",
+          "pattern": "existingCheckpoints|checkpoint\\.json"
+        }
+      ],
+      "tags": [
+        "auto",
+        "orchestrator",
+        "resume"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 466,
+      "name": "auto-phase-state-machine",
+      "command": "auto",
+      "prompt": "Phase lifecycle follows formal state machine with validated transitions",
+      "expected_output": "Should confirm that auto-orchestrator.cjs defines PHASE_TRANSITIONS with all phase states and uses transitionPhase() to validate each state change, including failure states like plan-failed and build-failed.",
+      "files": [],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "PHASE_TRANSITIONS|transitionPhase"
+        },
+        {
+          "type": "regex",
+          "pattern": "plan-failed|build-failed"
+        },
+        {
+          "type": "regex",
+          "pattern": "Invalid phase transition|Unknown phase state"
+        }
+      ],
+      "tags": [
+        "auto",
+        "orchestrator",
+        "state-machine"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 467,
+      "name": "auto-task-state-machine",
+      "command": "auto",
+      "prompt": "Task lifecycle follows formal state machine with retry transitions",
+      "expected_output": "Should confirm that auto-orchestrator.cjs defines TASK_TRANSITIONS with all task states and uses transitionTask() to validate each state change, including timed-out and queued retry states.",
+      "files": [],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "TASK_TRANSITIONS|transitionTask"
+        },
+        {
+          "type": "regex",
+          "pattern": "timed-out|queued"
+        },
+        {
+          "type": "regex",
+          "pattern": "Invalid task transition|Unknown task state"
+        }
+      ],
+      "tags": [
+        "auto",
+        "orchestrator",
+        "state-machine"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 468,
+      "name": "auto-state-driven-loop",
+      "command": "auto",
+      "prompt": "Main loop is driven by state machine transitions, not a fixed step array",
+      "expected_output": "Should confirm that the sequential phase loop in auto-orchestrator.cjs uses STATE_TO_STEP and MAX_PHASE_TRANSITIONS to drive execution, and that migratePhaseState and updatePhaseState are used for legacy state compatibility and persistence.",
+      "files": [],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "STATE_TO_STEP|MAX_PHASE_TRANSITIONS"
+        },
+        {
+          "type": "regex",
+          "pattern": "migratePhaseState|updatePhaseState"
+        },
+        {
+          "type": "regex",
+          "pattern": "phase_states|transitionCount"
+        }
+      ],
+      "tags": [
+        "auto",
+        "orchestrator",
+        "state-machine"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 469,
+      "name": "build-interactive-only",
+      "command": "build",
+      "prompt": "Build skill focuses on interactive use, no auto-mode conditionals",
+      "expected_output": "Should confirm that the build skill is focused on interactive use and dispatches via Agent tool, without auto-mode workflow conditionals.",
+      "files": [],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "interactive build|interactive use"
+        },
+        {
+          "type": "regex",
+          "pattern": "Agent tool|subagent"
+        }
+      ],
+      "tags": [
+        "build",
+        "orchestrator",
+        "interactive"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 470,
+      "name": "auto-2layer-documented",
+      "command": "auto",
+      "prompt": "Auto skill documents the 2-layer direct dispatch architecture",
+      "expected_output": "Should confirm that the auto skill SKILL.md describes the 2-layer architecture with orchestrator and task session layers, and direct dispatch via claude -p.",
+      "files": [],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "2-[Ll]ayer|2 layer"
+        },
+        {
+          "type": "regex",
+          "pattern": "direct dispatch|Direct [Dd]ispatch"
+        }
+      ],
+      "tags": [
+        "auto",
+        "orchestrator",
+        "documentation"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 471,
+      "name": "implementer-prompt-smart-tools",
+      "command": "build",
+      "prompt": "Implementer prompt includes smart tool discovery instructions",
+      "expected_output": "Should confirm that the implementer-prompt.md reference file includes smart tool discovery instructions with smart_outline, smart_unfold, and smart_search.",
+      "files": [],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "smart_outline|smart_unfold"
+        },
+        {
+          "type": "regex",
+          "pattern": "smart_search|code.*discovery"
+        }
+      ],
+      "tags": [
+        "build",
+        "orchestrator",
+        "smart-tools"
+      ],
+      "tier": "smoke"
     }
   ]
 }

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -15284,7 +15284,7 @@
       "files": [],
       "assertions": [
         {
-          "text": "Does NOT skip brainstorm for Simple task — presents at least one alternative approach",
+          "text": "Does NOT skip brainstorm for Simple task \u2014 presents at least one alternative approach",
           "type": "guard"
         },
         {
@@ -15297,7 +15297,10 @@
         }
       ],
       "tier": "smoke",
-      "tags": ["engagement", "brainstorm"],
+      "tags": [
+        "engagement",
+        "brainstorm"
+      ],
       "checks": [
         {
           "type": "regex",
@@ -15335,7 +15338,10 @@
         }
       ],
       "tier": "smoke",
-      "tags": ["engagement", "spec"],
+      "tags": [
+        "engagement",
+        "spec"
+      ],
       "checks": [
         {
           "type": "regex",
@@ -15391,6 +15397,1380 @@
           "pattern": "warn|missing|\u26a0|not.found"
         }
       ]
+    },
+    {
+      "id": 426,
+      "command": "build",
+      "prompt": "Build the dashboard plan at .planning/phases/02-dashboard/02-01-PLAN.md. It has 3 tasks in 2 waves.",
+      "expected_output": "Should start with Step 0 (Tool Readiness) by fetching claude-mem deferred tools via ToolSearch. Then use claude-mem search/smart_search to find planning context before reading files. Reference Warm-Up should use smart_outline on testing-guide. Subagent prompts must use the inlined template with Tool Decision Tree (ast-grep), Code Navigation (smart_outline, smart_unfold, smart_search), and Deviation Rules. After waves complete, read finalize-build.md for post-build steps.",
+      "files": [
+        "evals/fixtures/nextjs-app-deep/.planning/PROJECT.md",
+        "evals/fixtures/nextjs-app-deep/.planning/STATE.md",
+        "evals/fixtures/nextjs-app-deep/.planning/ROADMAP.md",
+        "evals/fixtures/nextjs-app-deep/.planning/phases/02-dashboard/02-01-PLAN.md",
+        "evals/fixtures/nextjs-app-deep/.planning/codebase/CONVENTIONS.md",
+        "evals/fixtures/nextjs-app-deep/.planning/codebase/STRUCTURE.md"
+      ],
+      "assertions": [
+        {
+          "text": "Step 0: Fetches claude-mem deferred tools via ToolSearch before any other work",
+          "type": "behavioral"
+        },
+        {
+          "text": "Uses claude-mem search or smart_search for context loading before file reads",
+          "type": "behavioral"
+        },
+        {
+          "text": "Reference Warm-Up uses smart_outline on testing guide",
+          "type": "behavioral"
+        },
+        {
+          "text": "Subagent prompts contain Tool Decision Tree with ast-grep",
+          "type": "behavioral"
+        },
+        {
+          "text": "Subagent prompts contain Code Navigation section with smart_outline/smart_unfold/smart_search",
+          "type": "behavioral"
+        },
+        {
+          "text": "Subagent prompts contain Deviation Rules table",
+          "type": "behavioral"
+        },
+        {
+          "text": "References finalize-build.md for post-build steps",
+          "type": "behavioral"
+        }
+      ],
+      "scenario_requires": [
+        "gsd_project"
+      ],
+      "tier": "smoke",
+      "tags": [
+        "fixture-required",
+        "happy-path",
+        "claude-mem",
+        "tool-compliance"
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "ToolSearch|tool.?readiness|fetch.*deferred|deferred.*tool"
+        },
+        {
+          "type": "regex",
+          "pattern": "smart_search|smart_outline|smart_unfold|claude.?mem"
+        },
+        {
+          "type": "regex",
+          "pattern": "Tool Decision Tree|ast.?grep|\bsg\b.*structural"
+        },
+        {
+          "type": "regex",
+          "pattern": "Code Navigation|smart_outline|smart_unfold"
+        },
+        {
+          "type": "regex",
+          "pattern": "Deviation|deviation|Rule 1|Rule 4|template.*verbatim|Subagent Prompt Template"
+        },
+        {
+          "type": "regex",
+          "pattern": "finalize.?build"
+        }
+      ]
+    },
+    {
+      "id": 427,
+      "command": "build",
+      "prompt": "build the plan. it has 5 tasks: task 1 renames getUserById to findUserById across 8 files, task 2 extracts a shared validation module from 4 duplicated files, task 3 adds a new API endpoint, task 4 writes tests, task 5 updates docs",
+      "expected_output": "Should detect that tasks 1 and 2 involve multi-file structural changes (rename across 8 files, extract from 4 files) and add ast-grep tool hints to those task prompts. Tasks 3-5 are single-file or non-structural and should NOT get the ast-grep hint. All subagent prompts should use the inlined template with Tool Decision Tree, not ad-hoc prompts.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Detects task 1 (rename across 8 files) as ast-grep candidate and adds tool hint",
+          "type": "behavioral"
+        },
+        {
+          "text": "Detects task 2 (extract from 4 files) as ast-grep candidate and adds tool hint",
+          "type": "behavioral"
+        },
+        {
+          "text": "All subagent prompts use the template (contain Tool Decision Tree)",
+          "type": "behavioral"
+        },
+        {
+          "text": "Does not write ad-hoc code-snippet prompts without template structure",
+          "type": "guard"
+        }
+      ],
+      "scenario_requires": [
+        "gsd_project"
+      ],
+      "tier": "smoke",
+      "tags": [
+        "happy-path",
+        "ast-grep",
+        "tool-compliance"
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "ast.?grep|\bsg\b|structural.?transform"
+        },
+        {
+          "type": "regex",
+          "pattern": "Tool.?hint|multi.?file.?structural|rename.*ast.?grep|extract.*ast.?grep"
+        },
+        {
+          "type": "regex",
+          "pattern": "Tool Decision Tree|template.*verbatim|Subagent Prompt Template|ast.?grep.*hint"
+        }
+      ]
+    },
+    {
+      "id": 428,
+      "command": "build",
+      "prompt": "Build the dashboard plan at .planning/phases/02-dashboard/02-01-PLAN.md",
+      "expected_output": "Should NOT read source files directly as orchestrator. Should use smart_search/smart_outline for context gathering, not raw Read/Grep/Glob on source code. Context loading uses claude-mem patterns (search by intent, not file path). Subagent prompts are filled from the inlined template, not written from scratch.",
+      "files": [
+        "evals/fixtures/nextjs-app-deep/.planning/PROJECT.md",
+        "evals/fixtures/nextjs-app-deep/.planning/STATE.md",
+        "evals/fixtures/nextjs-app-deep/.planning/phases/02-dashboard/02-01-PLAN.md"
+      ],
+      "assertions": [
+        {
+          "text": "Uses smart tools (smart_search, smart_outline, smart_unfold) for context gathering",
+          "type": "behavioral"
+        },
+        {
+          "text": "Does not read source .ts/.tsx files directly as orchestrator",
+          "type": "guard"
+        },
+        {
+          "text": "Subagent prompts use template placeholders ({TASK_TEXT}, {CLAUDE_MD_SECTIONS}, etc)",
+          "type": "behavioral"
+        }
+      ],
+      "scenario_requires": [
+        "gsd_project"
+      ],
+      "tier": "smoke",
+      "tags": [
+        "fixture-required",
+        "happy-path",
+        "claude-mem",
+        "context-efficiency"
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "smart_search|smart_outline|smart_unfold"
+        },
+        {
+          "type": "regex",
+          "pattern": "TASK_TEXT|CLAUDE_MD_SECTIONS|DESIGN_DECISIONS|PROJECT_CONSTRAINTS|SHARED_REFERENCES"
+        },
+        {
+          "type": "forbidden_terms",
+          "terms": [
+            "Read src/",
+            "reading src/",
+            "cat src/"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 429,
+      "command": "build",
+      "prompt": "build the plan at .planning/phases/02-dashboard/02-01-PLAN.md. The plan has a spec: field pointing to a SPEC.md with Architecture and Failure Modes sections.",
+      "expected_output": "Should use smart_unfold to load SPEC.md sections (Architecture, Failure Modes, Quality Rubrics, Data Flow) instead of reading the whole file. Should map to placeholders SPEC_ARCHITECTURE, SPEC_FAILURE_MODES etc. Should query claude-mem for past mistakes via smart_search before dispatching.",
+      "files": [
+        "evals/fixtures/nextjs-app-deep/.planning/PROJECT.md",
+        "evals/fixtures/nextjs-app-deep/.planning/STATE.md",
+        "evals/fixtures/nextjs-app-deep/.planning/phases/02-dashboard/02-01-PLAN.md"
+      ],
+      "assertions": [
+        {
+          "text": "Uses smart_unfold to load SPEC.md sections, not full Read",
+          "type": "behavioral"
+        },
+        {
+          "text": "Maps SPEC sections to placeholders (SPEC_ARCHITECTURE, SPEC_FAILURE_MODES)",
+          "type": "behavioral"
+        },
+        {
+          "text": "Queries claude-mem for past mistakes before dispatching",
+          "type": "behavioral"
+        }
+      ],
+      "scenario_requires": [
+        "gsd_project"
+      ],
+      "tier": "smoke",
+      "tags": [
+        "fixture-required",
+        "happy-path",
+        "claude-mem",
+        "spec-loading"
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "smart_unfold.*Architecture|smart_unfold.*Failure"
+        },
+        {
+          "type": "regex",
+          "pattern": "SPEC_ARCHITECTURE|SPEC_FAILURE_MODES"
+        },
+        {
+          "type": "regex",
+          "pattern": "past.?mistakes|build.?learning|smart_search.*mistakes"
+        }
+      ]
+    },
+    {
+      "id": 430,
+      "command": "build",
+      "prompt": "build the plan. It has 2 tasks: task 1 adds a new component, task 2 adds an API route. Both are single-file changes.",
+      "expected_output": "Should populate conventions context (Step 2e) by routing task types: UI task gets CONVENTIONS.md + STRUCTURE.md, API task gets ARCHITECTURE.md + CONVENTIONS.md. Should do Reference Warm-Up (Step 2b) with smart_outline on testing-guide.md once, then reuse across both subagent prompts. Should populate {PROJECT_CONSTRAINTS} from CLAUDE.md Gotchas section (Step 2d).",
+      "files": [
+        "evals/fixtures/nextjs-app-deep/.planning/PROJECT.md",
+        "evals/fixtures/nextjs-app-deep/.planning/STATE.md",
+        "evals/fixtures/nextjs-app-deep/.planning/codebase/CONVENTIONS.md",
+        "evals/fixtures/nextjs-app-deep/.planning/codebase/STRUCTURE.md",
+        "evals/fixtures/nextjs-app-deep/.planning/codebase/ARCHITECTURE.md"
+      ],
+      "assertions": [
+        {
+          "text": "Routes UI task to CONVENTIONS + STRUCTURE, API task to ARCHITECTURE + CONVENTIONS",
+          "type": "behavioral"
+        },
+        {
+          "text": "Reference Warm-Up uses smart_outline on testing-guide once and reuses",
+          "type": "behavioral"
+        },
+        {
+          "text": "Populates PROJECT_CONSTRAINTS from CLAUDE.md Gotchas",
+          "type": "behavioral"
+        }
+      ],
+      "scenario_requires": [
+        "gsd_project"
+      ],
+      "tier": "smoke",
+      "tags": [
+        "happy-path",
+        "context-routing",
+        "tool-compliance"
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "CONVENTIONS|STRUCTURE|ARCHITECTURE"
+        },
+        {
+          "type": "regex",
+          "pattern": "smart_outline.*testing|Reference Warm|warm.?up"
+        },
+        {
+          "type": "regex",
+          "pattern": "PROJECT_CONSTRAINTS|Gotchas|constraints"
+        }
+      ]
+    },
+    {
+      "id": 431,
+      "command": "build",
+      "prompt": "Build the dashboard plan at .planning/phases/02-dashboard/02-01-PLAN.md. Task 1 modifies src/components/sidebar.tsx, src/app/page.tsx, src/app/layout.tsx. Task 2 modifies src/components/metric-card.tsx, src/components/chart-widget.tsx, src/app/page.tsx. Task 3 creates src/app/api/sse/route.ts and src/hooks/use-sse.ts.",
+      "expected_output": "Should pre-load file outlines using smart_outline for each task file before dispatching. For existing files (sidebar.tsx, page.tsx, layout.tsx, metric-card.tsx, chart-widget.tsx), run smart_outline to get function/export signatures. For new files (sse/route.ts, use-sse.ts), skip outline (file does not exist). Should trace imports/references for modified files to build impact context \u2014 e.g., find what imports sidebar.tsx or page.tsx. Inject FILE_OUTLINES and IMPACT_CONTEXT into subagent prompts.",
+      "files": [
+        "evals/fixtures/nextjs-app-deep/.planning/PROJECT.md",
+        "evals/fixtures/nextjs-app-deep/.planning/STATE.md",
+        "evals/fixtures/nextjs-app-deep/.planning/phases/02-dashboard/02-01-PLAN.md",
+        "evals/fixtures/nextjs-app-deep/src/components/sidebar.tsx",
+        "evals/fixtures/nextjs-app-deep/src/app/page.tsx",
+        "evals/fixtures/nextjs-app-deep/src/app/layout.tsx",
+        "evals/fixtures/nextjs-app-deep/src/components/metric-card.tsx",
+        "evals/fixtures/nextjs-app-deep/src/components/chart-widget.tsx"
+      ],
+      "assertions": [
+        {
+          "text": "Runs smart_outline on task files before dispatching subagents",
+          "type": "behavioral"
+        },
+        {
+          "text": "Traces imports/references using ast-grep or LSP to find dependent files",
+          "type": "behavioral"
+        },
+        {
+          "text": "Injects FILE_OUTLINES into subagent prompts",
+          "type": "behavioral"
+        },
+        {
+          "text": "Injects IMPACT_CONTEXT with dependent file info into subagent prompts",
+          "type": "behavioral"
+        },
+        {
+          "text": "Skips smart_outline for files being created (not yet existing)",
+          "type": "behavioral"
+        }
+      ],
+      "scenario_requires": [
+        "gsd_project"
+      ],
+      "tier": "smoke",
+      "tags": [
+        "fixture-required",
+        "happy-path",
+        "claude-mem",
+        "file-preloading",
+        "tool-compliance"
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "smart_outline.*sidebar|smart_outline.*page|smart_outline.*layout|outline.*task.?file"
+        },
+        {
+          "type": "regex",
+          "pattern": "ast.?grep.*import|sg.*import|findReferences|IMPACT_CONTEXT|impact.?context|blast.?radius|depend|import.*trac"
+        },
+        {
+          "type": "regex",
+          "pattern": "FILE_OUTLINES|file.?outline|pre.?load|smart_outline.*each file|outline.*file.*list|outline.*task"
+        }
+      ]
+    },
+    {
+      "id": 432,
+      "command": "plan-work",
+      "prompt": "Plan a simple feature: add a health check endpoint to the API",
+      "expected_output": "Should show Tool Readiness step, reference claude-mem tools, and emit cross-session output",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Acknowledges Tool Readiness step with ToolSearch",
+          "type": "behavioral"
+        },
+        {
+          "text": "References claude-mem smart tools",
+          "type": "behavioral"
+        },
+        {
+          "text": "Emits cross-session output observation",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "required_terms",
+          "terms": [
+            "Tool Readiness",
+            "ToolSearch"
+          ]
+        },
+        {
+          "type": "required_terms",
+          "terms": [
+            "smart_search",
+            "smart_outline"
+          ]
+        },
+        {
+          "type": "regex",
+          "pattern": "Cross-Session Output|\\[plan-work-output\\]"
+        }
+      ],
+      "tags": [
+        "compliance",
+        "claude-mem",
+        "tool-readiness"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 433,
+      "command": "plan-review",
+      "prompt": "Review the plan at .planning/phases/01-auth/01-01-PLAN.md",
+      "expected_output": "Should show Tool Readiness step, reference claude-mem tools, and emit cross-session output",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Acknowledges Tool Readiness step with ToolSearch",
+          "type": "behavioral"
+        },
+        {
+          "text": "References claude-mem smart tools",
+          "type": "behavioral"
+        },
+        {
+          "text": "Emits cross-session output observation",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "required_terms",
+          "terms": [
+            "Tool Readiness",
+            "ToolSearch"
+          ]
+        },
+        {
+          "type": "required_terms",
+          "terms": [
+            "smart_search",
+            "smart_outline"
+          ]
+        },
+        {
+          "type": "regex",
+          "pattern": "Cross-Session Output|\\[plan-review-output\\]"
+        }
+      ],
+      "tags": [
+        "compliance",
+        "claude-mem",
+        "tool-readiness"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 434,
+      "command": "review",
+      "prompt": "Review the recent changes on this branch",
+      "expected_output": "Should show Tool Readiness step, reference claude-mem tools, and emit cross-session output",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Acknowledges Tool Readiness step with ToolSearch",
+          "type": "behavioral"
+        },
+        {
+          "text": "References claude-mem smart tools",
+          "type": "behavioral"
+        },
+        {
+          "text": "Emits cross-session output observation",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "required_terms",
+          "terms": [
+            "Tool Readiness",
+            "ToolSearch"
+          ]
+        },
+        {
+          "type": "required_terms",
+          "terms": [
+            "smart_search",
+            "smart_outline"
+          ]
+        },
+        {
+          "type": "regex",
+          "pattern": "Cross-Session Output|\\[review-output\\]"
+        }
+      ],
+      "tags": [
+        "compliance",
+        "claude-mem",
+        "tool-readiness"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 435,
+      "command": "fix",
+      "prompt": "Fix a bug where the dashboard shows stale data after refresh",
+      "expected_output": "Should show Tool Readiness step, reference claude-mem tools, and emit cross-session output",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Acknowledges Tool Readiness step with ToolSearch",
+          "type": "behavioral"
+        },
+        {
+          "text": "References claude-mem smart tools",
+          "type": "behavioral"
+        },
+        {
+          "text": "Emits cross-session output observation",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "required_terms",
+          "terms": [
+            "Tool Readiness",
+            "ToolSearch"
+          ]
+        },
+        {
+          "type": "required_terms",
+          "terms": [
+            "smart_search",
+            "smart_outline"
+          ]
+        },
+        {
+          "type": "regex",
+          "pattern": "Cross-Session Output|\\[fix-output\\]"
+        }
+      ],
+      "tags": [
+        "compliance",
+        "claude-mem",
+        "tool-readiness"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 436,
+      "command": "auto",
+      "prompt": "Run autonomous execution for the current project",
+      "expected_output": "Should show Tool Readiness step, reference claude-mem tools, and emit cross-session output",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Acknowledges Tool Readiness step with ToolSearch",
+          "type": "behavioral"
+        },
+        {
+          "text": "References claude-mem smart tools",
+          "type": "behavioral"
+        },
+        {
+          "text": "Emits cross-session output observation",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "required_terms",
+          "terms": [
+            "Tool Readiness",
+            "ToolSearch"
+          ]
+        },
+        {
+          "type": "required_terms",
+          "terms": [
+            "smart_search",
+            "smart_outline"
+          ]
+        },
+        {
+          "type": "regex",
+          "pattern": "Cross-Session Output|\\[auto-output\\]"
+        }
+      ],
+      "tags": [
+        "compliance",
+        "claude-mem",
+        "tool-readiness"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 437,
+      "command": "fix",
+      "prompt": "Fix a bug where the dashboard shows stale data after refresh",
+      "expected_output": "Should reference shipped debugging protocol, use verification checklist, no broken paths",
+      "files": [],
+      "assertions": [
+        {
+          "text": "References shipped debugging protocol",
+          "type": "behavioral"
+        },
+        {
+          "text": "Uses verification checklist for post-fix verification",
+          "type": "behavioral"
+        },
+        {
+          "text": "No references to repo-root skills/ paths",
+          "type": "guard"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "debugging-protocol|systematic.debug|hypothesis"
+        },
+        {
+          "type": "regex",
+          "pattern": "verification-checklist|verification|IDENTIFY.*RUN.*VERIFY"
+        },
+        {
+          "type": "regex",
+          "pattern": "references/|@references"
+        }
+      ],
+      "tags": [
+        "fix",
+        "compliance",
+        "reference-resolution"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 438,
+      "command": "fix",
+      "prompt": "Fix a complex authentication bug affecting multiple services \u2014 users can't log in after password reset",
+      "expected_output": "Should dispatch gsd-debugger with tool instructions for complex/parallel bugs",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Dispatches gsd-debugger agent for complex bugs",
+          "type": "behavioral"
+        },
+        {
+          "text": "Includes claude-mem tool instructions",
+          "type": "behavioral"
+        },
+        {
+          "text": "Uses hypothesis-driven debugging",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "gsd-debugger|debugger.*agent"
+        },
+        {
+          "type": "regex",
+          "pattern": "smart_outline|smart_search|claude-mem"
+        },
+        {
+          "type": "regex",
+          "pattern": "hypothesis|root.cause|Root.Cause"
+        }
+      ],
+      "tags": [
+        "fix",
+        "compliance",
+        "agent-dispatch"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 439,
+      "command": "fix",
+      "prompt": "Fix a CSS layout issue where the sidebar overlaps the main content on mobile",
+      "expected_output": "Should reference frontend review criteria from shipped path",
+      "files": [],
+      "assertions": [
+        {
+          "text": "References frontend review criteria",
+          "type": "behavioral"
+        },
+        {
+          "text": "Uses shipped reference paths",
+          "type": "behavioral"
+        },
+        {
+          "text": "Checks accessibility basics",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "frontend-review|frontend.*design|accessibility"
+        },
+        {
+          "type": "regex",
+          "pattern": "references/|@references"
+        },
+        {
+          "type": "regex",
+          "pattern": "responsive|mobile|layout|viewport"
+        }
+      ],
+      "tags": [
+        "fix",
+        "compliance",
+        "shipping-boundary"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 440,
+      "command": "fix",
+      "prompt": "Fix a failing test in the user registration flow",
+      "expected_output": "Should emit cross-session output and verify root cause",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Emits cross-session fix output",
+          "type": "behavioral"
+        },
+        {
+          "text": "Identifies and reports root cause",
+          "type": "behavioral"
+        },
+        {
+          "text": "Runs verification before claiming fix",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "fix-output|Cross-Session"
+        },
+        {
+          "type": "regex",
+          "pattern": "root.cause|Root.Cause"
+        },
+        {
+          "type": "regex",
+          "pattern": "verification|verify|IDENTIFY.*RUN"
+        }
+      ],
+      "tags": [
+        "fix",
+        "compliance",
+        "cross-session"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 441,
+      "command": "plan-review",
+      "prompt": "Review this plan in HOLD SCOPE mode",
+      "expected_output": "Should run HOLD SCOPE review with both business and engineering sections",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Selects HOLD SCOPE mode",
+          "type": "behavioral"
+        },
+        {
+          "text": "Reviews both business and engineering sections",
+          "type": "behavioral"
+        },
+        {
+          "text": "Updates CONTEXT.md with decisions",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "HOLD.*SCOPE|hold.scope|Hold"
+        },
+        {
+          "type": "regex",
+          "pattern": "must_haves|truths"
+        },
+        {
+          "type": "regex",
+          "pattern": "CONTEXT\\.md|decisions|Decisions"
+        }
+      ],
+      "tags": [
+        "plan-review",
+        "compliance",
+        "mode-hold"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 442,
+      "command": "plan-review",
+      "prompt": "Review this plan in SCOPE EXPANSION mode",
+      "expected_output": "Should run EXPANSION review identifying delight opportunities",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Selects EXPANSION mode",
+          "type": "behavioral"
+        },
+        {
+          "text": "Identifies delight opportunities",
+          "type": "behavioral"
+        },
+        {
+          "text": "Updates must_haves with review truths",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "EXPANSION|expansion|Expansion"
+        },
+        {
+          "type": "regex",
+          "pattern": "delight|bonus|opportunity"
+        },
+        {
+          "type": "regex",
+          "pattern": "must_haves|truths"
+        }
+      ],
+      "tags": [
+        "plan-review",
+        "compliance",
+        "mode-expansion"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 443,
+      "command": "plan-review",
+      "prompt": "Review this plan in SCOPE REDUCTION mode",
+      "expected_output": "Should strip plan to essentials in REDUCTION mode",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Selects REDUCTION mode",
+          "type": "behavioral"
+        },
+        {
+          "text": "Strips to essentials",
+          "type": "behavioral"
+        },
+        {
+          "text": "Updates must_haves",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "REDUCTION|reduction|Reduction"
+        },
+        {
+          "type": "regex",
+          "pattern": "essential|strip|minimum|minimal"
+        },
+        {
+          "type": "regex",
+          "pattern": "must_haves|truths"
+        }
+      ],
+      "tags": [
+        "plan-review",
+        "compliance",
+        "mode-reduction"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 444,
+      "command": "plan-review",
+      "prompt": "Review this plan focusing on engineering quality \u2014 architecture, testing, performance",
+      "expected_output": "Should cover engineering sections 7-10",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Covers architecture review",
+          "type": "behavioral"
+        },
+        {
+          "text": "Covers testing strategy",
+          "type": "behavioral"
+        },
+        {
+          "text": "Covers performance assessment",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "architecture|Architecture"
+        },
+        {
+          "type": "regex",
+          "pattern": "test.*strategy|testing|Testing"
+        },
+        {
+          "type": "regex",
+          "pattern": "performance|Performance"
+        }
+      ],
+      "tags": [
+        "plan-review",
+        "compliance",
+        "engineering"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 445,
+      "command": "plan-review",
+      "prompt": "Review this plan and update CONTEXT.md with your decisions",
+      "expected_output": "Should update CONTEXT.md with locked decisions from review",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Updates CONTEXT.md Decisions section",
+          "type": "behavioral"
+        },
+        {
+          "text": "Prefixes decisions with [review]",
+          "type": "behavioral"
+        },
+        {
+          "text": "Locks decisions",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "CONTEXT\\.md|Decisions"
+        },
+        {
+          "type": "regex",
+          "pattern": "\\[review\\]|review.*prefix"
+        },
+        {
+          "type": "regex",
+          "pattern": "locked|Locked|decision"
+        }
+      ],
+      "tags": [
+        "plan-review",
+        "compliance",
+        "context-update"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 446,
+      "command": "plan-review",
+      "prompt": "Review this plan and identify all failure modes",
+      "expected_output": "Should produce failure modes registry with critical gaps",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Produces failure modes registry",
+          "type": "behavioral"
+        },
+        {
+          "text": "Identifies critical gaps",
+          "type": "behavioral"
+        },
+        {
+          "text": "Maps error recovery paths",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "failure.*mode|Failure.*Mode"
+        },
+        {
+          "type": "regex",
+          "pattern": "CRITICAL.*GAP|critical|CRITICAL"
+        },
+        {
+          "type": "regex",
+          "pattern": "rescue|Recovery|recovery"
+        }
+      ],
+      "tags": [
+        "plan-review",
+        "compliance",
+        "failure-modes"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 447,
+      "command": "plan-review",
+      "prompt": "Review this plan thoroughly with both business and engineering perspectives",
+      "expected_output": "Should dispatch parallel business and engineering review agents",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Dispatches business review agent",
+          "type": "behavioral"
+        },
+        {
+          "text": "Dispatches engineering review agent",
+          "type": "behavioral"
+        },
+        {
+          "text": "Includes tool instructions in agent prompts",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "Business.*Review|Agent.*1|business"
+        },
+        {
+          "type": "regex",
+          "pattern": "Engineering.*Review|Agent.*2|engineering"
+        },
+        {
+          "type": "regex",
+          "pattern": "smart_search|smart_outline|claude-mem"
+        }
+      ],
+      "tags": [
+        "plan-review",
+        "compliance",
+        "agent-dispatch"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 448,
+      "command": "plan-review",
+      "prompt": "Review this plan and emit cross-session output for downstream skills",
+      "expected_output": "Should emit plan-review-output observation",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Emits cross-session output",
+          "type": "behavioral"
+        },
+        {
+          "text": "Includes gate decision",
+          "type": "behavioral"
+        },
+        {
+          "text": "Summarizes findings",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "plan-review-output|Cross-Session"
+        },
+        {
+          "type": "regex",
+          "pattern": "Gate.*=|PASS|WARN|BLOCK"
+        },
+        {
+          "type": "regex",
+          "pattern": "findings|Findings"
+        }
+      ],
+      "tags": [
+        "plan-review",
+        "compliance",
+        "cross-session"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 449,
+      "command": "review",
+      "prompt": "Review these code changes that have DRY violations and missing error handling",
+      "expected_output": "Should use direct dispatch from trigger table, not quality-refine agent",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Uses trigger table for sub-skill dispatch",
+          "type": "behavioral"
+        },
+        {
+          "text": "Dispatches design-simplify or design-harden directly",
+          "type": "behavioral"
+        },
+        {
+          "text": "Includes tool instructions in dispatch",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "trigger.*table|direct.*dispatch"
+        },
+        {
+          "type": "regex",
+          "pattern": "design-simplify|design-harden"
+        },
+        {
+          "type": "regex",
+          "pattern": "smart_outline|ast-grep"
+        }
+      ],
+      "tags": [
+        "review",
+        "compliance",
+        "step-2-5-flatten"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 450,
+      "command": "review",
+      "prompt": "Review this TypeScript code change thoroughly with full analysis",
+      "expected_output": "Should include tool instructions in all subagent prompts",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Includes smart tools in agent prompts",
+          "type": "behavioral"
+        },
+        {
+          "text": "Includes ast-grep in agent prompts",
+          "type": "behavioral"
+        },
+        {
+          "text": "Covers code quality and architecture",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "smart_outline|smart_search|smart_unfold"
+        },
+        {
+          "type": "regex",
+          "pattern": "ast-grep|sg.*pattern|find_code_by_rule"
+        },
+        {
+          "type": "regex",
+          "pattern": "Code.*Quality|Architecture"
+        }
+      ],
+      "tags": [
+        "review",
+        "compliance",
+        "tool-instructions"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 451,
+      "command": "review",
+      "prompt": "Review these changes and apply quality refinement if needed",
+      "expected_output": "Should use direct dispatch, no quality-refine intermediary",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Uses direct dispatch pattern",
+          "type": "behavioral"
+        },
+        {
+          "text": "References design sub-skills",
+          "type": "behavioral"
+        },
+        {
+          "text": "No quality-refine intermediary",
+          "type": "guard"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "direct.*dispatch|trigger.*table|sub-skill"
+        },
+        {
+          "type": "regex",
+          "pattern": "design-simplify|design-harden|design-normalize"
+        },
+        {
+          "type": "regex",
+          "pattern": "Quality.*Refinement|Step 2\\.5"
+        }
+      ],
+      "tags": [
+        "review",
+        "compliance",
+        "no-intermediate-agent"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 452,
+      "command": "auto",
+      "prompt": "Run autonomous execution for this project",
+      "expected_output": "Should inject tool guidance into downstream sessions",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Injects Tool Readiness into downstream sessions",
+          "type": "behavioral"
+        },
+        {
+          "text": "Uses consistent project name",
+          "type": "behavioral"
+        },
+        {
+          "text": "References ToolSearch for claude-mem",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "Tool.*Readiness|ToolSearch"
+        },
+        {
+          "type": "regex",
+          "pattern": "CLAUDE_MEM_PROJECT|project.*name"
+        },
+        {
+          "type": "regex",
+          "pattern": "git.*rev-parse|basename"
+        }
+      ],
+      "tags": [
+        "auto",
+        "compliance",
+        "tool-injection"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 453,
+      "command": "auto",
+      "prompt": "Set up autonomous execution and configure project",
+      "expected_output": "Should use git-based project name derivation",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Uses git rev-parse for project name",
+          "type": "behavioral"
+        },
+        {
+          "text": "Sets CLAUDE_MEM_PROJECT",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "git.*rev-parse|basename"
+        },
+        {
+          "type": "regex",
+          "pattern": "CLAUDE_MEM_PROJECT|project.*name"
+        }
+      ],
+      "tags": [
+        "auto",
+        "compliance",
+        "project-name"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 454,
+      "command": "plan-work",
+      "prompt": "Plan a complex feature requiring deep research: implement a real-time notification system with WebSocket support",
+      "expected_output": "Should include tool instructions in researcher agent dispatch",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Includes tool instructions in agent prompts",
+          "type": "behavioral"
+        },
+        {
+          "text": "References smart tools in research dispatch",
+          "type": "behavioral"
+        },
+        {
+          "text": "Uses ast-grep for structural analysis",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "smart_outline|smart_search|smart_unfold"
+        },
+        {
+          "type": "regex",
+          "pattern": "gsd-phase-researcher|researcher.*agent|spec-architect"
+        },
+        {
+          "type": "regex",
+          "pattern": "ast-grep|sg.*pattern"
+        }
+      ],
+      "tags": [
+        "plan-work",
+        "compliance",
+        "researcher-tools"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 455,
+      "command": "plan-work",
+      "prompt": "Plan the next task in the current phase",
+      "expected_output": "Should query cross-session cache before reading planning files",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Queries cross-session cache",
+          "type": "behavioral"
+        },
+        {
+          "text": "Checks for prior skill output",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "Cross-Session.*Cache|plan-work-output|auto-output"
+        },
+        {
+          "type": "regex",
+          "pattern": "search.*query|claude-mem"
+        }
+      ],
+      "tags": [
+        "plan-work",
+        "compliance",
+        "cross-session"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 456,
+      "command": "plan-work",
+      "prompt": "Plan a simple feature: add a health check endpoint to the API",
+      "expected_output": "Should use git-based project name derivation",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Uses git rev-parse for project name",
+          "type": "behavioral"
+        },
+        {
+          "text": "Sets project name for claude-mem calls",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "git.*rev-parse|basename"
+        },
+        {
+          "type": "regex",
+          "pattern": "project.*name|PROJECT_NAME"
+        }
+      ],
+      "tags": [
+        "plan-work",
+        "compliance",
+        "project-name"
+      ],
+      "tier": "smoke"
     }
   ]
 }

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -16771,6 +16771,105 @@
         "project-name"
       ],
       "tier": "smoke"
+    },
+    {
+      "id": 457,
+      "command": "auto",
+      "prompt": "Verify the shared orchestrator library at .claude/skills/auto/lib/ exports the expected functions: dispatchTask (from task-dispatch.cjs), buildTaskPrompt (from context-injection.cjs), parseWaves (from wave-analysis.cjs), runVerification (from verification.cjs), generateSummary (from summary-generation.cjs)",
+      "expected_output": "Should verify each module exists and exports the correct function. The barrel export (index.cjs) re-exports all 5 functions from task-dispatch.cjs, context-injection.cjs, wave-analysis.cjs, verification.cjs, and summary-generation.cjs.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Checks module exports",
+          "type": "behavioral"
+        },
+        {
+          "text": "Verifies barrel re-export",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "dispatchTask|buildTaskPrompt"
+        },
+        {
+          "type": "regex",
+          "pattern": "parseWaves|runVerification|generateSummary"
+        }
+      ],
+      "tags": [
+        "auto",
+        "orchestrator",
+        "shared-lib"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 458,
+      "command": "auto",
+      "prompt": "Verify that context-injection.cjs buildTaskPrompt includes instructions to use smart_outline and smart_unfold for code discovery, per Decision D3 (task sessions discover code-level context themselves)",
+      "expected_output": "Should confirm the prompt template includes smart tool instructions: smart_outline, smart_unfold, smart_search. Should NOT include pre-loaded file outlines (D3: task discovers its own code context).",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Includes smart tool instructions",
+          "type": "behavioral"
+        },
+        {
+          "text": "Does NOT pre-load file outlines",
+          "type": "guard"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "smart_outline|smart_unfold"
+        },
+        {
+          "type": "regex",
+          "pattern": "smart_search|code.*discovery"
+        }
+      ],
+      "tags": [
+        "auto",
+        "orchestrator",
+        "context-injection"
+      ],
+      "tier": "smoke"
+    },
+    {
+      "id": 459,
+      "command": "auto",
+      "prompt": "Verify that wave-analysis.cjs parseWaves correctly parses XML task blocks from a PLAN.md file, extracting name, files, action, verify, done fields and grouping by wave number",
+      "expected_output": "Should parse task XML blocks, extract all fields, group into waves. Default wave is 1 if not specified. Should handle multi-line action text.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Parses XML task blocks",
+          "type": "behavioral"
+        },
+        {
+          "text": "Groups tasks by wave",
+          "type": "behavioral"
+        }
+      ],
+      "checks": [
+        {
+          "type": "regex",
+          "pattern": "parseWaves|wave.*analysis"
+        },
+        {
+          "type": "regex",
+          "pattern": "task.*block|XML|frontmatter"
+        }
+      ],
+      "tags": [
+        "auto",
+        "orchestrator",
+        "wave-analysis"
+      ],
+      "tier": "smoke"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **Auto-orchestrator redesign (Phase 23)** — 5 plans: shared lib extraction, 2-layer direct dispatch, process group kill, state machine, build skill slimming
- **ToolSearch preamble simplified** — `+mcp-search` replaces 300-char `select:` string across all skills
- **15 new evals** (457-471) covering orchestrator architecture
- 409 total evals

## Changes

### Added
- 6 new CJS modules in `.claude/skills/auto/lib/` (task-dispatch, context-injection, wave-analysis, verification, summary-generation, barrel)
- 2-layer direct dispatch eliminating 3rd nesting layer
- Process group kill + checkpoint-before-spawn for crash resilience
- Phase & task state machines (12 + 6 states)

### Changed  
- ToolSearch preamble: `ToolSearch("+mcp-search", max_results: 10)` in 9 files
- Build skill: interactive-only (no auto-mode paths)
- Auto SKILL.md: documents new architecture

## Test plan
- [x] All 6 CJS modules pass `node -c` syntax check
- [x] Barrel export loads all 9 symbols
- [x] 15 new evals well-formed (2+ checks, valid regex, tags, tier)
- [x] 409 total evals, valid JSON
- [x] No TODOs/FIXMEs in new code
- [x] `auto_advance` count in build SKILL.md: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)