### PR TITLE
chore: add project-level pi settings to avoid global skill collisions

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,0 +1,8 @@
+{
+  "packages": [
+    {
+      "source": "git:github.com/cinjoff/fhhs-skills",
+      "skills": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `.pi/settings.json` at project scope
- override the `fhhs-skills` package entry with `"skills": []` for this repo
- ensures local repo skills are preferred when working inside this repository

## Why
When developing in this repo, globally installed `fhhs-skills` package skills can collide with local `.pi/skills`.
Project-level settings make behavior consistent across new worktrees without affecting other repositories.
