### PR TITLE
release: v1.65.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "fh",
       "description": "fhhs-skills: 33 skills and 31 agents — plan, spec, build, review, fix, research, design, and ship autonomously. Includes /fh:plan-work, /fh:build, /fh:fix, /fh:review, /fh:research, /fh:auto, and more.",
-      "version": "1.65.0",
+      "version": "1.65.1",
       "author": {
         "name": "Konstantin"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fh",
   "description": "fhhs-skills: All-in-one workflow plugin — 33 skills and 31 agents for spec-driven development, TDD, design quality, web research, startup validation, and autonomous execution. No other plugins required.",
-  "version": "1.65.0",
+  "version": "1.65.1",
   "author": {
     "name": "Konstantin"
   },

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -20,13 +20,22 @@ $ARGUMENTS
 
 ## Step 1: Get Installed Version
 
+Find the installed version by resolving the GSD symlink to the plugin cache directory:
+
 ```bash
-python3 -c "
-import json, pathlib
-data = json.loads(pathlib.Path(pathlib.Path.home() / '.claude/plugins/installed_plugins.json').read_text())
-entry = data.get('plugins', {}).get('fh@fhhs-skills') or {}
-print(entry.get('version', 'unknown'))
-"
+_FHHS_BIN="$HOME/.claude/get-shit-done/bin"
+if [ -L "$_FHHS_BIN" ]; then
+  _REAL="$(readlink -f "$_FHHS_BIN")"
+  _PLUGIN_ROOT="$(dirname "$_REAL")"
+  _PJ="$_PLUGIN_ROOT/.claude-plugin/plugin.json"
+  if [ -f "$_PJ" ]; then
+    python3 -c "import json; print(json.load(open('$_PJ'))['version'])"
+  else
+    echo "unknown"
+  fi
+else
+  echo "unknown"
+fi
 ```
 
 Save as `INSTALLED_VERSION`.
@@ -61,7 +70,11 @@ Then ask for confirmation before proceeding.
 
 ## Step 4: Install Update
 
-Run the plugin update:
+Refresh the marketplace index first, then run the plugin update:
+
+```bash
+claude skills marketplace update
+```
 
 ```bash
 claude plugin update fh@fhhs-skills

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Entries affecting `/fh:setup` or `/fh:new-project` environment carry reconciliat
 
 ## [Unreleased]
 
+## [1.65.1] - 2026-04-07
+
+### Fixed
+- **Update skill version detection** — resolves crash when `installed_plugins.json` entry is a list instead of a dict, and adds marketplace index refresh before updating
+
 ## [1.65.0] - 2026-04-07
 
 ### Added

--- a/hooks/fhhs-check-update.js
+++ b/hooks/fhhs-check-update.js
@@ -60,7 +60,9 @@ const child = spawn(process.execPath, ['-e', `
       const installedPlugins = path.join(${JSON.stringify(path.join(homeDir, '.claude'))}, 'plugins', 'installed_plugins.json');
       if (fs.existsSync(installedPlugins)) {
         const data = JSON.parse(fs.readFileSync(installedPlugins, 'utf8'));
-        const fhPlugin = data.plugins && data.plugins['fh@fhhs-skills'];
+        let fhPlugin = data.plugins && data.plugins['fh@fhhs-skills'];
+        // Handle both dict and array formats
+        if (Array.isArray(fhPlugin)) fhPlugin = fhPlugin[0];
         if (fhPlugin && fhPlugin.version) {
           installed = fhPlugin.version;
         }


### PR DESCRIPTION
## Summary
- Fix update skill version detection crash (installed_plugins.json entry is a list, not a dict)
- Add marketplace index refresh before plugin update
- Fix background update hook to handle both dict and list formats

## Changelog
### Fixed
- **Update skill version detection** — resolves crash when `installed_plugins.json` entry is a list instead of a dict, and adds marketplace index refresh before updating